### PR TITLE
Fix view frames not setting on app load

### DIFF
--- a/Scyther Playground/Scyther Playground.xcodeproj/project.pbxproj
+++ b/Scyther Playground/Scyther Playground.xcodeproj/project.pbxproj
@@ -635,7 +635,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/bstillitano/Scyther.git";
 			requirement = {
-				branch = main;
+				branch = "bugfix/view-frames-on-load";
 				kind = branch;
 			};
 		};

--- a/Scyther Playground/Scyther Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Scyther Playground/Scyther Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/bstillitano/Scyther.git",
         "state": {
           "branch": "bugfix/view-frames-on-load",
-          "revision": "66ce75c6510c363f9d9f7a58ef4ad01f2d402ced",
+          "revision": "2dcfd14d6a1f45853ad2ac2022a6c14606a1bba5",
           "version": null
         }
       },

--- a/Scyther Playground/Scyther Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Scyther Playground/Scyther Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
         "package": "Scyther",
         "repositoryURL": "https://github.com/bstillitano/Scyther.git",
         "state": {
-          "branch": "main",
-          "revision": "06085937b827b973561ee775af69bc1dbfa0657d",
+          "branch": "bugfix/view-frames-on-load",
+          "revision": "66ce75c6510c363f9d9f7a58ef4ad01f2d402ced",
           "version": null
         }
       },

--- a/Scyther Playground/Scyther Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Scyther Playground/Scyther Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/bstillitano/Scyther.git",
         "state": {
           "branch": "bugfix/view-frames-on-load",
-          "revision": "2dcfd14d6a1f45853ad2ac2022a6c14606a1bba5",
+          "revision": "a28e7b3748dd3d171ae0f2610b3dab67ee780e73",
           "version": null
         }
       },

--- a/Scyther Playground/Scyther Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Scyther Playground/Scyther Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/bstillitano/Scyther.git",
         "state": {
           "branch": "bugfix/view-frames-on-load",
-          "revision": "a28e7b3748dd3d171ae0f2610b3dab67ee780e73",
+          "revision": "b6735940ae82ddca29930a4dbcc1f8fff8d32199",
           "version": null
         }
       },

--- a/Scyther Playground/Scyther Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Scyther Playground/Scyther Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/bstillitano/Scyther.git",
         "state": {
           "branch": "main",
-          "revision": "3b8266fdb44c738f910113bcbfe64dbdb6883516",
+          "revision": "06085937b827b973561ee775af69bc1dbfa0657d",
           "version": null
         }
       },

--- a/Scyther Playground/Scyther Playground/AppDelegate.swift
+++ b/Scyther Playground/Scyther Playground/AppDelegate.swift
@@ -14,9 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         /// Run Scyther only on non AppStore builds to avoid introducing potential security issues into our app.
         if !AppEnvironment.isAppStore {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                Scyther.instance.start()
-            }
+            Scyther.instance.start()
         }
 
         //Register for Push
@@ -43,7 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         completionHandler([.list, .banner, .badge, .sound])
     }
 
-    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHan1ler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         Scyther.notificationTester.processNotification(userInfo)
     }
 }

--- a/Scyther Playground/Scyther Playground/AppDelegate.swift
+++ b/Scyther Playground/Scyther Playground/AppDelegate.swift
@@ -14,7 +14,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         /// Run Scyther only on non AppStore builds to avoid introducing potential security issues into our app.
         if !AppEnvironment.isAppStore {
-            //Setup Networking
             Scyther.instance.start()
         }
 

--- a/Scyther Playground/Scyther Playground/AppDelegate.swift
+++ b/Scyther Playground/Scyther Playground/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         /// Run Scyther only on non AppStore builds to avoid introducing potential security issues into our app.
         if !AppEnvironment.isAppStore {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 Scyther.instance.start()
             }
         }
@@ -43,7 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         completionHandler([.list, .banner, .badge, .sound])
     }
 
