### PR TITLE
fixed build issue on UI Test Builds

### DIFF
--- a/Sources/Scyther/Utilities/Interface Tookit/Touch Visualiser/TouchVisualiserConfiguration.swift
+++ b/Sources/Scyther/Utilities/Interface Tookit/Touch Visualiser/TouchVisualiserConfiguration.swift
@@ -11,7 +11,7 @@ import UIKit
 public struct TouchVisualiserConfiguration {
     // MARK: - Data
     /// Color to be used for touch indicators
-    public var touchIndicatorColor: UIColor = .systemGray.withAlphaComponent(0.7)
+    public var touchIndicatorColor: UIColor = UIColor.systemGray.withAlphaComponent(0.7)
 
     /// Image to be used for touch indicators. If not nil, this will replace color based touch indicators.
     public var touchIndicatorImage: UIImage? {


### PR DESCRIPTION
❌/Users/runner/Library/Developer/Xcode/DerivedData/SourcePackages/checkouts/Scyther/Sources/Scyther/Utilities/Interface Tookit/Touch Visualiser/TouchVisualiserConfiguration.swift:14:48: cannot infer contextual base in reference to member 'systemGray'

public var touchIndicatorColor: UIColor = .systemGray.withAlphaComponent(0.7)