### PR TITLE
Make Scyther selectedGesture public

### DIFF
--- a/Sources/Scyther/Scyther.swift
+++ b/Sources/Scyther/Scyther.swift
@@ -30,7 +30,7 @@ public class Scyther {
     internal var presented: Bool = false
     
     /// The gesture that is to be used to invoke the Scyther menu. Defaults to `shake`.
-    internal var selectedGesture: ScytherGesture = .shake
+    public var selectedGesture: ScytherGesture = .shake
     
     /// `Toggler` utility class. Used for local toggle/feature flag overrides.
     public static let toggler: Toggler = Toggler.instance


### PR DESCRIPTION
Hi @bstillitano ! I came across Scyther while looking to see if NetFox supports SPM (it still does not). Scyther actually looks a bit better to me, so I would prefer to use it.

The only thing is that I'd like to be able to disable the shake to show gesture. Currently this isn't possible (correct me if I'm wrong) because `selectedGesture` is internal. This PR changes it to public.