-    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHan1ler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         Scyther.notificationTester.processNotification(userInfo)
     }
 }

--- a/Scyther Playground/Scyther Playground/AppDelegate.swift
+++ b/Scyther Playground/Scyther Playground/AppDelegate.swift
@@ -14,7 +14,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         /// Run Scyther only on non AppStore builds to avoid introducing potential security issues into our app.
         if !AppEnvironment.isAppStore {
-            Scyther.instance.start()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                Scyther.instance.start()
+            }
         }
 
         //Register for Push
@@ -40,8 +42,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.list, .banner, .badge, .sound])
     }
-    
-    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         Scyther.notificationTester.processNotification(userInfo)
     }
 }

--- a/Scyther Playground/Scyther Playground/Info.plist
+++ b/Scyther Playground/Scyther Playground/Info.plist
@@ -41,6 +41,10 @@
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Sources/Scyther/Scyther.swift
+++ b/Sources/Scyther/Scyther.swift
@@ -127,10 +127,10 @@ extension Scyther {
             return nil
         }
     }
-    
-    /// Convenience for logging a message to the console.
-    fileprivate func logMessage(_ msg: String) {
-        print("🐛🐛🐛🐛🐛🐛🐛🐛🐛🐛\n\nScyther - [https://github.com/bstillitano/scyther]: \(msg)\n\n🐛🐛🐛🐛🐛🐛🐛🐛🐛🐛")
-    }
+}
+
+/// Convenience for logging a message to the console.
+internal func logMessage(_ msg: String) {
+    print("🐛🐛🐛🐛🐛🐛🐛🐛🐛🐛\n\nScyther - [https://github.com/bstillitano/scyther]: \(msg)\n\n🐛🐛🐛🐛🐛🐛🐛🐛🐛🐛")
 }
 #endif

--- a/Sources/Scyther/Scyther.swift
+++ b/Sources/Scyther/Scyther.swift
@@ -122,7 +122,7 @@ extension Scyther {
             
         } else {
             #if DEBUG
-            print("🐛🐛🐛🐛🐛🐛🐛🐛🐛🐛\n\nCould not find a keyWindow to anchor to. The menu will not be shown. This is expected.\n\n🐛🐛🐛🐛🐛🐛🐛🐛🐛🐛")
+            logMessage("Could not find a keyWindow to anchor to. The menu will not be shown. This is expected.")
             #endif
             return nil
         }
@@ -130,7 +130,7 @@ extension Scyther {
     
     /// Convenience for logging a message to the console.
     fileprivate func logMessage(_ msg: String) {
-        print("Scyther - [https://github.com/bstillitano/scyther]: \(msg)")
+        print("🐛🐛🐛🐛🐛🐛🐛🐛🐛🐛\n\nScyther - [https://github.com/bstillitano/scyther]: \(msg)\n\n🐛🐛🐛🐛🐛🐛🐛🐛🐛🐛")
     }
 }
 #endif

