### PR TITLE
Fix DeviceCell.imageView constraint conflict

### DIFF
--- a/Sources/Scyther/Components/Cells/DeviceCell.swift
+++ b/Sources/Scyther/Components/Cells/DeviceCell.swift
@@ -17,8 +17,9 @@ final internal class DeviceTableViewCell: UITableViewCell {
         imageView?.layer.masksToBounds = true
         
         imageView?.snp.remakeConstraints({ (make) in
-            make.top.equalToSuperview().inset(8)
-            make.bottom.equalToSuperview()
+            make.top.greaterThanOrEqualToSuperview()
+            make.bottom.lessThanOrEqualToSuperview()
+            make.centerY.equalToSuperview()
             make.left.equalToSuperview().inset(16)
             make.width.equalTo(48)
             make.height.equalTo(48)


### PR DESCRIPTION
Hi! I have been seeing some constraint errors with the device cell's app icon image view like these:

```
2022-03-10 12:11:18.198011-0600 APPNAME[1603:517406] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<SnapKit.LayoutConstraint:0x28284dfe0@DeviceCell.swift#20 UIImageView:0x145e61f70.top == UITableViewCellContentView:0x145e62150.top + 8.0>",
    "<SnapKit.LayoutConstraint:0x28284e0a0@DeviceCell.swift#21 UIImageView:0x145e61f70.bottom == UITableViewCellContentView:0x145e62150.bottom>",
    "<SnapKit.LayoutConstraint:0x28284e100@DeviceCell.swift#24 UIImageView:0x145e61f70.height == 48.0>",
    "<NSLayoutConstraint:0x282f3e260 'UIView-Encapsulated-Layout-Height' UITableViewCellContentView:0x145e62150.height == 56.5   (active)>"
)

Will attempt to recover by breaking constraint 
<SnapKit.LayoutConstraint:0x28284e100@DeviceCell.swift#24 UIImageView:0x145e61f70.height == 48.0>
```

To resolve these, I modified the image view's constraints to set its centerY equal to superview centerY with appropriate greater than / less than top & bottom constraints. 

Setting it to centerY also makes it match the behavior of the textLabel and detailTextLabel views here, which are have their bottom / top respectively aligned to centerY.