### PR TITLE
fix dynamic fonts

### DIFF
--- a/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
+++ b/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
@@ -192,9 +192,12 @@ public final class AppearanceOverrides: Sendable {
                 if let category = contentSizeCategory {
                     windowScene.traitOverrides.preferredContentSizeCategory = category
                 } else {
+                    #if os(iOS)
                     windowScene.traitOverrides.preferredContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
-                }
-            }
+                    #else
+                    windowScene.traitOverrides.preferredContentSizeCategory = .unspecified
+                    #endif
+                }            }
         }
     }
 

--- a/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
+++ b/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
@@ -192,12 +192,9 @@ public final class AppearanceOverrides: Sendable {
                 if let category = contentSizeCategory {
                     windowScene.traitOverrides.preferredContentSizeCategory = category
                 } else {
-                    #if os(iOS)
                     windowScene.traitOverrides.preferredContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
-                    #else
-                    windowScene.traitOverrides.preferredContentSizeCategory = .unspecified
-                    #endif
-                }            }
+                }
+            }
         }
     }
 

--- a/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
+++ b/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
@@ -191,8 +191,6 @@ public final class AppearanceOverrides: Sendable {
                 // Apply content size category override
                 if let category = contentSizeCategory {
                     windowScene.traitOverrides.preferredContentSizeCategory = category
-                } else {
-                    windowScene.traitOverrides.preferredContentSizeCategory = .unspecified
                 }
             }
         }

--- a/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
+++ b/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
@@ -192,7 +192,7 @@ public final class AppearanceOverrides: Sendable {
                 if let category = contentSizeCategory {
                     windowScene.traitOverrides.preferredContentSizeCategory = category
                 } else {
-                    windowScene.traitOverrides.preferredContentSizeCategory = .unspecified
+                    windowScene.traitOverrides.preferredContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
                 }
             }
         }

--- a/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
+++ b/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
@@ -177,6 +177,8 @@ public final class AppearanceOverrides: Sendable {
 
     /// Applies trait overrides (high contrast, content size) to all window scenes.
     private func applyTraitOverrides() {
+        guard highContrastEnabled || contentSizeCategory != nil else { return }
+        
         if #available(iOS 17.0, *) {
             for scene in UIApplication.shared.connectedScenes {
                 guard let windowScene = scene as? UIWindowScene else { continue }
@@ -191,6 +193,8 @@ public final class AppearanceOverrides: Sendable {
                 // Apply content size category override
                 if let category = contentSizeCategory {
                     windowScene.traitOverrides.preferredContentSizeCategory = category
+                } else {
+                    windowScene.traitOverrides.preferredContentSizeCategory = .unspecified
                 }
             }
         }

--- a/Sources/Scyther/Features/Fonts/FontsViewModel.swift
+++ b/Sources/Scyther/Features/Fonts/FontsViewModel.swift
@@ -84,7 +84,12 @@ class FontsViewModel: ViewModel {
             FontFamily(
                 name: familyName,
                 fonts: UIFont.fontNames(forFamilyName: familyName).map { fontName in
-                    FontItem(name: fontName, uiFont: UIFont(name: fontName, size: 16.0))
+                    FontItem(
+                        name: fontName,
+                        uiFont: UIFont(name: fontName, size: 16.0).map {
+                            UIFontMetrics.default.scaledFont(for: $0)
+                        }
+                    )
                 }
             )
         }

--- a/Sources/Scyther/Features/Fonts/FontsViewModel.swift
+++ b/Sources/Scyther/Features/Fonts/FontsViewModel.swift
@@ -84,12 +84,7 @@ class FontsViewModel: ViewModel {
             FontFamily(
                 name: familyName,
                 fonts: UIFont.fontNames(forFamilyName: familyName).map { fontName in
-                    FontItem(
-                        name: fontName,
-                        uiFont: UIFont(name: fontName, size: 16.0).map {
-                            UIFontMetrics.default.scaledFont(for: $0)
-                        }
-                    )
+                    FontItem(name: fontName, uiFont: UIFont(name: fontName, size: 16.0))
                 }
             )
         }


### PR DESCRIPTION
## Fix: SwiftUI Dynamic Type not responding to system font size

### Problem

When Scyther is active, SwiftUI views no longer respond to the system's Dynamic Type / Accessibility font size settings. UIKit views were unaffected.

The root cause is in `AppearanceOverrides.applyTraitOverrides()`: when no content size override is active, the code was setting `windowScene.traitOverrides.preferredContentSizeCategory = .unspecified`. Once a `traitOverride` is set on a window scene — even to `.unspecified` — SwiftUI no longer reads the value from the system environment and instead uses the override value, which results in the default font size being used regardless of the user's Accessibility settings.

UIKit is unaffected because it falls back to the real system trait in this case, but SwiftUI does not.

### Fix

Instead of setting `.unspecified` when no override is active, use `UIApplication.shared.preferredContentSizeCategory` to mirror the current system value. This keeps the trait override "occupied" (avoiding the SwiftUI fallback issue) while still reflecting the user's actual system setting.

```swift
// Before
windowScene.traitOverrides.preferredContentSizeCategory = .unspecified

// After
windowScene.traitOverrides.preferredContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
```

### Files changed

- `Sources/Scyther/Utilities/AppearanceOverrides.swift`