### PR TITLE
Fix issue causing view borders to be swizzled innacurately

### DIFF
--- a/Sources/Scyther/Models/ActionBlock.swift
+++ b/Sources/Scyther/Models/ActionBlock.swift
@@ -9,3 +9,4 @@ import Foundation
 
 /// `typealias` representing `() -> Void` used to allow actions/events to be set on views.
 public typealias ActionBlock = () -> Void
+public typealias ActionBlockWithData<T> = (T?) -> Void

--- a/Sources/Scyther/Models/ActionBlock.swift
+++ b/Sources/Scyther/Models/ActionBlock.swift
@@ -9,4 +9,6 @@ import Foundation
 
 /// `typealias` representing `() -> Void` used to allow actions/events to be set on views.
 public typealias ActionBlock = () -> Void
-public typealias ActionBlockWithData<T> = (T?) -> Void
+
+/// `typealias` representing `(T) -> Void` used to allow actions/events to be set on views as well as passing data along.
+public typealias ActionBlockWithData<T> = (T) -> Void

--- a/Sources/Scyther/Scyther.swift
+++ b/Sources/Scyther/Scyther.swift
@@ -71,8 +71,8 @@ public class Scyther {
         /// Starts the console logger and allows it intercept `stderr` output from `NSLog`
 //        ConsoleLogger.instance.start()
         
-        /// Sets up the interface toolit plugins
-//        InterfaceToolkit.instance.start()
+        /// Sets up the interface toolkit plugins
+        InterfaceToolkit.instance.start()
     }
 
     /// Convenience function for manually showing the Scyther menu. Would be used when no gesture is wanted to invoke the menu.

--- a/Sources/Scyther/Scyther.swift
+++ b/Sources/Scyther/Scyther.swift
@@ -72,7 +72,7 @@ public class Scyther {
 //        ConsoleLogger.instance.start()
         
         /// Sets up the interface toolit plugins
-        InterfaceToolkit.instance.start()
+//        InterfaceToolkit.instance.start()
     }
 
     /// Convenience function for manually showing the Scyther menu. Would be used when no gesture is wanted to invoke the menu.