--- a/Sources/Scyther/User Interface/Menu/MenuViewModel.swift
+++ b/Sources/Scyther/User Interface/Menu/MenuViewModel.swift
@@ -20,15 +20,13 @@ internal class MenuViewModel {
     // MARK: - Delegate
     weak var delegate: MenuViewModelProtocol?
 
-    func actionRow(name: String, icon: UIImage?, actionController: UIViewController?) -> DefaultRow {
+    func actionRow(name: String, icon: UIImage?, actionBlock: ActionBlock? = nil) -> DefaultRow {
         let row: DefaultRow = DefaultRow()
         row.text = name
         row.image = icon
         row.style = .default
-        row.accessoryType = actionController == nil ? UITableViewCell.AccessoryType.none : .disclosureIndicator
-        row.actionBlock = { [weak self] in
-            self?.delegate?.viewModel(viewModel: self, shouldShowViewController: actionController)
-        }
+        row.accessoryType = actionBlock == nil ? UITableViewCell.AccessoryType.none : .disclosureIndicator
+        row.actionBlock = actionBlock
         return row
     }
 
@@ -52,7 +50,7 @@ internal class MenuViewModel {
         row.accessoryType = UITableViewCell.AccessoryType.none
         return row
     }
-    
+
     /// Empty row that contains text in a 'disabled' style
     func emptyRow(text: String) -> EmptyRow {
         var row: EmptyRow = EmptyRow()
@@ -60,14 +58,14 @@ internal class MenuViewModel {
 
         return row
     }
-    
+
     /// Switch to enable/disable showing view frames
     var viewFramesSwitch: SwitchAccessoryRow {
         //Setup Row
         var row: SwitchAccessoryRow = SwitchAccessoryRow()
         row.text = "Show View Frames"
         row.image = UIImage(systemImage: "viewfinder")
-        
+
         //Setup Accessory
         let switchView = UIActionSwitch()
         switchView.isOn = InterfaceToolkit.instance.showsViewBorders
@@ -80,7 +78,7 @@ internal class MenuViewModel {
 
         return row
     }
-    
+
     /// Switch to enable/disable slow animations
     var slowAnimationsSwitch: SwitchAccessoryRow {
         //Setup Row
@@ -147,23 +145,33 @@ internal class MenuViewModel {
                                             icon: UIImage(systemImage: "network")))
         networkSection.rows.append(actionRow(name: "Network Logs",
                                              icon: UIImage(systemImage: "doc.append"),
-                                             actionController: NetworkLoggerViewController()))
+                                             actionBlock: { [weak self] in
+                                                 self?.delegate?.viewModel(viewModel: self, shouldShowViewController: NetworkLoggerViewController())
+                                             }))
         networkSection.rows.append(actionRow(name: "Server Configuration",
                                              icon: UIImage(systemImage: "externaldrive.badge.icloud"),
-                                             actionController: ServerConfigurationViewController()))
+                                             actionBlock: { [weak self] in
+                                                 self?.delegate?.viewModel(viewModel: self, shouldShowViewController: ServerConfigurationViewController())
+                                             }))
 
         /// Setup Environment Section
         var environmentSection: Section = Section()
         environmentSection.title = "Data"
         environmentSection.rows.append(actionRow(name: "Feature Flags",
                                                  icon: UIImage(systemImage: "flag"),
-                                                 actionController: FeatureFlagsViewController()))
+                                                 actionBlock: { [weak self] in
+                                                     self?.delegate?.viewModel(viewModel: self, shouldShowViewController: FeatureFlagsViewController())
+                                                 }))
         environmentSection.rows.append(actionRow(name: "User Defaults",
                                                  icon: UIImage(systemImage: "face.dashed"),
-                                                 actionController: UserDefaultsViewController()))
+                                                 actionBlock: { [weak self] in
+                                                     self?.delegate?.viewModel(viewModel: self, shouldShowViewController: UserDefaultsViewController())
+                                                 }))
         environmentSection.rows.append(actionRow(name: "Cookies",
                                                  icon: UIImage(systemImage: "info.circle"),
-                                                 actionController: CookieBrowserViewController()))
+                                                 actionBlock: { [weak self] in
+                                                     self?.delegate?.viewModel(viewModel: self, shouldShowViewController: CookieBrowserViewController())
+                                                 }))
 
         /// Setup Security Section
         var securitySection: Section = Section()
@@ -175,18 +183,24 @@ internal class MenuViewModel {
         supportSection.title = "Support"
         supportSection.rows.append(actionRow(name: "Console Logs",
                                              icon: UIImage(systemImage: "terminal"),
-                                             actionController: ConsoleLoggerViewController()))
+                                             actionBlock: { [weak self] in
+                                                 self?.delegate?.viewModel(viewModel: self, shouldShowViewController: ConsoleLoggerViewController())
+                                             }))
         supportSection.rows.append(emptyRow(text: "More coming soon"))
