### PR TITLE
Allow programmatic dismissal of menu

### DIFF
--- a/Sources/Scyther/Scyther.swift
+++ b/Sources/Scyther/Scyther.swift
@@ -126,6 +126,20 @@ public class Scyther {
         }
         Scyther.instance.presentingViewController?.present(navigationController, animated: true, completion: nil)
     }
+    
+    public static func dismissMenu(animated: Bool, completion: (() -> Void)? = nil) {
+        /// Check if Scyther is showing the menu. If not, don't do anything, it's not Scythers to touch.
+        guard Scyther.instance.presented else {
+            return
+        }
+        
+        /// Get topmost navigation controller and dismiss it
+        guard let viewContoller: UIViewController = Scyther.instance.presentingViewController else {
+            return
+        }
+        viewContoller.dismiss(animated: animated, completion: completion)
+        Scyther.instance.presented = false
+    }
 }
 
 extension Scyther {


### PR DESCRIPTION
This PR introduces functionality that allows for the programmatic dismissal of the menu. The function exists as a static function on `Scyther`. Invocation looks like `Scyther.dismissMenu(animated: true, completion: nil)` in its simplest form. The function signature is `public static func dismissMenu(animated: Bool, completion: (() -> Void)? = nil)`