--- a/Sources/Scyther/User Interface/Cookie Browser/Cookie Browser/CookieBrowserViewController.swift
+++ b/Sources/Scyther/User Interface/Cookie Browser/Cookie Browser/CookieBrowserViewController.swift
@@ -48,15 +48,9 @@ internal class CookieBrowserViewController: UIViewController {
     }
 
     private func setupConstraints() {
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-0-[subview]-0-|",
-                                                           options: .directionLeadingToTrailing,
-                                                           metrics: nil,
-                                                           views: ["subview": tableView]))
-        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[subview]-0-|",
-                                                           options: .directionLeadingToTrailing,
-                                                           metrics: nil,
-                                                           views: ["subview": tableView]))
+        tableView.snp.remakeConstraints { (make) in
+            make.edges.equalToSuperview()
+        }
     }
     
     private func setupData() {
@@ -88,7 +82,7 @@ extension CookieBrowserViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.numbeOfRows(inSection: section)
+        return viewModel.numberOfRows(inSection: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/Scyther/User Interface/Cookie Browser/Cookie Browser/CookieBrowserViewModel.swift
+++ b/Sources/Scyther/User Interface/Cookie Browser/Cookie Browser/CookieBrowserViewModel.swift
@@ -99,7 +99,7 @@ extension CookieBrowserViewModel {
         return sections[index].title
     }
 
-    func numbeOfRows(inSection index: Int) -> Int {
+    func numberOfRows(inSection index: Int) -> Int {
         return rows(inSection: index)?.count ?? 0
     }
 

--- a/Sources/Scyther/User Interface/Cookie Browser/Cookie Details/CookieDetailsViewController.swift
+++ b/Sources/Scyther/User Interface/Cookie Browser/Cookie Details/CookieDetailsViewController.swift
@@ -97,7 +97,7 @@ extension CookieDetailsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.numbeOfRows(inSection: section)
+        return viewModel.numberOfRows(inSection: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/Scyther/User Interface/Cookie Browser/Cookie Details/CookieDetailsViewModel.swift
+++ b/Sources/Scyther/User Interface/Cookie Browser/Cookie Details/CookieDetailsViewModel.swift
@@ -118,7 +118,7 @@ extension CookieDetailsViewModel {
         return sections[index].title
     }
 
-    func numbeOfRows(inSection index: Int) -> Int {
+    func numberOfRows(inSection index: Int) -> Int {
         return rows(inSection: index)?.count ?? 0
     }
 

--- a/Sources/Scyther/User Interface/Feature Flags/FeatureFlagsViewController.swift
+++ b/Sources/Scyther/User Interface/Feature Flags/FeatureFlagsViewController.swift
@@ -82,7 +82,7 @@ extension FeatureFlagsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.numbeOfRows(inSection: section)
+        return viewModel.numberOfRows(inSection: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/Scyther/User Interface/Feature Flags/FeatureFlagsViewModel.swift
+++ b/Sources/Scyther/User Interface/Feature Flags/FeatureFlagsViewModel.swift
@@ -118,7 +118,7 @@ extension FeatureFlagsViewModel {
         return sections[index].title
     }
 
-    func numbeOfRows(inSection index: Int) -> Int {
+    func numberOfRows(inSection index: Int) -> Int {
         return rows(inSection: index)?.count ?? 0
     }
 

--- a/Sources/Scyther/User Interface/Fonts/FontsViewController.swift
+++ b/Sources/Scyther/User Interface/Fonts/FontsViewController.swift
@@ -78,7 +78,7 @@ extension FontsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.numbeOfRows(inSection: section)
+        return viewModel.numberOfRows(inSection: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/Scyther/User Interface/Fonts/FontsViewModel.swift
+++ b/Sources/Scyther/User Interface/Fonts/FontsViewModel.swift
@@ -59,7 +59,7 @@ extension FontsViewModel {
         return sections[index].title
     }
 
-    func numbeOfRows(inSection index: Int) -> Int {
+    func numberOfRows(inSection index: Int) -> Int {
         return rows(inSection: index)?.count ?? 0
     }
 

--- a/Sources/Scyther/User Interface/Grid Overlay/GridOverlayViewController.swift
+++ b/Sources/Scyther/User Interface/Grid Overlay/GridOverlayViewController.swift
@@ -77,7 +77,7 @@ extension GridOverlayViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.numbeOfRows(inSection: section)
+        return viewModel.numberOfRows(inSection: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/Scyther/User Interface/Grid Overlay/GridOverlayViewModel.swift
+++ b/Sources/Scyther/User Interface/Grid Overlay/GridOverlayViewModel.swift
@@ -127,7 +127,7 @@ extension GridOverlayViewModel {
         return sections[index].title
     }
 
-    func numbeOfRows(inSection index: Int) -> Int {
+    func numberOfRows(inSection index: Int) -> Int {
         return rows(inSection: index)?.count ?? 0
     }
 

--- a/Sources/Scyther/User Interface/Menu/MenuViewController.swift
+++ b/Sources/Scyther/User Interface/Menu/MenuViewController.swift
@@ -98,7 +98,7 @@ extension MenuViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel?.numbeOfRows(inSection: section) ?? 0
+        return viewModel?.numberOfRows(inSection: section) ?? 0
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/Scyther/User Interface/Menu/MenuViewModel.swift
+++ b/Sources/Scyther/User Interface/Menu/MenuViewModel.swift
@@ -71,7 +71,7 @@ internal class MenuViewModel {
         let switchView = UIActionSwitch()
         switchView.isOn = InterfaceToolkit.instance.showsViewBorders
         switchView.actionBlock = {
-            InterfaceToolkit.instance.start()
+            InterfaceToolkit.instance.swizzleLayout()
             InterfaceToolkit.instance.showsViewBorders = switchView.isOn
         }
         switchView.addTarget(self, action: #selector(switchToggled(_:)), for: .valueChanged)

--- a/Sources/Scyther/User Interface/Menu/MenuViewModel.swift
+++ b/Sources/Scyther/User Interface/Menu/MenuViewModel.swift
@@ -71,6 +71,7 @@ internal class MenuViewModel {
         let switchView = UIActionSwitch()
         switchView.isOn = InterfaceToolkit.instance.showsViewBorders
         switchView.actionBlock = {
+            InterfaceToolkit.instance.start()
             InterfaceToolkit.instance.showsViewBorders = switchView.isOn
         }
         switchView.addTarget(self, action: #selector(switchToggled(_:)), for: .valueChanged)
@@ -237,7 +238,7 @@ extension MenuViewModel {
         return sections[index].title
     }
 
-    func numbeOfRows(inSection index: Int) -> Int {
+    func numberOfRows(inSection index: Int) -> Int {
         return rows(inSection: index)?.count ?? 0
     }
 

--- a/Sources/Scyther/User Interface/Network Logger/Log Details View Controller/LogDetailsViewController.swift
+++ b/Sources/Scyther/User Interface/Network Logger/Log Details View Controller/LogDetailsViewController.swift
@@ -78,7 +78,7 @@ extension LogDetailsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.numbeOfRows(inSection: section)
+        return viewModel.numberOfRows(inSection: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/Scyther/User Interface/Network Logger/Log Details View Controller/LogDetailsViewModel.swift
+++ b/Sources/Scyther/User Interface/Network Logger/Log Details View Controller/LogDetailsViewModel.swift
@@ -200,7 +200,7 @@ extension LogDetailsViewModel {
         return sections[index].title
     }
 
-    func numbeOfRows(inSection index: Int) -> Int {
+    func numberOfRows(inSection index: Int) -> Int {
         return rows(inSection: index)?.count ?? 0
     }
 

--- a/Sources/Scyther/User Interface/Network Logger/Log View Controller/NetworkLoggerViewController.swift
+++ b/Sources/Scyther/User Interface/Network Logger/Log View Controller/NetworkLoggerViewController.swift
@@ -113,7 +113,7 @@ extension NetworkLoggerViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.numbeOfRows(inSection: section)
+        return viewModel.numberOfRows(inSection: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/Scyther/User Interface/Network Logger/Log View Controller/NetworkLoggerViewModel.swift
+++ b/Sources/Scyther/User Interface/Network Logger/Log View Controller/NetworkLoggerViewModel.swift
@@ -98,7 +98,7 @@ extension NetworkLoggerViewModel {
         return sections[index].title
     }
 
-    func numbeOfRows(inSection index: Int) -> Int {
+    func numberOfRows(inSection index: Int) -> Int {
         return rows(inSection: index)?.count ?? 0
     }
 

--- a/Sources/Scyther/User Interface/Notification Tester/NotificationTesterViewController.swift
+++ b/Sources/Scyther/User Interface/Notification Tester/NotificationTesterViewController.swift
@@ -80,7 +80,7 @@ extension NotificationTesterViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.numbeOfRows(inSection: section)
+        return viewModel.numberOfRows(inSection: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/Scyther/User Interface/Notification Tester/NotificationTesterViewModel.swift
+++ b/Sources/Scyther/User Interface/Notification Tester/NotificationTesterViewModel.swift
@@ -209,7 +209,7 @@ extension NotitifcationTesterViewModel {
         return sections[index].title
     }
 
-    func numbeOfRows(inSection index: Int) -> Int {
+    func numberOfRows(inSection index: Int) -> Int {
         return rows(inSection: index)?.count ?? 0
     }
 

--- a/Sources/Scyther/User Interface/Server Configuration/ServerConfigurationViewController.swift
+++ b/Sources/Scyther/User Interface/Server Configuration/ServerConfigurationViewController.swift
@@ -80,7 +80,7 @@ extension ServerConfigurationViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.numbeOfRows(inSection: section)
+        return viewModel.numberOfRows(inSection: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/Scyther/User Interface/Server Configuration/ServerConfigurationViewModel.swift
+++ b/Sources/Scyther/User Interface/Server Configuration/ServerConfigurationViewModel.swift
@@ -92,7 +92,7 @@ extension ServerConfigurationViewModel {
         return sections[index].title
     }
 
-    func numbeOfRows(inSection index: Int) -> Int {
+    func numberOfRows(inSection index: Int) -> Int {
         return rows(inSection: index)?.count ?? 0
     }
 

--- a/Sources/Scyther/User Interface/UI Previews/InterfacePreviewsViewController.swift
+++ b/Sources/Scyther/User Interface/UI Previews/InterfacePreviewsViewController.swift
@@ -78,7 +78,7 @@ extension InterfacePreviewsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.numbeOfRows(inSection: section)
+        return viewModel.numberOfRows(inSection: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/Scyther/User Interface/UI Previews/InterfacePreviewsViewModel.swift
+++ b/Sources/Scyther/User Interface/UI Previews/InterfacePreviewsViewModel.swift
@@ -66,7 +66,7 @@ extension InterfacePreviewsViewModel {
         return sections[index].title
     }
 
-    func numbeOfRows(inSection index: Int) -> Int {
+    func numberOfRows(inSection index: Int) -> Int {
         return rows(inSection: index)?.count ?? 0
     }
 

--- a/Sources/Scyther/User Interface/User Defaults/UserDefaultsViewController.swift
+++ b/Sources/Scyther/User Interface/User Defaults/UserDefaultsViewController.swift
@@ -79,7 +79,7 @@ extension UserDefaultsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.numbeOfRows(inSection: section)
+        return viewModel.numberOfRows(inSection: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/Scyther/User Interface/User Defaults/UserDefaultsViewModel.swift
+++ b/Sources/Scyther/User Interface/User Defaults/UserDefaultsViewModel.swift
@@ -60,7 +60,7 @@ extension UserDefaultsViewModel {
         return sections[index].title
     }
 
-    func numbeOfRows(inSection index: Int) -> Int {
+    func numberOfRows(inSection index: Int) -> Int {
         return rows(inSection: index)?.count ?? 0
     }
 

--- a/Sources/Scyther/Utilities/Interface Tookit/InterfaceToolkit.swift
+++ b/Sources/Scyther/Utilities/Interface Tookit/InterfaceToolkit.swift
@@ -55,11 +55,14 @@ public class InterfaceToolkit: NSObject {
     }
 
     internal func start() {
-        UIView.swizzleLayout
         registerForNotitfcations()
         setupTopLevelViewsWrapper()
         setupGridOverlay()
         setWindowSpeed()
+    }
+    
+    internal func swizzleLayout() {
+        UIView.swizzleLayout
     }
 
     private func setupTopLevelViewsWrapper() {


### PR DESCRIPTION
This PR fixes an issue that was causing view borders to either be black or missing altogether. By swizzling and unswizzling on the fly, as opposed to at startup, we're able to avoid the inaccuracies that swizzling introduced. This has been referenced here https://github.com/bstillitano/Scyther/issues/11