-        
+
         /// Setup Notifications Section
         var notificationsSection: Section = Section()
         notificationsSection.title = "Notifications"
         notificationsSection.rows.append(actionRow(name: "Notification Logger",
-                                                 icon: UIImage(systemImage: "list.bullet"),
-                                                 actionController: NotificationLoggerViewController()))
+                                                   icon: UIImage(systemImage: "list.bullet"),
+                                                   actionBlock: { [weak self] in
+                                                       self?.delegate?.viewModel(viewModel: self, shouldShowViewController: NotificationLoggerViewController())
+                                                   }))
         notificationsSection.rows.append(actionRow(name: "Notification Tester",
-                                                 icon: UIImage(systemImage: "bell"),
-                                                 actionController: NotificationTesterViewController()))
+                                                   icon: UIImage(systemImage: "bell"),
+                                                   actionBlock: { [weak self] in
+                                                       self?.delegate?.viewModel(viewModel: self, shouldShowViewController: NotificationTesterViewController())
+                                                   }))
         notificationsSection.rows.append(valueRow(name: "APNS Token",
                                                   value: Scyther.instance.apnsToken ?? "Not set",
                                                   icon: UIImage(systemImage: "applelogo"),
@@ -200,17 +214,23 @@ internal class MenuViewModel {
         var uiUxSection: Section = Section()
         uiUxSection.title = "UI/UX"
         uiUxSection.rows.append(actionRow(name: "Fonts",
-                                                 icon: UIImage(systemImage: "textformat"),
-                                                 actionController: FontsViewController()))
+                                          icon: UIImage(systemImage: "textformat"),
+                                          actionBlock: { [weak self] in
+                                              self?.delegate?.viewModel(viewModel: self, shouldShowViewController: FontsViewController())
+                                          }))
         uiUxSection.rows.append(actionRow(name: "Interface Components",
-                                                 icon: UIImage(systemImage: "apps.iphone"),
-                                                 actionController: InterfacePreviewsViewController()))
+                                          icon: UIImage(systemImage: "apps.iphone"),
+                                          actionBlock: { [weak self] in
+                                              self?.delegate?.viewModel(viewModel: self, shouldShowViewController: InterfacePreviewsViewController())
+                                          }))
         uiUxSection.rows.append(actionRow(name: "Grid Overlay",
-                                                 icon: UIImage(systemImage: "rectangle.split.3x3"),
-                                                 actionController: GridOverlayViewController()))
+                                          icon: UIImage(systemImage: "rectangle.split.3x3"),
+                                          actionBlock: { [weak self] in
+                                              self?.delegate?.viewModel(viewModel: self, shouldShowViewController: GridOverlayViewController())
+                                          }))
         uiUxSection.rows.append(viewFramesSwitch)
         uiUxSection.rows.append(slowAnimationsSwitch)
-        
+
         /// Setup Development Section
         var developmentSection: Section = Section()
         developmentSection.title = "Development Tools"
@@ -220,7 +240,9 @@ internal class MenuViewModel {
             for tool: DeveloperOption in Scyther.instance.developerOptions {
                 developmentSection.rows.append(actionRow(name: tool.name ?? "",
                                                          icon: tool.icon,
-                                                         actionController: tool.viewController))
+                                                         actionBlock: { [weak self] in
+                                                             self?.delegate?.viewModel(viewModel: self, shouldShowViewController: tool.viewController)
+                                                         }))
             }
         }
 

--- a/Sources/Scyther/Utilities/Interface Tookit/InterfaceToolkit.swift
+++ b/Sources/Scyther/Utilities/Interface Tookit/InterfaceToolkit.swift
@@ -58,11 +58,11 @@ public class InterfaceToolkit: NSObject {
         registerForNotitfcations()
         
         /// Delaying here to allow UIWindow time to initialise.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            setupTopLevelViewsWrapper()
-            setupGridOverlay()
-            setWindowSpeed()
-            swizzleLayout()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.setupTopLevelViewsWrapper()
+            self?.setupGridOverlay()
+            self?.setWindowSpeed()
+            self?.swizzleLayout()
         }
     }
 

--- a/Sources/Scyther/Utilities/Interface Tookit/InterfaceToolkit.swift
+++ b/Sources/Scyther/Utilities/Interface Tookit/InterfaceToolkit.swift
@@ -56,12 +56,16 @@ public class InterfaceToolkit: NSObject {
 
     internal func start() {
         registerForNotitfcations()
-        setupTopLevelViewsWrapper()
-        setupGridOverlay()
-        setWindowSpeed()
-        swizzleLayout()
+        
+        /// Delaying here to allow UIWindow time to initialise.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            setupTopLevelViewsWrapper()
+            setupGridOverlay()
+            setWindowSpeed()
+            swizzleLayout()
+        }
     }
-    
+
     internal func swizzleLayout() {
         UIView.swizzleLayout
     }

--- a/Sources/Scyther/Utilities/Interface Tookit/InterfaceToolkit.swift
+++ b/Sources/Scyther/Utilities/Interface Tookit/InterfaceToolkit.swift
@@ -59,6 +59,7 @@ public class InterfaceToolkit: NSObject {
         setupTopLevelViewsWrapper()
         setupGridOverlay()
         setWindowSpeed()
+        swizzleLayout()
     }
     
     internal func swizzleLayout() {
@@ -67,7 +68,7 @@ public class InterfaceToolkit: NSObject {
 
     private func setupTopLevelViewsWrapper() {
         guard let keyWindow: UIWindow = UIApplication.shared.keyWindow else {
-            print("Scyher.InterfaceToolkit failed to setup the top level views wrapper. There is no keyWindow available at UIApplication.shared.keyWindow")
+            logMessage("Scyther.InterfaceToolkit failed to setup the top level views wrapper. There is no keyWindow available at UIApplication.shared.keyWindow")
             return
         }
         addTopLevelViewsWrapperToWindow(window: keyWindow)
@@ -85,7 +86,7 @@ public class InterfaceToolkit: NSObject {
     @objc
     internal func newKeyWindowNotification(notification: NSNotification) {
         guard let window: UIWindow = notification.object as? UIWindow else {
-            print("Scyher.InterfaceToolkit failed to setup the top level views wrapper. There is no window available at UIWindow.didResignKeyNotification.object")
+            logMessage("Scyther.InterfaceToolkit failed to setup the top level views wrapper. There is no window available at UIWindow.didResignKeyNotification.object")
             return
         }
         addTopLevelViewsWrapperToWindow(window: window)

--- a/Sources/Scyther/Utilities/Network Logger/LoggerHTTPModel.swift
+++ b/Sources/Scyther/Utilities/Network Logger/LoggerHTTPModel.swift
@@ -227,7 +227,7 @@ fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
         do {
             try dataString.write(toFile: toFile, atomically: false, encoding: String.Encoding.utf8.rawValue)
         } catch {
-            print("catch !!!")
+            logMessage("catch !!!")
         }
     }
 

--- a/Sources/Scyther/Utilities/Network Logger/LoggerNetworkHelper.swift
+++ b/Sources/Scyther/Utilities/Network Logger/LoggerNetworkHelper.swift
@@ -142,7 +142,7 @@ extension String {
             do {
                 try contentToAppend.write(toFile: filePath, atomically: true, encoding: String.Encoding.utf8)
             } catch {
-                print("Error creating \(filePath)")
+                logMessage("Error creating \(filePath)")
             }
         }
     }


### PR DESCRIPTION
This PR fixes an issue with view frames not being set to their previous debug state after relaunching the app. This PR also fixes an issue in which grid overlays and slow animations were not persisted between app sessions. Finally, this PR fixes a critical memory issue that was causing the main thread to lock up when accessing the menu for the first time within a session.