### PR TITLE
Pinnable menu items and a private UserDefaults suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A comprehensive iOS debugging toolkit that helps you cut through bugs in your iO
 
 - [Features](#features)
 - [Requirements](#requirements)
+- [Preferences Storage](#preferences-storage)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Detailed Usage Guide](#detailed-usage-guide)
@@ -134,6 +135,42 @@ Key public types conform to `Sendable` for safe cross-actor usage:
 ### Performance Optimizations
 
 Scyther uses `nonisolated` properties for UserDefaults-backed settings to avoid actor hop overhead in hot paths. This ensures the debugging tools don't impact your app's UI performance.
+
+## Preferences Storage
+
+Scyther never writes to `UserDefaults.standard`. Every setting it persists — feature flag
+overrides, pinned menu items, spoofed locations, grid overlay configuration, appearance
+overrides and the rest — lives in a private suite named `com.scyther.settings`.
+
+This matters because apps commonly clear their own defaults when a user signs out:
+
+```swift
+// Both of these wipe the application domain only.
+UserDefaults.standard.dictionaryRepresentation().keys
+    .forEach(UserDefaults.standard.removeObject(forKey:))
+
+UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+```
+
+A named suite is a separate persistent domain, so neither call touches Scyther's state.
+Your debugging setup survives sign-out.
+
+The store is exposed if you need it directly:
+
+```swift
+UserDefaults.scyther.bool(forKey: "Scyther_grid_overlay_enabled")
+```
+
+### Migration from earlier versions
+
+Versions before this change stored settings in `UserDefaults.standard`. The first time
+Scyther's store is accessed it moves every key prefixed `scyther` (case-insensitive) out of
+the standard store and into the suite, skipping any key the suite already has a value for,
+then records that it has done so. Existing overrides and preferences carry across
+automatically, and your app's standard domain is left cleaner than it was.
+
+You can inspect and edit the suite from **Data → UserDefaults**, using the store picker at
+the top of the screen.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,14 @@ Choosing **Remote** clears that flag's local override so it follows its remote v
 **Reset all to Remote** button clears every override in one tap. The **Enable overrides** toggle
 at the top gates whether these local values are applied by `isEnabled(_:)`.
 
+The flag sections and the reset button are only shown while **Enable overrides** is on. With
+overrides off, local values have no effect, so the list and the reset button are hidden; the
+search field remains visible either way.
+
+Toggles can be pinned via a left swipe. Pinned toggles appear in a **Pinned** section at the
+top of the list and also remain in the main list. Pins persist across launches in Scyther's
+private preferences suite.
+
 #### Reading an Override Off the Main Actor
 
 `Scyther.featureFlags` is `@MainActor`-isolated, but you can read a flag's developer

--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ Versions before this change stored settings in `UserDefaults.standard`. The firs
 Scyther's store is accessed it moves every key prefixed `scyther` (case-insensitive) out of
 the standard store and into the suite, skipping any key the suite already has a value for,
 then records that it has done so. Existing overrides and preferences carry across
-automatically, and your app's standard domain is left cleaner than it was.
+automatically, and your app's standard domain is left cleaner than it was. This prefix match
+is the one place migration touches data it did not write itself: a key your own app happens
+to store under a `scyther`-prefixed name would also be moved.
 
 You can inspect and edit the suite from **Data → UserDefaults**, using the store picker at
 the top of the screen.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A comprehensive iOS debugging toolkit that helps you cut through bugs in your iO
   - [Custom Developer Options](#custom-developer-options)
   - [Environment Variables](#environment-variables)
 - [Menu Invocation](#menu-invocation)
+  - [Pinning menu items](#pinning-menu-items)
 - [API Reference](#api-reference)
 - [FAQ](#faq)
 - [Contributing](#contributing)
@@ -972,6 +973,22 @@ if Scyther.isPresented {
     Scyther.hideMenu()
 }
 ```
+
+### Pinning menu items
+
+Any row in the main menu can be pinned. Swipe left on a row and tap **Pin**; a **Pinned**
+section appears directly beneath **Device** containing your shortcuts.
+
+Pinned rows stay in their original section as well, so the menu never changes shape — the
+Pinned section is purely an additional shortcut. Rows appear in the order you pinned them,
+oldest first. Swipe and tap **Unpin** on either copy to remove one.
+
+Everything is pinnable, including information rows such as **Bundle ID**, inline toggles
+such as **Slow Animations**, and any custom options you register via
+`Scyther.developerOptions`.
+
+Pins persist across launches in Scyther's private preferences suite, so they survive your
+app clearing its own `UserDefaults`. See [Preferences Storage](#preferences-storage).
 
 ---
 

--- a/Sources/Scyther/Core/InterfaceToolkit.swift
+++ b/Sources/Scyther/Core/InterfaceToolkit.swift
@@ -46,40 +46,40 @@ public final class InterfaceToolkit: NSObject, Sendable {
     // MARK: - Data (nonisolated for UserDefaults access - thread-safe)
     internal nonisolated var visualiseTouches: Bool {
         get {
-            UserDefaults.standard.bool(forKey: InterfaceToolkit.VisualiseTouchesUserDefaultsKey)
+            UserDefaults.scyther.bool(forKey: InterfaceToolkit.VisualiseTouchesUserDefaultsKey)
         }
         set {
-            UserDefaults.standard.setValue(newValue, forKey: InterfaceToolkit.VisualiseTouchesUserDefaultsKey)
+            UserDefaults.scyther.setValue(newValue, forKey: InterfaceToolkit.VisualiseTouchesUserDefaultsKey)
             NotificationCenter.default.post(name: InterfaceToolkit.VisualiseTouchesChangeNotification,
                                             object: newValue)
         }
     }
     internal nonisolated var showsViewBorders: Bool {
         get {
-            UserDefaults.standard.bool(forKey: InterfaceToolkit.ViewFramesUserDefaultsKey)
+            UserDefaults.scyther.bool(forKey: InterfaceToolkit.ViewFramesUserDefaultsKey)
         }
         set {
-            UserDefaults.standard.setValue(newValue, forKey: InterfaceToolkit.ViewFramesUserDefaultsKey)
+            UserDefaults.scyther.setValue(newValue, forKey: InterfaceToolkit.ViewFramesUserDefaultsKey)
             NotificationCenter.default.post(name: InterfaceToolkit.DebugBordersChangeNotification,
                                             object: newValue)
         }
     }
     internal nonisolated var showsViewSizes: Bool {
         get {
-            UserDefaults.standard.bool(forKey: InterfaceToolkit.ViewSizesUserDefaultsKey)
+            UserDefaults.scyther.bool(forKey: InterfaceToolkit.ViewSizesUserDefaultsKey)
         }
         set {
-            UserDefaults.standard.setValue(newValue, forKey: InterfaceToolkit.ViewSizesUserDefaultsKey)
+            UserDefaults.scyther.setValue(newValue, forKey: InterfaceToolkit.ViewSizesUserDefaultsKey)
             NotificationCenter.default.post(name: InterfaceToolkit.DebugSizesChangeNotification,
                                             object: newValue)
         }
     }
     internal nonisolated var slowAnimationsEnabled: Bool {
         get {
-            UserDefaults.standard.bool(forKey: InterfaceToolkit.SlowAnimationsUserDefaultsKey)
+            UserDefaults.scyther.bool(forKey: InterfaceToolkit.SlowAnimationsUserDefaultsKey)
         }
         set {
-            UserDefaults.standard.setValue(newValue, forKey: InterfaceToolkit.SlowAnimationsUserDefaultsKey)
+            UserDefaults.scyther.setValue(newValue, forKey: InterfaceToolkit.SlowAnimationsUserDefaultsKey)
             DispatchQueue.main.async {
                 MainActor.assumeIsolated {
                     self.setWindowSpeed()

--- a/Sources/Scyther/Core/Scyther.swift
+++ b/Sources/Scyther/Core/Scyther.swift
@@ -481,7 +481,7 @@ public actor Servers {
 
     /// The identifier of the currently selected server.
     ///
-    /// This value is persisted across app launches in ``UserDefaults/scyther``, Scyther's
+    /// This value is persisted across app launches in `UserDefaults.scyther`, Scyther's
     /// private preferences suite, so it survives the host app clearing its own defaults.
     public var currentId: String {
         get { UserDefaults.scyther.string(forKey: defaultsKey) ?? "" }

--- a/Sources/Scyther/Core/Scyther.swift
+++ b/Sources/Scyther/Core/Scyther.swift
@@ -322,8 +322,8 @@ public final class FeatureFlags: Sendable {
     /// When `true`, the Scyther UI allows users to toggle feature flags locally.
     /// The ``isEnabled(_:)`` method will return local override values when available.
     public var localOverridesEnabled: Bool {
-        get { UserDefaults.standard.bool(forKey: Self.overridesEnabledKey) }
-        set { UserDefaults.standard.set(newValue, forKey: Self.overridesEnabledKey) }
+        get { UserDefaults.scyther.bool(forKey: Self.overridesEnabledKey) }
+        set { UserDefaults.scyther.set(newValue, forKey: Self.overridesEnabledKey) }
     }
 
     /// Registers a feature flag.
@@ -422,7 +422,7 @@ public extension FeatureFlags {
     /// - Parameter name: The flag name to read the override for.
     /// - Returns: The overridden value, or `nil` when there is no active override.
     nonisolated public func localOverride(for name: String) -> Bool? {
-        let defaults = UserDefaults.standard
+        let defaults = UserDefaults.scyther
         guard defaults.bool(forKey: Self.overridesEnabledKey) else { return nil }
         let key = FeatureToggle.localValueKey(for: name)
         guard defaults.object(forKey: key) != nil else { return nil }
@@ -481,10 +481,11 @@ public actor Servers {
 
     /// The identifier of the currently selected server.
     ///
-    /// This value is persisted across app launches using `UserDefaults`.
+    /// This value is persisted across app launches in ``UserDefaults/scyther``, Scyther's
+    /// private preferences suite, so it survives the host app clearing its own defaults.
     public var currentId: String {
-        get { UserDefaults.standard.string(forKey: defaultsKey) ?? "" }
-        set { UserDefaults.standard.set(newValue, forKey: defaultsKey) }
+        get { UserDefaults.scyther.string(forKey: defaultsKey) ?? "" }
+        set { UserDefaults.scyther.set(newValue, forKey: defaultsKey) }
     }
 
     /// The currently selected server configuration.

--- a/Sources/Scyther/Core/ScytherDefaults.swift
+++ b/Sources/Scyther/Core/ScytherDefaults.swift
@@ -32,7 +32,7 @@ import Foundation
 /// ## Migration
 ///
 /// Earlier versions of Scyther wrote to `UserDefaults.standard`. The first time
-/// ``UserDefaults/scyther`` is accessed, ``migrateIfNeeded(from:to:)`` moves every key
+/// `UserDefaults.scyther` is accessed, ``migrateIfNeeded(from:to:)`` moves every key
 /// prefixed `scyther` (compared case-insensitively) into the suite and removes it from the
 /// standard store, so existing overrides, pins and spoofed locations survive the upgrade.
 ///
@@ -50,7 +50,7 @@ import Foundation
 /// ### Construction
 /// - ``makeStore()``
 internal enum ScytherDefaults {
-    /// The name of the `UserDefaults` suite backing ``UserDefaults/scyther``.
+    /// The name of the `UserDefaults` suite backing `UserDefaults.scyther`.
     static let suiteName = "com.scyther.settings"
 
     /// The prefix every Scyther-owned defaults key carries, compared case-insensitively.

--- a/Sources/Scyther/Core/ScytherDefaults.swift
+++ b/Sources/Scyther/Core/ScytherDefaults.swift
@@ -108,6 +108,11 @@ internal enum ScytherDefaults {
     /// - Note: `dictionaryRepresentation()` also returns inherited global-domain keys. That
     ///   is harmless here because no `NSGlobalDomain` key carries the `scyther` prefix, so
     ///   the filter excludes them.
+    ///
+    /// - Warning: The `scyther` prefix match is name-based, not ownership-based: a key a host
+    ///   app happens to store under a `scyther`-prefixed name in `source` is indistinguishable
+    ///   from one Scyther itself wrote, and is relocated (and removed from `source`) the same
+    ///   way. This is the one path where Scyther touches data it did not write.
     static func migrate(from source: UserDefaults, to destination: UserDefaults) {
         let legacyKeys = source.dictionaryRepresentation().keys
             .filter { $0.lowercased().hasPrefix(keyPrefix) }

--- a/Sources/Scyther/Core/ScytherDefaults.swift
+++ b/Sources/Scyther/Core/ScytherDefaults.swift
@@ -1,0 +1,143 @@
+//
+//  ScytherDefaults.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+import Foundation
+
+/// Scyther's private preferences store.
+///
+/// Every setting, override and preference Scyther persists is written here rather than to
+/// `UserDefaults.standard`, so that a host app clearing its own defaults does not destroy
+/// Scyther's state.
+///
+/// ## Why a separate suite
+///
+/// Apps commonly wipe their preferences when a user signs out, using either of:
+///
+/// ```swift
+/// UserDefaults.standard.dictionaryRepresentation().keys
+///     .forEach(UserDefaults.standard.removeObject(forKey:))
+///
+/// UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+/// ```
+///
+/// Both operate on the **application domain** only. A named suite is a separate persistent
+/// domain, so neither touches it. On iOS the suite is written to
+/// `<container>/Library/Preferences/com.scyther.settings.plist`, inside the app's own
+/// sandbox — a fixed suite name therefore carries no cross-app collision risk.
+///
+/// ## Migration
+///
+/// Earlier versions of Scyther wrote to `UserDefaults.standard`. The first time
+/// ``UserDefaults/scyther`` is accessed, ``migrateIfNeeded(from:to:)`` moves every key
+/// prefixed `scyther` (compared case-insensitively) into the suite and removes it from the
+/// standard store, so existing overrides, pins and spoofed locations survive the upgrade.
+///
+/// ## Topics
+///
+/// ### Configuration
+/// - ``suiteName``
+/// - ``keyPrefix``
+/// - ``migrationKey``
+///
+/// ### Migration
+/// - ``migrate(from:to:)``
+/// - ``migrateIfNeeded(from:to:)``
+///
+/// ### Construction
+/// - ``makeStore()``
+internal enum ScytherDefaults {
+    /// The name of the `UserDefaults` suite backing ``UserDefaults/scyther``.
+    static let suiteName = "com.scyther.settings"
+
+    /// The prefix every Scyther-owned defaults key carries, compared case-insensitively.
+    ///
+    /// Scyther's keys are consistently namespaced (`Scyther_*`, `Scyther.*`, `scyther.*`),
+    /// which makes this a safe predicate for deciding what belongs to Scyther during
+    /// migration.
+    static let keyPrefix = "scyther"
+
+    /// The key recording that the one-time migration out of `UserDefaults.standard` has run.
+    ///
+    /// Stored in the destination suite so that clearing the standard store can never cause
+    /// the migration to run a second time.
+    static let migrationKey = "Scyther.Defaults.DidMigrateFromStandard"
+
+    /// Builds the Scyther preferences store and runs the one-time migration.
+    ///
+    /// - Returns: The `com.scyther.settings` suite, or `UserDefaults.standard` if the suite
+    ///   could not be created. Falling back keeps Scyther functional rather than trapping;
+    ///   the only consequence is the loss of isolation.
+    static func makeStore() -> UserDefaults {
+        guard let store = UserDefaults(suiteName: suiteName) else {
+            return .standard
+        }
+        migrateIfNeeded(from: .standard, to: store)
+        return store
+    }
+
+    /// Runs ``migrate(from:to:)`` once, then records that it has happened.
+    ///
+    /// Subsequent calls return immediately. This guard lives here rather than inside
+    /// ``migrate(from:to:)`` so the migration itself stays a pure, directly testable
+    /// operation.
+    ///
+    /// - Parameters:
+    ///   - source: The store to migrate legacy keys out of.
+    ///   - destination: The store to migrate legacy keys into, and where the completion
+    ///     flag is recorded.
+    static func migrateIfNeeded(from source: UserDefaults, to destination: UserDefaults) {
+        guard !destination.bool(forKey: migrationKey) else { return }
+        migrate(from: source, to: destination)
+        destination.set(true, forKey: migrationKey)
+    }
+
+    /// Moves every ``keyPrefix``-prefixed key from one store to another.
+    ///
+    /// A key already present in `destination` is left alone — newer state is never
+    /// clobbered by a stale value — but is still removed from `source`, so the migration
+    /// always leaves the source clean.
+    ///
+    /// - Parameters:
+    ///   - source: The store to read from and remove keys from.
+    ///   - destination: The store to write keys into.
+    ///
+    /// - Note: `dictionaryRepresentation()` also returns inherited global-domain keys. That
+    ///   is harmless here because no `NSGlobalDomain` key carries the `scyther` prefix, so
+    ///   the filter excludes them.
+    static func migrate(from source: UserDefaults, to destination: UserDefaults) {
+        let legacyKeys = source.dictionaryRepresentation().keys
+            .filter { $0.lowercased().hasPrefix(keyPrefix) }
+
+        for key in legacyKeys {
+            if destination.object(forKey: key) == nil {
+                destination.set(source.object(forKey: key), forKey: key)
+            }
+            source.removeObject(forKey: key)
+        }
+    }
+}
+
+public extension UserDefaults {
+    /// Scyther's private preferences store, isolated from `UserDefaults.standard`.
+    ///
+    /// Backed by the `com.scyther.settings` suite. Host apps that clear their standard
+    /// defaults — a common sign-out behaviour — leave this store untouched, so feature flag
+    /// overrides, pinned items, spoofed locations and every other Scyther setting persist.
+    ///
+    /// On first access, any Scyther keys left behind in `UserDefaults.standard` by an
+    /// earlier version are migrated across automatically.
+    ///
+    /// ```swift
+    /// UserDefaults.scyther.set(true, forKey: "Scyther_grid_overlay_enabled")
+    /// ```
+    ///
+    /// - Note: Declared `nonisolated(unsafe)` because the iOS SDK marks `UserDefaults` as
+    ///   non-`Sendable`. `UserDefaults` is documented as thread-safe, and this property is
+    ///   an immutable `let`, so unsynchronised access from any actor is safe. This mirrors
+    ///   the `nonisolated` accessors already used across Scyther to avoid main-actor hops.
+    nonisolated(unsafe) static let scyther: UserDefaults = ScytherDefaults.makeStore()
+}

--- a/Sources/Scyther/Core/UIView+InterfaceToolkit.swift
+++ b/Sources/Scyther/Core/UIView+InterfaceToolkit.swift
@@ -90,12 +90,12 @@ extension UIView: InterfaceToolkitPrivate {
 internal extension UIView {
     /// Reads directly from UserDefaults to avoid MainActor hop
     private static var showsViewBordersFromDefaults: Bool {
-        UserDefaults.standard.bool(forKey: InterfaceToolkit.ViewFramesUserDefaultsKey)
+        UserDefaults.scyther.bool(forKey: InterfaceToolkit.ViewFramesUserDefaultsKey)
     }
 
     /// Reads directly from UserDefaults to avoid MainActor hop
     private static var showsViewSizesFromDefaults: Bool {
-        UserDefaults.standard.bool(forKey: InterfaceToolkit.ViewSizesUserDefaultsKey)
+        UserDefaults.scyther.bool(forKey: InterfaceToolkit.ViewSizesUserDefaultsKey)
     }
 
     func refreshDebugBorders() {

--- a/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
+++ b/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
@@ -47,7 +47,7 @@ public enum ColorSchemeOverride: String, CaseIterable, Sendable {
 /// - **High Contrast**: Enable increased contrast mode (iOS 17+)
 /// - **Dynamic Type**: Test all content size categories
 ///
-/// Settings are persisted in ``UserDefaults/scyther``, Scyther's private preferences suite,
+/// Settings are persisted in `UserDefaults.scyther`, Scyther's private preferences suite,
 /// and automatically restored on app launch.
 ///
 /// ```swift
@@ -95,7 +95,7 @@ public final class AppearanceOverrides: Sendable {
     /// The current color scheme override setting.
     ///
     /// Setting this value immediately applies the color scheme to all windows
-    /// and persists the preference to ``UserDefaults/scyther``.
+    /// and persists the preference to `UserDefaults.scyther`.
     public nonisolated var colorScheme: ColorSchemeOverride {
         get {
             let rawValue = UserDefaults.scyther.string(forKey: AppearanceOverrides.ColorSchemeDefaultsKey) ?? "system"
@@ -115,7 +115,7 @@ public final class AppearanceOverrides: Sendable {
     ///
     /// When enabled, the system uses increased contrast colors for better visibility.
     /// This setting requires iOS 17+ to take effect via trait overrides.
-    /// The value is persisted to ``UserDefaults/scyther``.
+    /// The value is persisted to `UserDefaults.scyther`.
     public nonisolated var highContrastEnabled: Bool {
         get {
             return UserDefaults.scyther.bool(forKey: AppearanceOverrides.HighContrastDefaultsKey)
@@ -134,7 +134,7 @@ public final class AppearanceOverrides: Sendable {
     ///
     /// Use this to test how your app responds to different Dynamic Type sizes.
     /// When set to `nil`, the system default is used.
-    /// The value is persisted to ``UserDefaults/scyther``.
+    /// The value is persisted to `UserDefaults.scyther`.
     public nonisolated var contentSizeCategory: UIContentSizeCategory? {
         get {
             guard let rawValue = UserDefaults.scyther.string(forKey: AppearanceOverrides.ContentSizeCategoryDefaultsKey) else {

--- a/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
+++ b/Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift
@@ -47,7 +47,8 @@ public enum ColorSchemeOverride: String, CaseIterable, Sendable {
 /// - **High Contrast**: Enable increased contrast mode (iOS 17+)
 /// - **Dynamic Type**: Test all content size categories
 ///
-/// Settings are persisted to `UserDefaults` and automatically restored on app launch.
+/// Settings are persisted in ``UserDefaults/scyther``, Scyther's private preferences suite,
+/// and automatically restored on app launch.
 ///
 /// ```swift
 /// // Force dark mode
@@ -94,14 +95,14 @@ public final class AppearanceOverrides: Sendable {
     /// The current color scheme override setting.
     ///
     /// Setting this value immediately applies the color scheme to all windows
-    /// and persists the preference to UserDefaults.
+    /// and persists the preference to ``UserDefaults/scyther``.
     public nonisolated var colorScheme: ColorSchemeOverride {
         get {
-            let rawValue = UserDefaults.standard.string(forKey: AppearanceOverrides.ColorSchemeDefaultsKey) ?? "system"
+            let rawValue = UserDefaults.scyther.string(forKey: AppearanceOverrides.ColorSchemeDefaultsKey) ?? "system"
             return ColorSchemeOverride(rawValue: rawValue) ?? .system
         }
         set {
-            UserDefaults.standard.setValue(newValue.rawValue, forKey: AppearanceOverrides.ColorSchemeDefaultsKey)
+            UserDefaults.scyther.setValue(newValue.rawValue, forKey: AppearanceOverrides.ColorSchemeDefaultsKey)
             Task { @MainActor in
                 self.applyColorScheme()
             }
@@ -114,13 +115,13 @@ public final class AppearanceOverrides: Sendable {
     ///
     /// When enabled, the system uses increased contrast colors for better visibility.
     /// This setting requires iOS 17+ to take effect via trait overrides.
-    /// The value is persisted to UserDefaults.
+    /// The value is persisted to ``UserDefaults/scyther``.
     public nonisolated var highContrastEnabled: Bool {
         get {
-            return UserDefaults.standard.bool(forKey: AppearanceOverrides.HighContrastDefaultsKey)
+            return UserDefaults.scyther.bool(forKey: AppearanceOverrides.HighContrastDefaultsKey)
         }
         set {
-            UserDefaults.standard.setValue(newValue, forKey: AppearanceOverrides.HighContrastDefaultsKey)
+            UserDefaults.scyther.setValue(newValue, forKey: AppearanceOverrides.HighContrastDefaultsKey)
             Task { @MainActor in
                 self.applyTraitOverrides()
             }
@@ -133,19 +134,19 @@ public final class AppearanceOverrides: Sendable {
     ///
     /// Use this to test how your app responds to different Dynamic Type sizes.
     /// When set to `nil`, the system default is used.
-    /// The value is persisted to UserDefaults.
+    /// The value is persisted to ``UserDefaults/scyther``.
     public nonisolated var contentSizeCategory: UIContentSizeCategory? {
         get {
-            guard let rawValue = UserDefaults.standard.string(forKey: AppearanceOverrides.ContentSizeCategoryDefaultsKey) else {
+            guard let rawValue = UserDefaults.scyther.string(forKey: AppearanceOverrides.ContentSizeCategoryDefaultsKey) else {
                 return nil
             }
             return UIContentSizeCategory(rawValue: rawValue)
         }
         set {
             if let newValue = newValue {
-                UserDefaults.standard.setValue(newValue.rawValue, forKey: AppearanceOverrides.ContentSizeCategoryDefaultsKey)
+                UserDefaults.scyther.setValue(newValue.rawValue, forKey: AppearanceOverrides.ContentSizeCategoryDefaultsKey)
             } else {
-                UserDefaults.standard.removeObject(forKey: AppearanceOverrides.ContentSizeCategoryDefaultsKey)
+                UserDefaults.scyther.removeObject(forKey: AppearanceOverrides.ContentSizeCategoryDefaultsKey)
             }
             Task { @MainActor in
                 self.applyTraitOverrides()
@@ -200,9 +201,9 @@ public final class AppearanceOverrides: Sendable {
 
     /// Resets all appearance overrides to system defaults.
     public func resetToDefaults() {
-        UserDefaults.standard.removeObject(forKey: AppearanceOverrides.ColorSchemeDefaultsKey)
-        UserDefaults.standard.removeObject(forKey: AppearanceOverrides.HighContrastDefaultsKey)
-        UserDefaults.standard.removeObject(forKey: AppearanceOverrides.ContentSizeCategoryDefaultsKey)
+        UserDefaults.scyther.removeObject(forKey: AppearanceOverrides.ColorSchemeDefaultsKey)
+        UserDefaults.scyther.removeObject(forKey: AppearanceOverrides.HighContrastDefaultsKey)
+        UserDefaults.scyther.removeObject(forKey: AppearanceOverrides.ContentSizeCategoryDefaultsKey)
         applyAllOverrides()
     }
 

--- a/Sources/Scyther/Features/CrashLogs/CrashLogger.swift
+++ b/Sources/Scyther/Features/CrashLogs/CrashLogger.swift
@@ -13,7 +13,8 @@ import UIKit
 ///
 /// `CrashLogger` uses `NSSetUncaughtExceptionHandler` to intercept Objective-C
 /// and Swift exceptions before the app terminates. Captured crashes are persisted
-/// to UserDefaults and can be viewed on subsequent app launches.
+/// to ``UserDefaults/scyther``, Scyther's private preferences suite, and can be viewed on
+/// subsequent app launches.
 ///
 /// ## Features
 /// - Automatic exception interception
@@ -161,13 +162,13 @@ public final class CrashLogger: @unchecked Sendable {
 
     /// Clears all stored crash logs.
     public func clear() {
-        UserDefaults.standard.removeObject(forKey: CrashLogger.storageKey)
+        UserDefaults.scyther.removeObject(forKey: CrashLogger.storageKey)
         NotificationCenter.default.post(name: CrashLogger.didRecordCrashNotification, object: nil)
     }
 
-    /// Loads crash logs from UserDefaults.
+    /// Loads crash logs from ``UserDefaults/scyther``.
     private func load() -> [CrashLogEntry] {
-        guard let data = UserDefaults.standard.data(forKey: CrashLogger.storageKey) else {
+        guard let data = UserDefaults.scyther.data(forKey: CrashLogger.storageKey) else {
             return []
         }
 
@@ -178,12 +179,12 @@ public final class CrashLogger: @unchecked Sendable {
         }
     }
 
-    /// Saves crash logs to UserDefaults.
+    /// Saves crash logs to ``UserDefaults/scyther``.
     private func save(_ crashes: [CrashLogEntry]) {
         do {
             let data = try JSONEncoder().encode(crashes)
-            UserDefaults.standard.set(data, forKey: CrashLogger.storageKey)
-            UserDefaults.standard.synchronize() // Force immediate write - we're crashing
+            UserDefaults.scyther.set(data, forKey: CrashLogger.storageKey)
+            UserDefaults.scyther.synchronize() // Force immediate write - we're crashing
         } catch {
             // Can't do much if encoding fails during a crash
         }

--- a/Sources/Scyther/Features/CrashLogs/CrashLogger.swift
+++ b/Sources/Scyther/Features/CrashLogs/CrashLogger.swift
@@ -13,7 +13,7 @@ import UIKit
 ///
 /// `CrashLogger` uses `NSSetUncaughtExceptionHandler` to intercept Objective-C
 /// and Swift exceptions before the app terminates. Captured crashes are persisted
-/// to ``UserDefaults/scyther``, Scyther's private preferences suite, and can be viewed on
+/// to `UserDefaults.scyther`, Scyther's private preferences suite, and can be viewed on
 /// subsequent app launches.
 ///
 /// ## Features
@@ -166,7 +166,7 @@ public final class CrashLogger: @unchecked Sendable {
         NotificationCenter.default.post(name: CrashLogger.didRecordCrashNotification, object: nil)
     }
 
-    /// Loads crash logs from ``UserDefaults/scyther``.
+    /// Loads crash logs from `UserDefaults.scyther`.
     private func load() -> [CrashLogEntry] {
         guard let data = UserDefaults.scyther.data(forKey: CrashLogger.storageKey) else {
             return []
@@ -179,7 +179,7 @@ public final class CrashLogger: @unchecked Sendable {
         }
     }
 
-    /// Saves crash logs to ``UserDefaults/scyther``.
+    /// Saves crash logs to `UserDefaults.scyther`.
     private func save(_ crashes: [CrashLogEntry]) {
         do {
             let data = try JSONEncoder().encode(crashes)

--- a/Sources/Scyther/Features/DeepLinkTester/DeepLinkTester.swift
+++ b/Sources/Scyther/Features/DeepLinkTester/DeepLinkTester.swift
@@ -185,7 +185,7 @@ public final class DeepLinkTester: Sendable {
     // MARK: - Persistence
 
     private func loadHistory() {
-        guard let data = UserDefaults.standard.data(forKey: Self.HistoryDefaultsKey),
+        guard let data = UserDefaults.scyther.data(forKey: Self.HistoryDefaultsKey),
               let decoded = try? JSONDecoder().decode([DeepLinkHistoryEntry].self, from: data) else {
             return
         }
@@ -194,11 +194,11 @@ public final class DeepLinkTester: Sendable {
 
     private func saveHistory() {
         guard let data = try? JSONEncoder().encode(history) else { return }
-        UserDefaults.standard.set(data, forKey: Self.HistoryDefaultsKey)
+        UserDefaults.scyther.set(data, forKey: Self.HistoryDefaultsKey)
     }
 
     private func loadPresets() {
-        guard let data = UserDefaults.standard.data(forKey: Self.PresetsDefaultsKey),
+        guard let data = UserDefaults.scyther.data(forKey: Self.PresetsDefaultsKey),
               let decoded = try? JSONDecoder().decode([DeepLinkPreset].self, from: data) else {
             return
         }
@@ -207,7 +207,7 @@ public final class DeepLinkTester: Sendable {
 
     private func savePresets() {
         guard let data = try? JSONEncoder().encode(presets) else { return }
-        UserDefaults.standard.set(data, forKey: Self.PresetsDefaultsKey)
+        UserDefaults.scyther.set(data, forKey: Self.PresetsDefaultsKey)
     }
 }
 #endif

--- a/Sources/Scyther/Features/FPSCounter/FPSCounter.swift
+++ b/Sources/Scyther/Features/FPSCounter/FPSCounter.swift
@@ -41,7 +41,7 @@ public enum FPSCounterPosition: String, CaseIterable, Sendable {
 /// - **Yellow** (30-54 FPS): Acceptable but may need optimization
 /// - **Red** (<30 FPS): Poor performance, needs investigation
 ///
-/// Settings are persisted in ``UserDefaults/scyther``, Scyther's private preferences suite,
+/// Settings are persisted in `UserDefaults.scyther`, Scyther's private preferences suite,
 /// and automatically restored on app launch.
 ///
 /// ```swift
@@ -102,7 +102,7 @@ public final class FPSCounter: Sendable {
     /// Controls whether the FPS counter overlay is visible on screen.
     ///
     /// Setting this to `true` displays the FPS counter and starts measuring frame rate.
-    /// The value is persisted to ``UserDefaults/scyther`` and restored on app launch.
+    /// The value is persisted to `UserDefaults.scyther` and restored on app launch.
     public nonisolated var enabled: Bool {
         get {
             return UserDefaults.scyther.bool(forKey: FPSCounter.EnabledDefaultsKey)
@@ -123,7 +123,7 @@ public final class FPSCounter: Sendable {
     /// The position of the FPS counter on screen.
     ///
     /// Choose a corner that doesn't interfere with your app's UI.
-    /// The value is persisted to ``UserDefaults/scyther``.
+    /// The value is persisted to `UserDefaults.scyther`.
     public nonisolated var position: FPSCounterPosition {
         get {
             let rawValue = UserDefaults.scyther.string(forKey: FPSCounter.PositionDefaultsKey) ?? "topLeft"

--- a/Sources/Scyther/Features/FPSCounter/FPSCounter.swift
+++ b/Sources/Scyther/Features/FPSCounter/FPSCounter.swift
@@ -41,7 +41,8 @@ public enum FPSCounterPosition: String, CaseIterable, Sendable {
 /// - **Yellow** (30-54 FPS): Acceptable but may need optimization
 /// - **Red** (<30 FPS): Poor performance, needs investigation
 ///
-/// Settings are persisted to `UserDefaults` and automatically restored on app launch.
+/// Settings are persisted in ``UserDefaults/scyther``, Scyther's private preferences suite,
+/// and automatically restored on app launch.
 ///
 /// ```swift
 /// // Enable the FPS counter
@@ -101,13 +102,13 @@ public final class FPSCounter: Sendable {
     /// Controls whether the FPS counter overlay is visible on screen.
     ///
     /// Setting this to `true` displays the FPS counter and starts measuring frame rate.
-    /// The value is persisted to UserDefaults and restored on app launch.
+    /// The value is persisted to ``UserDefaults/scyther`` and restored on app launch.
     public nonisolated var enabled: Bool {
         get {
-            return UserDefaults.standard.bool(forKey: FPSCounter.EnabledDefaultsKey)
+            return UserDefaults.scyther.bool(forKey: FPSCounter.EnabledDefaultsKey)
         }
         set {
-            UserDefaults.standard.setValue(newValue, forKey: FPSCounter.EnabledDefaultsKey)
+            UserDefaults.scyther.setValue(newValue, forKey: FPSCounter.EnabledDefaultsKey)
             Task { @MainActor in
                 if newValue {
                     self.start()
@@ -122,14 +123,14 @@ public final class FPSCounter: Sendable {
     /// The position of the FPS counter on screen.
     ///
     /// Choose a corner that doesn't interfere with your app's UI.
-    /// The value is persisted to UserDefaults.
+    /// The value is persisted to ``UserDefaults/scyther``.
     public nonisolated var position: FPSCounterPosition {
         get {
-            let rawValue = UserDefaults.standard.string(forKey: FPSCounter.PositionDefaultsKey) ?? "topLeft"
+            let rawValue = UserDefaults.scyther.string(forKey: FPSCounter.PositionDefaultsKey) ?? "topLeft"
             return FPSCounterPosition(rawValue: rawValue) ?? .topLeft
         }
         set {
-            UserDefaults.standard.setValue(newValue.rawValue, forKey: FPSCounter.PositionDefaultsKey)
+            UserDefaults.scyther.setValue(newValue.rawValue, forKey: FPSCounter.PositionDefaultsKey)
             Task { @MainActor in
                 InterfaceToolkit.instance.fpsCounterView.updatePosition()
             }

--- a/Sources/Scyther/Features/FeatureFlags/FeatureFlagsView.swift
+++ b/Sources/Scyther/Features/FeatureFlags/FeatureFlagsView.swift
@@ -13,12 +13,17 @@ import Combine
 /// This view provides a searchable list of all registered feature toggles with the ability to:
 /// - Enable/disable local overrides globally
 /// - Set each feature flag to True, False, or Remote via a dropdown menu
-/// - Pin frequently used toggles to the top
+/// - Pin frequently used toggles to an additional section at the top; pinned toggles remain
+///   in the main list as well
 /// - Search toggles by name
 /// - Reset all toggles back to their remote values
 ///
 /// The view displays both remote and local values for each toggle, making it easy to see
 /// which features have been overridden during development.
+///
+/// While **Enable overrides** is off, the Pinned and Toggles sections and the reset button
+/// are hidden — local overrides have no effect in that state, so presenting an interactive
+/// list would be misleading. The search field remains visible throughout.
 struct FeatureFlagsView: View {
     @StateObject private var viewModel = FeatureFlagsViewModel()
     @State private var searchText: String = ""
@@ -32,82 +37,103 @@ struct FeatureFlagsView: View {
         return viewModel.pinnedToggles.filter { $0.name.lowercased().contains(search) }
     }
 
-    private var filteredUnpinnedToggles: [FeatureToggleItem] {
-        guard !debouncedSearchText.isEmpty else { return viewModel.unpinnedToggles }
+    private var filteredToggles: [FeatureToggleItem] {
+        guard !debouncedSearchText.isEmpty else { return viewModel.toggles }
         let search = debouncedSearchText.lowercased()
-        return viewModel.unpinnedToggles.filter { $0.name.lowercased().contains(search) }
+        return viewModel.toggles.filter { $0.name.lowercased().contains(search) }
     }
 
     var body: some View {
+        list
+            .searchable(text: $searchText, prompt: "Search toggles")
+            .navigationTitle("Feature Flags")
+            .onChange(of: searchText) { newValue in
+                searchSubject.send(newValue)
+            }
+            .onChange(of: viewModel.overridesEnabled) { enabled in
+                guard !enabled else { return }
+                searchText = ""
+                debouncedSearchText = ""
+            }
+            .onAppear {
+                cancellable = searchSubject
+                    .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+                    .sink { debouncedSearchText = $0 }
+            }
+            .onFirstAppear {
+                await viewModel.onFirstAppear()
+            }
+    }
+
+    private var list: some View {
         List {
-            Section("Global Settings") {
+            Section {
                 Toggle("Enable overrides", isOn: $viewModel.overridesEnabled)
 
-                Button("Reset all to Remote") {
-                    viewModel.resetAllToRemote()
-                }
-            }
-
-            if !filteredPinnedToggles.isEmpty {
-                Section("Pinned") {
-                    ForEach(filteredPinnedToggles) { toggle in
-                        toggleRow(for: toggle)
-                            .swipeActions(edge: .trailing) {
-                                Button {
-                                    viewModel.togglePin(for: toggle.name)
-                                } label: {
-                                    Label("Unpin", systemImage: "pin.slash")
-                                }
-                                .tint(.blue)
-                            }
+                if viewModel.overridesEnabled {
+                    Button("Reset all to Remote") {
+                        viewModel.resetAllToRemote()
                     }
                 }
+            } header: {
+                Text("Global Settings")
+            } footer: {
+                if !viewModel.overridesEnabled {
+                    Text("Enable overrides to view and modify feature flags.")
+                }
             }
 
-            Section("Toggles") {
-                if viewModel.toggles.isEmpty {
-                    Text("No toggles configured")
-                        .fontWeight(.bold)
-                        .foregroundStyle(.gray)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                } else if filteredUnpinnedToggles.isEmpty && debouncedSearchText.isEmpty {
-                    Text("All toggles are pinned")
-                        .fontWeight(.bold)
-                        .foregroundStyle(.gray)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                } else if filteredUnpinnedToggles.isEmpty {
-                    Text("No matching toggles")
-                        .fontWeight(.bold)
-                        .foregroundStyle(.gray)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                } else {
-                    ForEach(filteredUnpinnedToggles) { toggle in
-                        toggleRow(for: toggle)
-                            .swipeActions(edge: .trailing) {
-                                Button {
-                                    viewModel.togglePin(for: toggle.name)
-                                } label: {
-                                    Label("Pin", systemImage: "pin")
+            if viewModel.overridesEnabled {
+                if !filteredPinnedToggles.isEmpty {
+                    Section("Pinned") {
+                        ForEach(filteredPinnedToggles, id: \.pinnedRowID) { toggle in
+                            toggleRow(for: toggle)
+                                .swipeActions(edge: .trailing) {
+                                    pinButton(for: toggle)
                                 }
-                                .tint(.blue)
-                            }
+                        }
+                    }
+                }
+
+                Section("Toggles") {
+                    if viewModel.toggles.isEmpty {
+                        Text("No toggles configured")
+                            .fontWeight(.bold)
+                            .foregroundStyle(.gray)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    } else if filteredToggles.isEmpty {
+                        Text("No matching toggles")
+                            .fontWeight(.bold)
+                            .foregroundStyle(.gray)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    } else {
+                        ForEach(filteredToggles) { toggle in
+                            toggleRow(for: toggle)
+                                .swipeActions(edge: .trailing) {
+                                    pinButton(for: toggle)
+                                }
+                        }
                     }
                 }
             }
         }
-        .navigationTitle("Feature Flags")
-        .searchable(text: $searchText, prompt: "Search toggles")
-        .onChange(of: searchText) { newValue in
-            searchSubject.send(newValue)
+    }
+
+    /// The pin/unpin swipe action for a toggle.
+    ///
+    /// The label reflects the toggle's pin state rather than which section it is rendered
+    /// in, because pinned toggles remain in the main list.
+    @ViewBuilder
+    private func pinButton(for toggle: FeatureToggleItem) -> some View {
+        Button {
+            viewModel.togglePin(for: toggle.name)
+        } label: {
+            Label(
+                toggle.isPinned ? "Unpin" : "Pin",
+                systemImage: toggle.isPinned ? "pin.slash" : "pin"
+            )
         }
-        .onAppear {
-            cancellable = searchSubject
-                .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
-                .sink { debouncedSearchText = $0 }
-        }
-        .onFirstAppear {
-            await viewModel.onFirstAppear()
-        }
+        .tint(.blue)
     }
 
     @ViewBuilder

--- a/Sources/Scyther/Features/FeatureFlags/FeatureFlagsViewModel.swift
+++ b/Sources/Scyther/Features/FeatureFlags/FeatureFlagsViewModel.swift
@@ -112,7 +112,7 @@ struct FeatureToggleItem: Identifiable {
 ///
 /// The view model maintains a published array of ``FeatureToggleItem`` instances that
 /// represent the current state of all feature toggles. Pin state is persisted to
-/// ``UserDefaults/scyther`` using the key `Scyther.FeatureFlags.PinnedToggles` and is
+/// `UserDefaults.scyther` using the key `Scyther.FeatureFlags.PinnedToggles` and is
 /// automatically restored when the view model loads. Pinned toggles remain in the full
 /// ``toggles`` list, so a pinned toggle is shown both in the "Pinned" section and in the
 /// main list.
@@ -174,7 +174,7 @@ class FeatureFlagsViewModel: ViewModel {
         super.init()
     }
 
-    /// The set of toggle names that have been pinned, persisted in ``UserDefaults/scyther``.
+    /// The set of toggle names that have been pinned, persisted in `UserDefaults.scyther`.
     ///
     /// This property reads from and writes to ``defaults`` using the key
     /// ``pinnedTogglesKey`` to maintain pin state across app launches.
@@ -296,7 +296,7 @@ class FeatureFlagsViewModel: ViewModel {
     /// Toggles the pinned state of a feature toggle.
     ///
     /// This method updates both the in-memory ``toggles`` array and persists
-    /// the change to ``UserDefaults/scyther`` via ``pinnedToggleNames``.
+    /// the change to `UserDefaults.scyther` via ``pinnedToggleNames``.
     ///
     /// - Parameter name: The name of the toggle to pin or unpin.
     ///

--- a/Sources/Scyther/Features/FeatureFlags/FeatureFlagsViewModel.swift
+++ b/Sources/Scyther/Features/FeatureFlags/FeatureFlagsViewModel.swift
@@ -107,7 +107,7 @@ struct FeatureToggleItem: Identifiable {
 /// represent the current state of all feature toggles. It provides computed properties
 /// to separate pinned and unpinned toggles for easy UI organization.
 ///
-/// Pin state is persisted to `UserDefaults` using the key `Scyther.FeatureFlags.PinnedToggles`
+/// Pin state is persisted to ``UserDefaults/scyther`` using the key `Scyther.FeatureFlags.PinnedToggles`
 /// and is automatically restored when the view model loads.
 ///
 /// ## Topics
@@ -164,16 +164,16 @@ class FeatureFlagsViewModel: ViewModel {
         toggles.filter { !$0.isPinned }
     }
 
-    /// The set of toggle names that have been pinned, persisted in UserDefaults.
+    /// The set of toggle names that have been pinned, persisted in ``UserDefaults/scyther``.
     ///
-    /// This property reads from and writes to `UserDefaults` using the key
+    /// This property reads from and writes to ``UserDefaults/scyther`` using the key
     /// ``pinnedTogglesKey`` to maintain pin state across app launches.
     private var pinnedToggleNames: Set<String> {
         get {
-            Set(UserDefaults.standard.stringArray(forKey: Self.pinnedTogglesKey) ?? [])
+            Set(UserDefaults.scyther.stringArray(forKey: Self.pinnedTogglesKey) ?? [])
         }
         set {
-            UserDefaults.standard.set(Array(newValue), forKey: Self.pinnedTogglesKey)
+            UserDefaults.scyther.set(Array(newValue), forKey: Self.pinnedTogglesKey)
         }
     }
 
@@ -286,7 +286,7 @@ class FeatureFlagsViewModel: ViewModel {
     /// Toggles the pinned state of a feature toggle.
     ///
     /// This method updates both the in-memory ``toggles`` array and persists
-    /// the change to `UserDefaults` via ``pinnedToggleNames``.
+    /// the change to ``UserDefaults/scyther`` via ``pinnedToggleNames``.
     ///
     /// - Parameter name: The name of the toggle to pin or unpin.
     ///

--- a/Sources/Scyther/Features/FeatureFlags/FeatureFlagsViewModel.swift
+++ b/Sources/Scyther/Features/FeatureFlags/FeatureFlagsViewModel.swift
@@ -40,6 +40,7 @@ import Combine
 /// - ``state``
 /// - ``remoteValue``
 /// - ``isPinned``
+/// - ``pinnedRowID``
 struct FeatureToggleItem: Identifiable {
     /// Unique identifier for this toggle item.
     let id = UUID()
@@ -55,6 +56,12 @@ struct FeatureToggleItem: Identifiable {
 
     /// Whether this toggle is pinned to the top of the list.
     var isPinned: Bool
+
+    /// A namespaced identifier for rendering this toggle inside the "Pinned" section.
+    ///
+    /// Pinned toggles remain in the main list, so the same toggle appears twice in one
+    /// `List`. Namespacing the pinned copy keeps SwiftUI's row identity unambiguous.
+    var pinnedRowID: String { "pinned.\(name)" }
 }
 
 /// View model for the feature flags view.
@@ -104,11 +111,11 @@ struct FeatureToggleItem: Identifiable {
 /// ## Implementation Details
 ///
 /// The view model maintains a published array of ``FeatureToggleItem`` instances that
-/// represent the current state of all feature toggles. It provides computed properties
-/// to separate pinned and unpinned toggles for easy UI organization.
-///
-/// Pin state is persisted to ``UserDefaults/scyther`` using the key `Scyther.FeatureFlags.PinnedToggles`
-/// and is automatically restored when the view model loads.
+/// represent the current state of all feature toggles. Pin state is persisted to
+/// ``UserDefaults/scyther`` using the key `Scyther.FeatureFlags.PinnedToggles` and is
+/// automatically restored when the view model loads. Pinned toggles remain in the full
+/// ``toggles`` list, so a pinned toggle is shown both in the "Pinned" section and in the
+/// main list.
 ///
 /// ## Topics
 ///
@@ -116,7 +123,6 @@ struct FeatureToggleItem: Identifiable {
 /// - ``overridesEnabled``
 /// - ``toggles``
 /// - ``pinnedToggles``
-/// - ``unpinnedToggles``
 ///
 /// ### Toggle Operations
 /// - ``setState(_:forToggle:)``
@@ -143,9 +149,9 @@ class FeatureFlagsViewModel: ViewModel {
 
     /// All feature toggles currently displayed.
     ///
-    /// This array is sorted alphabetically by toggle name and includes both
-    /// pinned and unpinned toggles. Use ``pinnedToggles`` and ``unpinnedToggles``
-    /// to access filtered subsets.
+    /// This array is sorted alphabetically by toggle name and includes both pinned and
+    /// unpinned toggles. Use ``pinnedToggles`` to access the pinned subset; pinned toggles
+    /// remain in this array as well.
     @Published var toggles: [FeatureToggleItem] = []
 
     /// Toggles that have been pinned to the top of the list.
@@ -156,24 +162,28 @@ class FeatureFlagsViewModel: ViewModel {
         toggles.filter { $0.isPinned }
     }
 
-    /// Toggles that are not pinned.
+    /// The store pinned toggle names are read from and written to.
+    private let defaults: UserDefaults
+
+    /// Creates a feature flags view model.
     ///
-    /// This computed property filters ``toggles`` to return only items where
-    /// ``FeatureToggleItem/isPinned`` is `false`, maintaining the same sort order.
-    var unpinnedToggles: [FeatureToggleItem] {
-        toggles.filter { !$0.isPinned }
+    /// - Parameter defaults: The store backing pin state. Defaults to Scyther's private
+    ///   preferences suite; tests inject a throwaway suite.
+    init(defaults: UserDefaults = .scyther) {
+        self.defaults = defaults
+        super.init()
     }
 
     /// The set of toggle names that have been pinned, persisted in ``UserDefaults/scyther``.
     ///
-    /// This property reads from and writes to ``UserDefaults/scyther`` using the key
+    /// This property reads from and writes to ``defaults`` using the key
     /// ``pinnedTogglesKey`` to maintain pin state across app launches.
     private var pinnedToggleNames: Set<String> {
         get {
-            Set(UserDefaults.scyther.stringArray(forKey: Self.pinnedTogglesKey) ?? [])
+            Set(defaults.stringArray(forKey: Self.pinnedTogglesKey) ?? [])
         }
         set {
-            UserDefaults.scyther.set(Array(newValue), forKey: Self.pinnedTogglesKey)
+            defaults.set(Array(newValue), forKey: Self.pinnedTogglesKey)
         }
     }
 

--- a/Sources/Scyther/Features/FeatureFlags/FeatureToggle.swift
+++ b/Sources/Scyther/Features/FeatureFlags/FeatureToggle.swift
@@ -86,7 +86,7 @@ public struct FeatureToggle {
 
     /// The local override value for this feature toggle.
     ///
-    /// When set, the value is persisted to UserDefaults. This allows developers to override
+    /// When set, the value is persisted to ``UserDefaults/scyther``. This allows developers to override
     /// feature flags during development and testing without modifying server configuration.
     ///
     /// - Note: The getter returns `false` when no override has been stored. Use
@@ -96,10 +96,10 @@ public struct FeatureToggle {
     /// - Complexity: O(1)
     public var localValue: Bool {
         get {
-            return UserDefaults.standard.bool(forKey: defaultsKey)
+            return UserDefaults.scyther.bool(forKey: defaultsKey)
         }
         set {
-            UserDefaults.standard.setValue(newValue, forKey: defaultsKey)
+            UserDefaults.scyther.setValue(newValue, forKey: defaultsKey)
         }
     }
 
@@ -111,7 +111,7 @@ public struct FeatureToggle {
     ///
     /// - Complexity: O(1)
     public var hasLocalOverride: Bool {
-        return UserDefaults.standard.object(forKey: defaultsKey) != nil
+        return UserDefaults.scyther.object(forKey: defaultsKey) != nil
     }
 
     /// Removes any stored local override for this toggle.
@@ -121,6 +121,6 @@ public struct FeatureToggle {
     ///
     /// - Complexity: O(1)
     public func clearLocalValue() {
-        UserDefaults.standard.removeObject(forKey: defaultsKey)
+        UserDefaults.scyther.removeObject(forKey: defaultsKey)
     }
 }

--- a/Sources/Scyther/Features/FeatureFlags/FeatureToggle.swift
+++ b/Sources/Scyther/Features/FeatureFlags/FeatureToggle.swift
@@ -86,7 +86,7 @@ public struct FeatureToggle {
 
     /// The local override value for this feature toggle.
     ///
-    /// When set, the value is persisted to ``UserDefaults/scyther``. This allows developers to override
+    /// When set, the value is persisted to `UserDefaults.scyther`. This allows developers to override
     /// feature flags during development and testing without modifying server configuration.
     ///
     /// - Note: The getter returns `false` when no override has been stored. Use

--- a/Sources/Scyther/Features/GridOverlay/GridOverlay.swift
+++ b/Sources/Scyther/Features/GridOverlay/GridOverlay.swift
@@ -14,7 +14,8 @@ import UIKit
 /// layout alignment and spacing verification. The grid's appearance can be customized with
 /// different colors, opacity levels, and grid sizes.
 ///
-/// Settings are persisted to `UserDefaults` and automatically applied when changed.
+/// Settings are persisted in ``UserDefaults/scyther``, Scyther's private preferences suite,
+/// and automatically applied when changed.
 ///
 /// ```swift
 /// // Enable the grid overlay
@@ -69,13 +70,13 @@ internal final class GridOverlay: Sendable {
     /// Controls whether the grid overlay is visible on screen.
     ///
     /// Setting this to `true` displays the grid overlay over the entire application interface.
-    /// The value is persisted to UserDefaults and restored on app launch.
+    /// The value is persisted to ``UserDefaults/scyther`` and restored on app launch.
     internal nonisolated var enabled: Bool {
         get {
-            return UserDefaults.standard.bool(forKey: GridOverlay.EnabledDefaultsKey)
+            return UserDefaults.scyther.bool(forKey: GridOverlay.EnabledDefaultsKey)
         }
         set {
-            UserDefaults.standard.setValue(newValue, forKey: GridOverlay.EnabledDefaultsKey)
+            UserDefaults.scyther.setValue(newValue, forKey: GridOverlay.EnabledDefaultsKey)
             Task { @MainActor in InterfaceToolkit.instance.showGridOverlay() }
         }
     }
@@ -83,13 +84,13 @@ internal final class GridOverlay: Sendable {
     /// The color scheme used for the grid lines.
     ///
     /// Choose from predefined color schemes to ensure the grid is visible against
-    /// your app's color scheme. The value is persisted to UserDefaults.
+    /// your app's color scheme. The value is persisted to ``UserDefaults/scyther``.
     internal nonisolated var colorScheme: GridOverlayColorScheme {
         get {
-            return GridOverlayColorScheme(rawValue: UserDefaults.standard.string(forKey: GridOverlay.ColorDefaultsKey) ?? "red") ?? .red
+            return GridOverlayColorScheme(rawValue: UserDefaults.scyther.string(forKey: GridOverlay.ColorDefaultsKey) ?? "red") ?? .red
         }
         set {
-            UserDefaults.standard.setValue(newValue.rawValue, forKey: GridOverlay.ColorDefaultsKey)
+            UserDefaults.scyther.setValue(newValue.rawValue, forKey: GridOverlay.ColorDefaultsKey)
             Task { @MainActor in
                 InterfaceToolkit.instance.gridOverlayView.colorScheme = newValue
             }
@@ -99,13 +100,13 @@ internal final class GridOverlay: Sendable {
     /// The opacity of the grid overlay.
     ///
     /// Valid range is 0.0 (fully transparent) to 1.0 (fully opaque).
-    /// Adjust this to make the grid more or less prominent. The value is persisted to UserDefaults.
+    /// Adjust this to make the grid more or less prominent. The value is persisted to ``UserDefaults/scyther``.
     internal nonisolated var opacity: Float {
         get {
-            return UserDefaults.standard.object(forKey: GridOverlay.OpacityDefaultsKey) as? Float ?? 0.5
+            return UserDefaults.scyther.object(forKey: GridOverlay.OpacityDefaultsKey) as? Float ?? 0.5
         }
         set {
-            UserDefaults.standard.setValue(newValue, forKey: GridOverlay.OpacityDefaultsKey)
+            UserDefaults.scyther.setValue(newValue, forKey: GridOverlay.OpacityDefaultsKey)
             Task { @MainActor in
                 InterfaceToolkit.instance.gridOverlayView.opacity = CGFloat(newValue)
             }
@@ -115,13 +116,13 @@ internal final class GridOverlay: Sendable {
     /// The size of each grid square in points.
     ///
     /// Smaller values create a finer grid, larger values create a coarser grid.
-    /// Common values range from 4 to 16 points. The value is persisted to UserDefaults.
+    /// Common values range from 4 to 16 points. The value is persisted to ``UserDefaults/scyther``.
     internal nonisolated var size: Int {
         get {
-            return UserDefaults.standard.object(forKey: GridOverlay.SizeDefaultsKey) as? Int ?? 8
+            return UserDefaults.scyther.object(forKey: GridOverlay.SizeDefaultsKey) as? Int ?? 8
         }
         set {
-            UserDefaults.standard.setValue(newValue, forKey: GridOverlay.SizeDefaultsKey)
+            UserDefaults.scyther.setValue(newValue, forKey: GridOverlay.SizeDefaultsKey)
             Task { @MainActor in
                 InterfaceToolkit.instance.gridOverlayView.gridSize = newValue
             }

--- a/Sources/Scyther/Features/GridOverlay/GridOverlay.swift
+++ b/Sources/Scyther/Features/GridOverlay/GridOverlay.swift
@@ -14,7 +14,7 @@ import UIKit
 /// layout alignment and spacing verification. The grid's appearance can be customized with
 /// different colors, opacity levels, and grid sizes.
 ///
-/// Settings are persisted in ``UserDefaults/scyther``, Scyther's private preferences suite,
+/// Settings are persisted in `UserDefaults.scyther`, Scyther's private preferences suite,
 /// and automatically applied when changed.
 ///
 /// ```swift
@@ -70,7 +70,7 @@ internal final class GridOverlay: Sendable {
     /// Controls whether the grid overlay is visible on screen.
     ///
     /// Setting this to `true` displays the grid overlay over the entire application interface.
-    /// The value is persisted to ``UserDefaults/scyther`` and restored on app launch.
+    /// The value is persisted to `UserDefaults.scyther` and restored on app launch.
     internal nonisolated var enabled: Bool {
         get {
             return UserDefaults.scyther.bool(forKey: GridOverlay.EnabledDefaultsKey)
@@ -84,7 +84,7 @@ internal final class GridOverlay: Sendable {
     /// The color scheme used for the grid lines.
     ///
     /// Choose from predefined color schemes to ensure the grid is visible against
-    /// your app's color scheme. The value is persisted to ``UserDefaults/scyther``.
+    /// your app's color scheme. The value is persisted to `UserDefaults.scyther`.
     internal nonisolated var colorScheme: GridOverlayColorScheme {
         get {
             return GridOverlayColorScheme(rawValue: UserDefaults.scyther.string(forKey: GridOverlay.ColorDefaultsKey) ?? "red") ?? .red
@@ -100,7 +100,7 @@ internal final class GridOverlay: Sendable {
     /// The opacity of the grid overlay.
     ///
     /// Valid range is 0.0 (fully transparent) to 1.0 (fully opaque).
-    /// Adjust this to make the grid more or less prominent. The value is persisted to ``UserDefaults/scyther``.
+    /// Adjust this to make the grid more or less prominent. The value is persisted to `UserDefaults.scyther`.
     internal nonisolated var opacity: Float {
         get {
             return UserDefaults.scyther.object(forKey: GridOverlay.OpacityDefaultsKey) as? Float ?? 0.5
@@ -116,7 +116,7 @@ internal final class GridOverlay: Sendable {
     /// The size of each grid square in points.
     ///
     /// Smaller values create a finer grid, larger values create a coarser grid.
-    /// Common values range from 4 to 16 points. The value is persisted to ``UserDefaults/scyther``.
+    /// Common values range from 4 to 16 points. The value is persisted to `UserDefaults.scyther`.
     internal nonisolated var size: Int {
         get {
             return UserDefaults.scyther.object(forKey: GridOverlay.SizeDefaultsKey) as? Int ?? 8

--- a/Sources/Scyther/Features/LocationSpoofer/LocationSpoofer.swift
+++ b/Sources/Scyther/Features/LocationSpoofer/LocationSpoofer.swift
@@ -87,25 +87,25 @@ public final class LocationSpoofer: CLLocationManager, @unchecked Sendable {
     // MARK: - Nonisolated Read Accessors (UserDefaults is thread-safe)
     public nonisolated var spoofingEnabled: Bool {
         get {
-            UserDefaults.standard.bool(forKey: LocationSpoofer.LocationSpoofingEnabledDefaultsKey)
+            UserDefaults.scyther.bool(forKey: LocationSpoofer.LocationSpoofingEnabledDefaultsKey)
         }
         set {
-            UserDefaults.standard.setValue(newValue, forKey: LocationSpoofer.LocationSpoofingEnabledDefaultsKey)
+            UserDefaults.scyther.setValue(newValue, forKey: LocationSpoofer.LocationSpoofingEnabledDefaultsKey)
             NotificationCenter.default.post(name: LocationSpoofer.LocationSpoofingEnabledChangeNotification, object: newValue)
         }
     }
     public nonisolated var useCustomLocation: Bool {
         get {
-            UserDefaults.standard.bool(forKey: LocationSpoofer.LocationSpoofingCustomLocationEnabledDefaultsKey)
+            UserDefaults.scyther.bool(forKey: LocationSpoofer.LocationSpoofingCustomLocationEnabledDefaultsKey)
         } set {
-            UserDefaults.standard.setValue(newValue, forKey: LocationSpoofer.LocationSpoofingCustomLocationEnabledDefaultsKey)
+            UserDefaults.scyther.setValue(newValue, forKey: LocationSpoofer.LocationSpoofingCustomLocationEnabledDefaultsKey)
             NotificationCenter.default.post(name: LocationSpoofer.LocationSpoofingLocationChangeNotification, object: newValue)
         }
     }
     public nonisolated var customLocation: Location {
         get {
-            let latitude = UserDefaults.standard.value(forKey: LocationSpoofer.LocationSpoofingCustomLatitudeKey) as? Double
-            let longitude = UserDefaults.standard.value(forKey: LocationSpoofer.LocationSpoofingCustomLongitudeKey) as? Double
+            let latitude = UserDefaults.scyther.value(forKey: LocationSpoofer.LocationSpoofingCustomLatitudeKey) as? Double
+            let longitude = UserDefaults.scyther.value(forKey: LocationSpoofer.LocationSpoofingCustomLongitudeKey) as? Double
             return Location(id: "custom",
                             name: "Custom Location",
                             latitude: latitude ?? .zero,
@@ -113,12 +113,12 @@ public final class LocationSpoofer: CLLocationManager, @unchecked Sendable {
         }
         set {
             // Clear route when setting custom location
-            UserDefaults.standard.removeObject(forKey: LocationSpoofer.LocationSpoofingRouteIdKey)
+            UserDefaults.scyther.removeObject(forKey: LocationSpoofer.LocationSpoofingRouteIdKey)
             // Set custom location
-            UserDefaults.standard.removeObject(forKey: LocationSpoofer.LocationSpoofingCustomLatitudeKey)
-            UserDefaults.standard.removeObject(forKey: LocationSpoofer.LocationSpoofingCustomLongitudeKey)
-            UserDefaults.standard.setValue(newValue.latitude, forKey: LocationSpoofer.LocationSpoofingCustomLatitudeKey)
-            UserDefaults.standard.setValue(newValue.longitude, forKey: LocationSpoofer.LocationSpoofingCustomLongitudeKey)
+            UserDefaults.scyther.removeObject(forKey: LocationSpoofer.LocationSpoofingCustomLatitudeKey)
+            UserDefaults.scyther.removeObject(forKey: LocationSpoofer.LocationSpoofingCustomLongitudeKey)
+            UserDefaults.scyther.setValue(newValue.latitude, forKey: LocationSpoofer.LocationSpoofingCustomLatitudeKey)
+            UserDefaults.scyther.setValue(newValue.longitude, forKey: LocationSpoofer.LocationSpoofingCustomLongitudeKey)
             NotificationCenter.default.post(name: LocationSpoofer.LocationSpoofingLocationChangeNotification, object: newValue)
         }
     }
@@ -127,36 +127,36 @@ public final class LocationSpoofer: CLLocationManager, @unchecked Sendable {
             if useCustomLocation {
                 return customLocation
             } else {
-                let latitude = UserDefaults.standard.value(forKey: LocationSpoofer.LocationSpoofingLatitudeKey) as? Double
-                let longitude = UserDefaults.standard.value(forKey: LocationSpoofer.LocationSpoofingLongitudeKey) as? Double
+                let latitude = UserDefaults.scyther.value(forKey: LocationSpoofer.LocationSpoofingLatitudeKey) as? Double
+                let longitude = UserDefaults.scyther.value(forKey: LocationSpoofer.LocationSpoofingLongitudeKey) as? Double
                 return Self.presetLocationsList.first(where: { $0.latitude == latitude && $0.longitude == longitude }) ?? .sydney
             }
         }
         set {
             // Clear other modes
-            UserDefaults.standard.setValue(false, forKey: LocationSpoofer.LocationSpoofingCustomLocationEnabledDefaultsKey)
-            UserDefaults.standard.removeObject(forKey: LocationSpoofer.LocationSpoofingRouteIdKey)
+            UserDefaults.scyther.setValue(false, forKey: LocationSpoofer.LocationSpoofingCustomLocationEnabledDefaultsKey)
+            UserDefaults.scyther.removeObject(forKey: LocationSpoofer.LocationSpoofingRouteIdKey)
             // Set location
-            UserDefaults.standard.removeObject(forKey: LocationSpoofer.LocationSpoofingLatitudeKey)
-            UserDefaults.standard.removeObject(forKey: LocationSpoofer.LocationSpoofingLongitudeKey)
-            UserDefaults.standard.setValue(newValue.latitude, forKey: LocationSpoofer.LocationSpoofingLatitudeKey)
-            UserDefaults.standard.setValue(newValue.longitude, forKey: LocationSpoofer.LocationSpoofingLongitudeKey)
+            UserDefaults.scyther.removeObject(forKey: LocationSpoofer.LocationSpoofingLatitudeKey)
+            UserDefaults.scyther.removeObject(forKey: LocationSpoofer.LocationSpoofingLongitudeKey)
+            UserDefaults.scyther.setValue(newValue.latitude, forKey: LocationSpoofer.LocationSpoofingLatitudeKey)
+            UserDefaults.scyther.setValue(newValue.longitude, forKey: LocationSpoofer.LocationSpoofingLongitudeKey)
             NotificationCenter.default.post(name: LocationSpoofer.LocationSpoofingLocationChangeNotification, object: newValue)
         }
     }
     public nonisolated var spoofedRoute: Route? {
         get {
-            return Self.presetRoutesList.first(where: { $0.id == UserDefaults.standard.string(forKey: LocationSpoofer.LocationSpoofingRouteIdKey) })
+            return Self.presetRoutesList.first(where: { $0.id == UserDefaults.scyther.string(forKey: LocationSpoofer.LocationSpoofingRouteIdKey) })
         }
         set {
             // Clear other modes
-            UserDefaults.standard.setValue(false, forKey: LocationSpoofer.LocationSpoofingCustomLocationEnabledDefaultsKey)
+            UserDefaults.scyther.setValue(false, forKey: LocationSpoofer.LocationSpoofingCustomLocationEnabledDefaultsKey)
 
             guard let newValue = newValue else {
-                UserDefaults.standard.removeObject(forKey: LocationSpoofer.LocationSpoofingRouteIdKey)
+                UserDefaults.scyther.removeObject(forKey: LocationSpoofer.LocationSpoofingRouteIdKey)
                 return
             }
-            UserDefaults.standard.setValue(newValue.id, forKey: LocationSpoofer.LocationSpoofingRouteIdKey)
+            UserDefaults.scyther.setValue(newValue.id, forKey: LocationSpoofer.LocationSpoofingRouteIdKey)
             NotificationCenter.default.post(name: LocationSpoofer.LocationSpoofingLocationChangeNotification,
                                             object: newValue)
         }

--- a/Sources/Scyther/Features/Menu/MenuItem.swift
+++ b/Sources/Scyther/Features/Menu/MenuItem.swift
@@ -1,0 +1,265 @@
+//
+//  MenuItem.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+import Foundation
+
+/// A single row in the Scyther main menu.
+///
+/// Giving every row a stable identity is what makes pinning possible: an identifier can be
+/// persisted, and the same case can be rendered both in its home section and in the "Pinned"
+/// section without duplicating its definition.
+///
+/// ## Features
+///
+/// - Stable, persistable ``id`` for every row
+/// - Lossless round-tripping via ``init(id:)``, returning `nil` for rows that no longer exist
+/// - Single source of truth for each row's ``title`` and ``icon``
+/// - Support for host-supplied rows via ``developerOption(name:)``
+///
+/// ## Usage
+///
+/// ```swift
+/// let item = MenuItem.featureFlags
+/// item.id       // "featureFlags"
+/// item.title    // "Feature Flags"
+/// item.icon     // "flag"
+///
+/// MenuItem(id: "featureFlags")   // .featureFlags
+/// MenuItem(id: "removedInV2")    // nil
+/// ```
+///
+/// ## Implementation Details
+///
+/// Dynamic values — a value row's description, a navigation row's destination, a toggle
+/// row's binding — deliberately live in ``MenuView`` rather than here. This type owns only
+/// what is stable across renders.
+///
+/// The device header shown at the top of the menu is not a `MenuItem`; it is a plain header
+/// view and is not pinnable.
+///
+/// ## Topics
+///
+/// ### Identity
+/// - ``id``
+/// - ``init(id:)``
+/// - ``pinnedRowID``
+/// - ``allStaticCases``
+///
+/// ### Presentation
+/// - ``title``
+/// - ``icon``
+enum MenuItem: Hashable, Identifiable {
+    // Device
+    case osVersion, hardware, releaseYear, uuid
+
+    // Application
+    case appIdPrefix, displayName, bundleId, processId
+    case version, buildNumber, buildDate, releaseType
+
+    // Development Tools
+    case developerOption(name: String)
+
+    // Networking
+    case ipAddress, networkLogs, serverConfiguration, environmentVariables
+
+    // Data
+    case featureFlags, userDefaults, cookies, fileBrowser, databaseBrowser
+
+    // Security
+    case keychainBrowser
+
+    // System Tools
+    case locationSpoofer, consoleLogs, deepLinkTester, crashLogs
+
+    // Notifications
+    case notificationLogger, notificationTester, apnsToken, fcmToken
+
+    // UI/UX
+    case fonts, interfaceComponents, gridOverlay, fpsCounter
+    case touchVisualiser, appearance
+    case slowAnimations, showViewFrames, showViewSizes
+
+    /// The identifier prefix distinguishing host-supplied rows from built-in ones.
+    static let developerOptionPrefix = "developerOption."
+
+    /// Every built-in row, in menu order.
+    ///
+    /// Excludes ``developerOption(name:)``, which is supplied at runtime by the host app via
+    /// `Scyther.developerOptions`.
+    static let allStaticCases: [MenuItem] = [
+        .osVersion, .hardware, .releaseYear, .uuid,
+        .appIdPrefix, .displayName, .bundleId, .processId,
+        .version, .buildNumber, .buildDate, .releaseType,
+        .ipAddress, .networkLogs, .serverConfiguration, .environmentVariables,
+        .featureFlags, .userDefaults, .cookies, .fileBrowser, .databaseBrowser,
+        .keychainBrowser,
+        .locationSpoofer, .consoleLogs, .deepLinkTester, .crashLogs,
+        .notificationLogger, .notificationTester, .apnsToken, .fcmToken,
+        .fonts, .interfaceComponents, .gridOverlay, .fpsCounter,
+        .touchVisualiser, .appearance,
+        .slowAnimations, .showViewFrames, .showViewSizes
+    ]
+
+    /// A stable identifier, safe to persist across app launches and Scyther versions.
+    var id: String {
+        switch self {
+        case .osVersion: return "osVersion"
+        case .hardware: return "hardware"
+        case .releaseYear: return "releaseYear"
+        case .uuid: return "uuid"
+        case .appIdPrefix: return "appIdPrefix"
+        case .displayName: return "displayName"
+        case .bundleId: return "bundleId"
+        case .processId: return "processId"
+        case .version: return "version"
+        case .buildNumber: return "buildNumber"
+        case .buildDate: return "buildDate"
+        case .releaseType: return "releaseType"
+        case .developerOption(let name): return Self.developerOptionPrefix + name
+        case .ipAddress: return "ipAddress"
+        case .networkLogs: return "networkLogs"
+        case .serverConfiguration: return "serverConfiguration"
+        case .environmentVariables: return "environmentVariables"
+        case .featureFlags: return "featureFlags"
+        case .userDefaults: return "userDefaults"
+        case .cookies: return "cookies"
+        case .fileBrowser: return "fileBrowser"
+        case .databaseBrowser: return "databaseBrowser"
+        case .keychainBrowser: return "keychainBrowser"
+        case .locationSpoofer: return "locationSpoofer"
+        case .consoleLogs: return "consoleLogs"
+        case .deepLinkTester: return "deepLinkTester"
+        case .crashLogs: return "crashLogs"
+        case .notificationLogger: return "notificationLogger"
+        case .notificationTester: return "notificationTester"
+        case .apnsToken: return "apnsToken"
+        case .fcmToken: return "fcmToken"
+        case .fonts: return "fonts"
+        case .interfaceComponents: return "interfaceComponents"
+        case .gridOverlay: return "gridOverlay"
+        case .fpsCounter: return "fpsCounter"
+        case .touchVisualiser: return "touchVisualiser"
+        case .appearance: return "appearance"
+        case .slowAnimations: return "slowAnimations"
+        case .showViewFrames: return "showViewFrames"
+        case .showViewSizes: return "showViewSizes"
+        }
+    }
+
+    /// A namespaced identifier for rendering this item inside the "Pinned" section.
+    ///
+    /// Pinned rows remain in their home section, so the same item appears twice in one
+    /// `List`. Namespacing the pinned copy keeps SwiftUI's row identity unambiguous.
+    var pinnedRowID: String { "pinned.\(id)" }
+
+    /// Reconstructs an item from a persisted identifier.
+    ///
+    /// - Parameter id: An identifier previously produced by ``id``.
+    /// - Returns: The matching item, or `nil` if no such row exists. A `nil` result is
+    ///   expected and harmless — it means a stored pin refers to a row removed in a later
+    ///   version of Scyther.
+    init?(id: String) {
+        if id.hasPrefix(Self.developerOptionPrefix) {
+            let name = String(id.dropFirst(Self.developerOptionPrefix.count))
+            guard !name.isEmpty else { return nil }
+            self = .developerOption(name: name)
+            return
+        }
+
+        guard let match = Self.allStaticCases.first(where: { $0.id == id }) else { return nil }
+        self = match
+    }
+
+    /// The row's display label.
+    var title: String {
+        switch self {
+        case .osVersion: return "OS Version"
+        case .hardware: return "Hardware"
+        case .releaseYear: return "Release Year"
+        case .uuid: return "UUID"
+        case .appIdPrefix: return "App ID Prefix"
+        case .displayName: return "Display Name"
+        case .bundleId: return "Bundle ID"
+        case .processId: return "Process ID"
+        case .version: return "Version"
+        case .buildNumber: return "Build Number"
+        case .buildDate: return "Build Date"
+        case .releaseType: return "Release Type"
+        case .developerOption(let name): return name
+        case .ipAddress: return "IP Address"
+        case .networkLogs: return "Network Logs"
+        case .serverConfiguration: return "Server Configuration"
+        case .environmentVariables: return "Environment Variables"
+        case .featureFlags: return "Feature Flags"
+        case .userDefaults: return "UserDefaults"
+        case .cookies: return "Cookies"
+        case .fileBrowser: return "File Browser"
+        case .databaseBrowser: return "Database Browser"
+        case .keychainBrowser: return "Keychain Browser"
+        case .locationSpoofer: return "Location Spoofer"
+        case .consoleLogs: return "Console Logs"
+        case .deepLinkTester: return "Deep Link Tester"
+        case .crashLogs: return "Crash Logs"
+        case .notificationLogger: return "Notification Logger"
+        case .notificationTester: return "Notification Tester"
+        case .apnsToken: return "APNS Token"
+        case .fcmToken: return "FCM Token"
+        case .fonts: return "Fonts"
+        case .interfaceComponents: return "Interface Components"
+        case .gridOverlay: return "Grid Overlay"
+        case .fpsCounter: return "FPS Counter"
+        case .touchVisualiser: return "Touch Visualiser"
+        case .appearance: return "Appearance"
+        case .slowAnimations: return "Slow Animations"
+        case .showViewFrames: return "Show View Frames"
+        case .showViewSizes: return "Show View Sizes"
+        }
+    }
+
+    /// The SF Symbol shown alongside the row, or `nil` for rows that display no icon.
+    ///
+    /// Device and application information rows intentionally have no icon, matching the
+    /// menu's existing appearance. ``developerOption(name:)`` also returns `nil` here — its
+    /// icon comes from the host-supplied `DeveloperOption`, which may be a `UIImage` rather
+    /// than an SF Symbol.
+    var icon: String? {
+        switch self {
+        case .osVersion, .hardware, .releaseYear, .uuid,
+             .appIdPrefix, .displayName, .bundleId, .processId,
+             .version, .buildNumber, .buildDate, .releaseType,
+             .developerOption:
+            return nil
+        case .ipAddress: return "network"
+        case .networkLogs: return "text.page.badge.magnifyingglass"
+        case .serverConfiguration: return "server.rack"
+        case .environmentVariables: return "x.squareroot"
+        case .featureFlags: return "flag"
+        case .userDefaults: return "face.dashed"
+        case .cookies: return "info.circle"
+        case .fileBrowser: return "folder"
+        case .databaseBrowser: return "cylinder.split.1x2"
+        case .keychainBrowser: return "key"
+        case .locationSpoofer: return "location.circle"
+        case .consoleLogs: return "terminal"
+        case .deepLinkTester: return "link"
+        case .crashLogs: return "exclamationmark.triangle"
+        case .notificationLogger: return "list.bullet"
+        case .notificationTester: return "bell"
+        case .apnsToken: return "applelogo"
+        case .fcmToken: return "flame"
+        case .fonts: return "textformat"
+        case .interfaceComponents: return "apps.iphone"
+        case .gridOverlay: return "rectangle.split.3x3"
+        case .fpsCounter: return "speedometer"
+        case .touchVisualiser: return "hand.point.up"
+        case .appearance: return "paintbrush"
+        case .slowAnimations: return "tortoise"
+        case .showViewFrames: return "rectangle.dashed"
+        case .showViewSizes: return "ruler"
+        }
+    }
+}

--- a/Sources/Scyther/Features/Menu/MenuItem.swift
+++ b/Sources/Scyther/Features/Menu/MenuItem.swift
@@ -61,6 +61,12 @@ enum MenuItem: Hashable, Identifiable {
     case version, buildNumber, buildDate, releaseType
 
     // Development Tools
+
+    /// A host-supplied row from `Scyther.developerOptions`, identified by its ``DeveloperOption/name``.
+    ///
+    /// - Note: Because the pin identifier is derived from `name` (see ``id``), renaming a
+    ///   developer option in the host app silently drops any pin on it — the old identifier
+    ///   no longer resolves via ``init(id:)``, and behaves like any other stale pin.
     case developerOption(name: String)
 
     // Networking

--- a/Sources/Scyther/Features/Menu/MenuSection.swift
+++ b/Sources/Scyther/Features/Menu/MenuSection.swift
@@ -1,0 +1,97 @@
+//
+//  MenuSection.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+import Foundation
+
+/// A titled group of rows in the Scyther main menu.
+///
+/// Describing the menu as data rather than as literal SwiftUI sections is what lets
+/// ``MenuView`` render the same ``MenuItem`` in both its home section and the "Pinned"
+/// section from a single row definition.
+///
+/// ## Usage
+///
+/// ```swift
+/// for section in MenuSection.allSections(developerOptions: Scyther.developerOptions) {
+///     print(section.title, section.items.count)
+/// }
+/// ```
+///
+/// ## Topics
+///
+/// ### Properties
+/// - ``id``
+/// - ``title``
+/// - ``items``
+///
+/// ### Layout
+/// - ``allSections(developerOptions:)``
+struct MenuSection: Identifiable {
+    /// Stable identifier, derived from the section's title.
+    var id: String { title }
+
+    /// The section header text.
+    let title: String
+
+    /// The rows in this section, in display order.
+    let items: [MenuItem]
+
+    /// The full menu layout, in display order.
+    ///
+    /// "Device" is always first — ``MenuView`` renders the device header inside it and
+    /// inserts the "Pinned" section immediately afterwards.
+    ///
+    /// - Parameter developerOptions: The host app's custom options, from
+    ///   `Scyther.developerOptions`. When empty, the "Development Tools" section is omitted
+    ///   entirely rather than rendered blank.
+    /// - Returns: Every section that should be displayed.
+    static func allSections(developerOptions: [DeveloperOption]) -> [MenuSection] {
+        var sections: [MenuSection] = [
+            MenuSection(title: "Device", items: [
+                .osVersion, .hardware, .releaseYear, .uuid
+            ]),
+            MenuSection(title: "Application", items: [
+                .appIdPrefix, .displayName, .bundleId, .processId,
+                .version, .buildNumber, .buildDate, .releaseType
+            ])
+        ]
+
+        if !developerOptions.isEmpty {
+            sections.append(
+                MenuSection(
+                    title: "Development Tools",
+                    items: developerOptions.map { .developerOption(name: $0.name) }
+                )
+            )
+        }
+
+        sections.append(contentsOf: [
+            MenuSection(title: "Networking", items: [
+                .ipAddress, .networkLogs, .serverConfiguration, .environmentVariables
+            ]),
+            MenuSection(title: "Data", items: [
+                .featureFlags, .userDefaults, .cookies, .fileBrowser, .databaseBrowser
+            ]),
+            MenuSection(title: "Security", items: [
+                .keychainBrowser
+            ]),
+            MenuSection(title: "System Tools", items: [
+                .locationSpoofer, .consoleLogs, .deepLinkTester, .crashLogs
+            ]),
+            MenuSection(title: "Notifications", items: [
+                .notificationLogger, .notificationTester, .apnsToken, .fcmToken
+            ]),
+            MenuSection(title: "UI/UX", items: [
+                .fonts, .interfaceComponents, .gridOverlay, .fpsCounter,
+                .touchVisualiser, .appearance,
+                .slowAnimations, .showViewFrames, .showViewSizes
+            ])
+        ])
+
+        return sections
+    }
+}

--- a/Sources/Scyther/Features/Menu/MenuView.swift
+++ b/Sources/Scyther/Features/Menu/MenuView.swift
@@ -78,6 +78,9 @@ public struct MenuView: View {
         .onFirstAppear {
             await viewModel.onFirstAppear()
         }
+        .onSubsequentAppear {
+            await viewModel.onSubsequentAppear()
+        }
         .navigationTitle("Scyther")
         .interactiveDismissDisabled()
     }

--- a/Sources/Scyther/Features/Menu/MenuView.swift
+++ b/Sources/Scyther/Features/Menu/MenuView.swift
@@ -23,6 +23,11 @@ import SwiftUI
 ///
 /// The menu displays device information in a header and provides navigation
 /// to all sub-features.
+///
+/// Any row can be pinned via a trailing swipe action. Pinned rows appear in a "Pinned"
+/// section rendered directly beneath **Device**, and also remain in their home section, so
+/// the menu's structure never changes shape as rows are pinned. Pins are ordered oldest
+/// first and persist across launches in ``UserDefaults/scyther``.
 public struct MenuView: View {
     @StateObject private var viewModel: MenuViewModel = MenuViewModel()
 
@@ -30,228 +35,35 @@ public struct MenuView: View {
 
     public var body: some View {
         List {
-            Section {
-                header
-                row(
-                    withLabel: "OS Version",
-                    description: UIDevice.current.systemVersion
-                )
-                row(
-                    withLabel: "Hardware",
-                    description: UIDevice.current.modelName
-                )
-                row(
-                    withLabel: "Release Year",
-                    description: UIDevice.current.generation.withoutDecimals
-                )
-                row(
-                    withLabel: "UUID",
-                    description: UIDevice.current.identifierForVendor?.uuidString
-                )
-            } header: {
-                Text("Device")
-            }
-            
-            Section {
-                row(
-                    withLabel: "App ID Prefix",
-                    description: Bundle.main.seedId
-                )
-                row(
-                    withLabel: "Display Name",
-                    description: String(UIApplication.shared.appName)
-                )
-                row(
-                    withLabel: "Bundle ID",
-                    description: Bundle.main.bundleIdentifier
-                )
-                row(
-                    withLabel: "Process ID",
-                    description: String(getpid())
-                )
-                row(
-                    withLabel: "Version",
-                    description: Bundle.main.versionNumber
-                )
-                row(
-                    withLabel: "Build Number",
-                    description: Bundle.main.buildNumber
-                )
-                row(
-                    withLabel: "Build Date",
-                    description: Bundle.main.buildDate.formatted()
-                )
-                row(
-                    withLabel: "Release Type",
-                    description: AppEnvironment.configuration().rawValue
-                )
-            } header: {
-                Text("Application")
-            }
-
-            if !Scyther.developerOptions.isEmpty {
+            if let deviceSection = viewModel.sections.first {
                 Section {
-                    ForEach(Scyther.developerOptions, id: \.name) { option in
-                        developerOptionRow(option)
+                    header
+                    ForEach(deviceSection.items) { item in
+                        pinnableRow(for: item)
                     }
                 } header: {
-                    Text("Development Tools")
+                    Text(deviceSection.title)
                 }
             }
 
-            Section {
-                row(
-                    withLabel: "IP Address",
-                    description: viewModel.ipAddress,
-                    icon: "network",
-                    andLoadingState: viewModel.isLoadingIPAddress
-                )
-                NavigationLink {
-                    NetworkLogsView()
-                } label: {
-                    row(
-                        withLabel: "Network Logs",
-                        icon: "text.page.badge.magnifyingglass"
-                    )
+            if !viewModel.pinnedItems.isEmpty {
+                Section {
+                    ForEach(viewModel.pinnedItems, id: \.pinnedRowID) { item in
+                        pinnableRow(for: item)
+                    }
+                } header: {
+                    Text("Pinned")
                 }
-                NavigationLink {
-                    ServerConfigurationView()
-                } label: {
-                    row(
-                        withLabel: "Server Configuration",
-                        icon: "server.rack"
-                    )
-                }
-                NavigationLink {
-                    EnvironmentVariablesView()
-                } label: {
-                    row(
-                        withLabel: "Environment Variables",
-                        icon: "x.squareroot"
-                    )
-                }
-            } header: {
-                Text("Networking")
             }
-            
-            Section {
-                NavigationLink {
-                    FeatureFlagsView()
-                } label: {
-                    row(withLabel: "Feature Flags", icon: "flag")
+
+            ForEach(Array(viewModel.sections.dropFirst())) { section in
+                Section {
+                    ForEach(section.items) { item in
+                        pinnableRow(for: item)
+                    }
+                } header: {
+                    Text(section.title)
                 }
-                NavigationLink {
-                    UserDefaultsView()
-                } label: {
-                    row(withLabel: "UserDefaults", icon: "face.dashed")
-                }
-                NavigationLink {
-                    CookieBrowserView()
-                } label: {
-                    row(withLabel: "Cookies", icon: "info.circle")
-                }
-                NavigationLink {
-                    FileBrowserView()
-                } label: {
-                    row(withLabel: "File Browser", icon: "folder")
-                }
-                NavigationLink {
-                    DatabaseBrowserView()
-                } label: {
-                    row(withLabel: "Database Browser", icon: "cylinder.split.1x2")
-                }
-            } header: {
-                Text("Data")
-            }
-            
-            Section {
-                NavigationLink {
-                    KeychainBrowserView()
-                } label: {
-                    row(withLabel: "Keychain Browser", icon: "key")
-                }
-            } header: {
-                Text("Security")
-            }
-            
-            Section {
-                NavigationLink {
-                    LocationSpooferView()
-                } label: {
-                    row(withLabel: "Location Spoofer", icon: "location.circle")
-                }
-                NavigationLink {
-                    ConsoleLoggerView()
-                } label: {
-                    row(withLabel: "Console Logs", icon: "terminal")
-                }
-                NavigationLink {
-                    DeepLinkTesterView()
-                } label: {
-                    row(withLabel: "Deep Link Tester", icon: "link")
-                }
-                NavigationLink {
-                    CrashLogsView()
-                } label: {
-                    row(withLabel: "Crash Logs", icon: "exclamationmark.triangle")
-                }
-            } header: {
-                Text("System Tools")
-            }
-            
-            Section {
-                NavigationLink {
-                    NotificationLoggerView()
-                } label: {
-                    row(withLabel: "Notification Logger", icon: "list.bullet")
-                }
-                NavigationLink {
-                    NotificationTesterView()
-                } label: {
-                    row(withLabel: "Notification Tester", icon: "bell")
-                }
-                row(withLabel: "APNS Token", icon: "applelogo")
-                row(withLabel: "FCM Token", icon: "flame")
-            } header: {
-                Text("Notifications")
-            }
-            
-            Section {
-                NavigationLink {
-                    FontsView()
-                } label: {
-                    row(withLabel: "Fonts", icon: "textformat")
-                }
-                NavigationLink {
-                    InterfacePreviewsView()
-                } label: {
-                    row(withLabel: "Interface Components", icon: "apps.iphone")
-                }
-                NavigationLink {
-                    GridOverlaySettingsView()
-                } label: {
-                    row(withLabel: "Grid Overlay", icon: "rectangle.split.3x3")
-                }
-                NavigationLink {
-                    FPSCounterSettingsView()
-                } label: {
-                    row(withLabel: "FPS Counter", icon: "speedometer")
-                }
-                NavigationLink {
-                    TouchVisualiserView()
-                } label: {
-                    row(withLabel: "Touch Visualiser", icon: "hand.point.up")
-                }
-                NavigationLink {
-                    AppearanceOverridesView()
-                } label: {
-                    row(withLabel: "Appearance", icon: "paintbrush")
-                }
-                toggleRow("Slow Animations", icon: "tortoise", isOn: $viewModel.slowAnimationsEnabled)
-                toggleRow("Show View Frames", icon: "rectangle.dashed", isOn: $viewModel.showViewFrames)
-                toggleRow("Show View Sizes", icon: "ruler", isOn: $viewModel.showViewSizes)
-            } header: {
-                Text("UI/UX")
             }
         }
         .toolbar {
@@ -269,7 +81,163 @@ public struct MenuView: View {
         .navigationTitle("Scyther")
         .interactiveDismissDisabled()
     }
-    
+
+    /// Wraps a row in its pin/unpin swipe action.
+    ///
+    /// The action's label is derived from the row's current pin state rather than from which
+    /// section it is being rendered in, because pinned rows remain in their home section — a
+    /// pinned row therefore reads "Unpin" in both places.
+    @ViewBuilder
+    private func pinnableRow(for item: MenuItem) -> some View {
+        rowContent(for: item)
+            .swipeActions(edge: .trailing) {
+                Button {
+                    viewModel.togglePin(for: item)
+                } label: {
+                    Label(
+                        viewModel.isPinned(item) ? "Unpin" : "Pin",
+                        systemImage: viewModel.isPinned(item) ? "pin.slash" : "pin"
+                    )
+                }
+                .tint(.blue)
+            }
+    }
+
+    /// Builds a row that pushes a destination view.
+    ///
+    /// The label is derived entirely from the item, so every navigation row in the menu is
+    /// laid out identically and only the destination varies.
+    ///
+    /// - Parameters:
+    ///   - item: The row to render.
+    ///   - destination: The view to push when the row is tapped. Built lazily.
+    private func navigationRow<Destination: View>(
+        for item: MenuItem,
+        @ViewBuilder destination: @escaping () -> Destination
+    ) -> some View {
+        NavigationLink {
+            destination()
+        } label: {
+            row(withLabel: item.title, icon: item.icon)
+        }
+    }
+
+    /// The single definition of every menu row.
+    ///
+    /// ``MenuItem`` supplies each row's title and icon; this method supplies everything
+    /// dynamic — a value row's description, a navigation row's destination, a toggle row's
+    /// binding. Because there is one definition, the "Pinned" section and a row's home
+    /// section always render identically.
+    @ViewBuilder
+    private func rowContent(for item: MenuItem) -> some View {
+        switch item {
+        // MARK: Device
+        case .osVersion:
+            row(withLabel: item.title, description: UIDevice.current.systemVersion)
+        case .hardware:
+            row(withLabel: item.title, description: UIDevice.current.modelName)
+        case .releaseYear:
+            row(withLabel: item.title, description: UIDevice.current.generation.withoutDecimals)
+        case .uuid:
+            row(withLabel: item.title, description: UIDevice.current.identifierForVendor?.uuidString)
+
+        // MARK: Application
+        case .appIdPrefix:
+            row(withLabel: item.title, description: Bundle.main.seedId)
+        case .displayName:
+            row(withLabel: item.title, description: String(UIApplication.shared.appName))
+        case .bundleId:
+            row(withLabel: item.title, description: Bundle.main.bundleIdentifier)
+        case .processId:
+            row(withLabel: item.title, description: String(getpid()))
+        case .version:
+            row(withLabel: item.title, description: Bundle.main.versionNumber)
+        case .buildNumber:
+            row(withLabel: item.title, description: Bundle.main.buildNumber)
+        case .buildDate:
+            row(withLabel: item.title, description: Bundle.main.buildDate.formatted())
+        case .releaseType:
+            row(withLabel: item.title, description: AppEnvironment.configuration().rawValue)
+
+        // MARK: Development Tools
+        case .developerOption(let name):
+            if let option = Scyther.developerOptions.first(where: { $0.name == name }) {
+                developerOptionRow(option)
+            }
+
+        // MARK: Networking
+        case .ipAddress:
+            row(
+                withLabel: item.title,
+                description: viewModel.ipAddress,
+                icon: item.icon,
+                andLoadingState: viewModel.isLoadingIPAddress
+            )
+        case .networkLogs:
+            navigationRow(for: item) { NetworkLogsView() }
+        case .serverConfiguration:
+            navigationRow(for: item) { ServerConfigurationView() }
+        case .environmentVariables:
+            navigationRow(for: item) { EnvironmentVariablesView() }
+
+        // MARK: Data
+        case .featureFlags:
+            navigationRow(for: item) { FeatureFlagsView() }
+        case .userDefaults:
+            navigationRow(for: item) { UserDefaultsView() }
+        case .cookies:
+            navigationRow(for: item) { CookieBrowserView() }
+        case .fileBrowser:
+            navigationRow(for: item) { FileBrowserView() }
+        case .databaseBrowser:
+            navigationRow(for: item) { DatabaseBrowserView() }
+
+        // MARK: Security
+        case .keychainBrowser:
+            navigationRow(for: item) { KeychainBrowserView() }
+
+        // MARK: System Tools
+        case .locationSpoofer:
+            navigationRow(for: item) { LocationSpooferView() }
+        case .consoleLogs:
+            navigationRow(for: item) { ConsoleLoggerView() }
+        case .deepLinkTester:
+            navigationRow(for: item) { DeepLinkTesterView() }
+        case .crashLogs:
+            navigationRow(for: item) { CrashLogsView() }
+
+        // MARK: Notifications
+        case .notificationLogger:
+            navigationRow(for: item) { NotificationLoggerView() }
+        case .notificationTester:
+            navigationRow(for: item) { NotificationTesterView() }
+        case .apnsToken:
+            row(withLabel: item.title, icon: item.icon)
+        case .fcmToken:
+            row(withLabel: item.title, icon: item.icon)
+
+        // MARK: UI/UX
+        case .fonts:
+            navigationRow(for: item) { FontsView() }
+        case .interfaceComponents:
+            navigationRow(for: item) { InterfacePreviewsView() }
+        case .gridOverlay:
+            navigationRow(for: item) { GridOverlaySettingsView() }
+        case .fpsCounter:
+            navigationRow(for: item) { FPSCounterSettingsView() }
+        case .touchVisualiser:
+            navigationRow(for: item) { TouchVisualiserView() }
+        case .appearance:
+            navigationRow(for: item) { AppearanceOverridesView() }
+        case .slowAnimations:
+            toggleRow(item.title, icon: item.icon, isOn: $viewModel.slowAnimationsEnabled)
+        case .showViewFrames:
+            toggleRow(item.title, icon: item.icon, isOn: $viewModel.showViewFrames)
+        case .showViewSizes:
+            toggleRow(item.title, icon: item.icon, isOn: $viewModel.showViewSizes)
+        }
+    }
+
     func row(withLabel label: String, description: String? = nil, icon: String? = nil, andLoadingState loading: Bool = false) -> some View {
         HStack {
             if let icon {
@@ -289,17 +257,29 @@ public struct MenuView: View {
         }
     }
 
-    func toggleRow(_ label: String, icon: String, isOn: Binding<Bool>) -> some View {
+    /// Builds a toggle row bound to a Boolean setting.
+    ///
+    /// - Parameters:
+    ///   - label: The row's title.
+    ///   - icon: An optional SF Symbol shown alongside the label. Rows without an icon
+    ///     (there are currently none among toggle rows, but ``MenuItem/icon`` is optional)
+    ///     render as plain text.
+    ///   - isOn: The binding the toggle reads from and writes to.
+    func toggleRow(_ label: String, icon: String?, isOn: Binding<Bool>) -> some View {
         Toggle(isOn: isOn) {
-            Label {
+            if let icon {
+                Label {
+                    Text(label)
+                } icon: {
+                    Image(systemName: icon)
+                        .foregroundStyle(Color.accentColor)
+                }
+            } else {
                 Text(label)
-            } icon: {
-                Image(systemName: icon)
-                    .foregroundStyle(Color.accentColor)
             }
         }
     }
-    
+
     @ViewBuilder
     func developerOptionRow(_ option: DeveloperOption) -> some View {
         switch option.type {

--- a/Sources/Scyther/Features/Menu/MenuView.swift
+++ b/Sources/Scyther/Features/Menu/MenuView.swift
@@ -161,7 +161,13 @@ public struct MenuView: View {
 
         // MARK: Development Tools
         case .developerOption(let name):
-            if let option = Scyther.developerOptions.first(where: { $0.name == name }) {
+            // Resolved from `viewModel`'s snapshot of `Scyther.developerOptions`, the same
+            // snapshot `sections` was built from, rather than re-reading the global directly.
+            // A host app can mutate `Scyther.developerOptions` while this menu is on screen;
+            // reading the same snapshot here guarantees this lookup always succeeds for a name
+            // that `sections` listed, so a row is never left blank while `pinnableRow` has
+            // already attached a live swipe action to it.
+            if let option = viewModel.developerOption(named: name) {
                 developerOptionRow(option)
             }
 

--- a/Sources/Scyther/Features/Menu/MenuView.swift
+++ b/Sources/Scyther/Features/Menu/MenuView.swift
@@ -27,7 +27,7 @@ import SwiftUI
 /// Any row can be pinned via a trailing swipe action. Pinned rows appear in a "Pinned"
 /// section rendered directly beneath **Device**, and also remain in their home section, so
 /// the menu's structure never changes shape as rows are pinned. Pins are ordered oldest
-/// first and persist across launches in ``UserDefaults/scyther``.
+/// first and persist across launches in `UserDefaults.scyther`.
 public struct MenuView: View {
     @StateObject private var viewModel: MenuViewModel = MenuViewModel()
 

--- a/Sources/Scyther/Features/Menu/MenuViewModel.swift
+++ b/Sources/Scyther/Features/Menu/MenuViewModel.swift
@@ -76,6 +76,7 @@ import SwiftUI
 /// ### Lifecycle
 ///
 /// - ``onFirstAppear()``
+/// - ``onSubsequentAppear()``
 @MainActor
 class MenuViewModel: ViewModel {
     // MARK: - Menu Structure
@@ -171,6 +172,20 @@ class MenuViewModel: ViewModel {
         defaults.set(pinnedItemIDs, forKey: Self.pinnedItemsKey)
     }
 
+    /// Re-reads ``pinnedItemIDs`` from ``defaults``.
+    ///
+    /// `MenuView` sits at the root of a `UINavigationController` (see `Scyther.hideMenu()`
+    /// and `Scyther.showMenu()`), so its `@StateObject MenuViewModel` survives pushing into,
+    /// and popping back from, other screens — including the UserDefaults browser. Without
+    /// this, a "Reset all Scyther settings" or a hand-edit of `Scyther.Menu.PinnedItems`
+    /// performed while the menu is off screen would go unnoticed: ``pinnedItemIDs`` would
+    /// keep reflecting whatever was in memory when the view model was created, and the next
+    /// ``togglePin(for:)`` would write that stale array straight back to disk, undoing the
+    /// reset.
+    private func reloadPinnedItemIDs() {
+        pinnedItemIDs = defaults.stringArray(forKey: Self.pinnedItemsKey) ?? []
+    }
+
     // MARK: - Network Properties
 
     /// The device's current IP address.
@@ -240,6 +255,22 @@ class MenuViewModel: ViewModel {
         await super.onFirstAppear()
 
         await loadIPAddress()
+    }
+
+    /// Called every time the menu reappears after the first time.
+    ///
+    /// Reloads ``pinnedItemIDs`` from ``defaults`` — see ``reloadPinnedItemIDs()`` — so pins
+    /// changed while the menu was off screen (a reset of the Scyther store, or a hand-edit of
+    /// `Scyther.Menu.PinnedItems` in the UserDefaults browser) are reflected immediately on
+    /// return. Deliberately does not re-run ``loadIPAddress()``, which stays confined to
+    /// ``onFirstAppear()``.
+    ///
+    /// - Important: Always call `await super.onSubsequentAppear()` to ensure proper lifecycle
+    ///   tracking.
+    override func onSubsequentAppear() async {
+        await super.onSubsequentAppear()
+
+        reloadPinnedItemIDs()
     }
 
     // MARK: - Private Methods

--- a/Sources/Scyther/Features/Menu/MenuViewModel.swift
+++ b/Sources/Scyther/Features/Menu/MenuViewModel.swift
@@ -15,6 +15,8 @@ import SwiftUI
 ///
 /// ## Features
 ///
+/// - **Menu Structure**: Supplies the ordered section layout and the set of pinned rows
+/// - **Pinning**: Persists pinned rows to Scyther's preferences suite, oldest pin first
 /// - **Network Information**: Asynchronously fetches and displays the device's current IP address
 /// - **Animation Controls**: Manages slow animations mode for UI debugging
 /// - **View Debugging**: Controls visibility of view frames and sizes
@@ -51,6 +53,14 @@ import SwiftUI
 ///
 /// ## Topics
 ///
+/// ### Menu Structure
+///
+/// - ``sections``
+/// - ``pinnedItems``
+/// - ``pinnedItemIDs``
+/// - ``isPinned(_:)``
+/// - ``togglePin(for:)``
+///
 /// ### Network Information
 ///
 /// - ``ipAddress``
@@ -67,6 +77,69 @@ import SwiftUI
 /// - ``onFirstAppear()``
 @MainActor
 class MenuViewModel: ViewModel {
+    // MARK: - Menu Structure
+
+    /// The key backing ``pinnedItemIDs`` in Scyther's preferences store.
+    static let pinnedItemsKey = "Scyther.Menu.PinnedItems"
+
+    /// The store pinned item identifiers are read from and written to.
+    private let defaults: UserDefaults
+
+    /// The identifiers of pinned rows, in the order they were pinned.
+    ///
+    /// An array rather than a `Set` so that oldest-first pin order survives a relaunch.
+    @Published private(set) var pinnedItemIDs: [String]
+
+    /// The full menu layout, including any host-supplied developer options.
+    var sections: [MenuSection] {
+        MenuSection.allSections(developerOptions: Scyther.developerOptions)
+    }
+
+    /// The pinned rows, oldest pin first.
+    ///
+    /// Stored identifiers that no longer resolve to a row currently present in ``sections``
+    /// are dropped. This covers both a feature removed in a later version of Scyther and a
+    /// developer option the host app no longer registers.
+    var pinnedItems: [MenuItem] {
+        let available = Set(sections.flatMap(\.items))
+        return pinnedItemIDs
+            .compactMap(MenuItem.init(id:))
+            .filter { available.contains($0) }
+    }
+
+    /// Creates a menu view model.
+    ///
+    /// - Parameter defaults: The store backing pin state. Defaults to Scyther's private
+    ///   preferences suite; tests inject a throwaway suite.
+    init(defaults: UserDefaults = .scyther) {
+        self.defaults = defaults
+        self.pinnedItemIDs = defaults.stringArray(forKey: Self.pinnedItemsKey) ?? []
+        super.init()
+    }
+
+    /// Whether the given row is pinned.
+    ///
+    /// - Parameter item: The row to check.
+    /// - Returns: `true` when the row appears in the "Pinned" section.
+    func isPinned(_ item: MenuItem) -> Bool {
+        pinnedItemIDs.contains(item.id)
+    }
+
+    /// Pins or unpins a row, persisting the change immediately.
+    ///
+    /// Pinning appends the row to the end of the pinned list, so the "Pinned" section reads
+    /// oldest pin first. Unpinning leaves the order of the remaining rows untouched.
+    ///
+    /// - Parameter item: The row to pin or unpin.
+    func togglePin(for item: MenuItem) {
+        if let index = pinnedItemIDs.firstIndex(of: item.id) {
+            pinnedItemIDs.remove(at: index)
+        } else {
+            pinnedItemIDs.append(item.id)
+        }
+        defaults.set(pinnedItemIDs, forKey: Self.pinnedItemsKey)
+    }
+
     // MARK: - Network Properties
 
     /// The device's current IP address.

--- a/Sources/Scyther/Features/Menu/MenuViewModel.swift
+++ b/Sources/Scyther/Features/Menu/MenuViewModel.swift
@@ -60,6 +60,7 @@ import SwiftUI
 /// - ``pinnedItemIDs``
 /// - ``isPinned(_:)``
 /// - ``togglePin(for:)``
+/// - ``developerOption(named:)``
 ///
 /// ### Network Information
 ///
@@ -90,9 +91,36 @@ class MenuViewModel: ViewModel {
     /// An array rather than a `Set` so that oldest-first pin order survives a relaunch.
     @Published private(set) var pinnedItemIDs: [String]
 
+    /// A snapshot of ``Scyther/developerOptions``, taken once when the view model is created.
+    ///
+    /// `Scyther.developerOptions` is a `nonisolated(unsafe)` global a host app can mutate at
+    /// any time, including while the menu is on screen. ``sections``, ``pinnedItems``, and
+    /// ``developerOption(named:)`` all derive from this single stored copy rather than
+    /// re-reading the global independently, so they can never disagree about which developer
+    /// options exist for the lifetime of this view model. Without that, a section could list a
+    /// `.developerOption(name:)` row that a later, independent lookup could no longer resolve —
+    /// `MenuView` would render nothing for that row while its swipe-to-pin action, attached
+    /// alongside the row content, remains live.
+    private let developerOptions: [DeveloperOption]
+
     /// The full menu layout, including any host-supplied developer options.
     var sections: [MenuSection] {
-        MenuSection.allSections(developerOptions: Scyther.developerOptions)
+        MenuSection.allSections(developerOptions: developerOptions)
+    }
+
+    /// Resolves a host-supplied developer option by name.
+    ///
+    /// Looks up the option in ``developerOptions``, the snapshot also used to build
+    /// ``sections`` — the same name that appears in a `.developerOption(name:)` row is
+    /// therefore always resolvable here, regardless of what a host app has since done to
+    /// `Scyther.developerOptions`.
+    ///
+    /// - Parameter name: A developer option's ``DeveloperOption/name``, as carried by a
+    ///   ``MenuItem/developerOption(name:)`` row.
+    /// - Returns: The matching option, or `nil` if none was registered under that name when
+    ///   this view model was created.
+    func developerOption(named name: String) -> DeveloperOption? {
+        developerOptions.first { $0.name == name }
     }
 
     /// The pinned rows, oldest pin first.
@@ -109,10 +137,13 @@ class MenuViewModel: ViewModel {
 
     /// Creates a menu view model.
     ///
+    /// Snapshots ``Scyther/developerOptions`` at this point — see ``developerOptions``.
+    ///
     /// - Parameter defaults: The store backing pin state. Defaults to Scyther's private
     ///   preferences suite; tests inject a throwaway suite.
     init(defaults: UserDefaults = .scyther) {
         self.defaults = defaults
+        self.developerOptions = Scyther.developerOptions
         self.pinnedItemIDs = defaults.stringArray(forKey: Self.pinnedItemsKey) ?? []
         super.init()
     }

--- a/Sources/Scyther/Features/NetworkLogger/HTTPRequest.swift
+++ b/Sources/Scyther/Features/NetworkLogger/HTTPRequest.swift
@@ -319,14 +319,21 @@ final class HTTPRequest: @unchecked Sendable, Identifiable {
     }
 
     /// Saves the provided string data to the specified file.
+    ///
+    /// The containing directory for `toFile` is created (including any intermediate
+    /// directories) if it does not already exist. If the write fails for any reason,
+    /// the underlying error is logged via `logMessage` rather than thrown or ignored.
     /// - Parameters:
     ///   - dataString: The string data to save.
     ///   - toFile: The file path where the data should be saved.
     func saveData(_ dataString: NSString, toFile: String) {
         do {
+            let url = URL(fileURLWithPath: toFile)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
             try dataString.write(toFile: toFile, atomically: false, encoding: String.Encoding.utf8.rawValue)
         } catch {
-            logMessage("catch !!!")
+            logMessage("Scyther: failed to write body to \(toFile): \(error)")
         }
     }
 

--- a/Sources/Scyther/Features/TouchVisualiser/TouchVisualiserConfiguration.swift
+++ b/Sources/Scyther/Features/TouchVisualiser/TouchVisualiserConfiguration.swift
@@ -11,7 +11,7 @@ import UIKit
 ///
 /// This structure controls the appearance and behavior of touch indicators displayed
 /// on screen when the touch visualiser is enabled. Settings are automatically persisted
-/// to ``UserDefaults/scyther``, Scyther's private preferences suite.
+/// to `UserDefaults.scyther`, Scyther's private preferences suite.
 ///
 /// ## Usage
 /// ```swift
@@ -61,7 +61,7 @@ public struct TouchVisualiserConfiguration {
     ///
     /// When enabled, a label appears above each touch showing how long it has been active.
     /// Useful for debugging time-based interactions like long presses. Default is `false`.
-    /// This setting is persisted to ``UserDefaults/scyther``.
+    /// This setting is persisted to `UserDefaults.scyther`.
     public var showsTouchDuration: Bool {
         get {
             UserDefaults.scyther.bool(forKey: Self.showsTouchDurationKey)
@@ -75,7 +75,7 @@ public struct TouchVisualiserConfiguration {
     ///
     /// When enabled, touch indicators scale to match the actual touch area. This only
     /// works on physical devices, as simulators don't provide touch radius information.
-    /// Default is `false`. This setting is persisted to ``UserDefaults/scyther``.
+    /// Default is `false`. This setting is persisted to `UserDefaults.scyther`.
     public var showsTouchRadius: Bool {
         get {
             UserDefaults.scyther.bool(forKey: Self.showsTouchRadiusKey)
@@ -89,7 +89,7 @@ public struct TouchVisualiserConfiguration {
     ///
     /// When enabled, detailed touch information is logged to the console. This has a
     /// performance impact and is automatically disabled in App Store builds regardless
-    /// of this setting. Default is `false`. This setting is persisted to ``UserDefaults/scyther``.
+    /// of this setting. Default is `false`. This setting is persisted to `UserDefaults.scyther`.
     public var loggingEnabled: Bool {
         get {
             return AppEnvironment.isAppStore ? false : UserDefaults.scyther.bool(forKey: Self.loggingEnabledKey)

--- a/Sources/Scyther/Features/TouchVisualiser/TouchVisualiserConfiguration.swift
+++ b/Sources/Scyther/Features/TouchVisualiser/TouchVisualiserConfiguration.swift
@@ -11,7 +11,7 @@ import UIKit
 ///
 /// This structure controls the appearance and behavior of touch indicators displayed
 /// on screen when the touch visualiser is enabled. Settings are automatically persisted
-/// to UserDefaults.
+/// to ``UserDefaults/scyther``, Scyther's private preferences suite.
 ///
 /// ## Usage
 /// ```swift
@@ -61,13 +61,13 @@ public struct TouchVisualiserConfiguration {
     ///
     /// When enabled, a label appears above each touch showing how long it has been active.
     /// Useful for debugging time-based interactions like long presses. Default is `false`.
-    /// This setting is persisted to UserDefaults.
+    /// This setting is persisted to ``UserDefaults/scyther``.
     public var showsTouchDuration: Bool {
         get {
-            UserDefaults.standard.bool(forKey: Self.showsTouchDurationKey)
+            UserDefaults.scyther.bool(forKey: Self.showsTouchDurationKey)
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: Self.showsTouchDurationKey)
+            UserDefaults.scyther.set(newValue, forKey: Self.showsTouchDurationKey)
         }
     }
 
@@ -75,13 +75,13 @@ public struct TouchVisualiserConfiguration {
     ///
     /// When enabled, touch indicators scale to match the actual touch area. This only
     /// works on physical devices, as simulators don't provide touch radius information.
-    /// Default is `false`. This setting is persisted to UserDefaults.
+    /// Default is `false`. This setting is persisted to ``UserDefaults/scyther``.
     public var showsTouchRadius: Bool {
         get {
-            UserDefaults.standard.bool(forKey: Self.showsTouchRadiusKey)
+            UserDefaults.scyther.bool(forKey: Self.showsTouchRadiusKey)
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: Self.showsTouchRadiusKey)
+            UserDefaults.scyther.set(newValue, forKey: Self.showsTouchRadiusKey)
         }
     }
 
@@ -89,13 +89,13 @@ public struct TouchVisualiserConfiguration {
     ///
     /// When enabled, detailed touch information is logged to the console. This has a
     /// performance impact and is automatically disabled in App Store builds regardless
-    /// of this setting. Default is `false`. This setting is persisted to UserDefaults.
+    /// of this setting. Default is `false`. This setting is persisted to ``UserDefaults/scyther``.
     public var loggingEnabled: Bool {
         get {
-            return AppEnvironment.isAppStore ? false : UserDefaults.standard.bool(forKey: Self.loggingEnabledKey)
+            return AppEnvironment.isAppStore ? false : UserDefaults.scyther.bool(forKey: Self.loggingEnabledKey)
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: Self.loggingEnabledKey)
+            UserDefaults.scyther.set(newValue, forKey: Self.loggingEnabledKey)
         }
     }
 

--- a/Sources/Scyther/Features/UserDefaults/DefaultsStore.swift
+++ b/Sources/Scyther/Features/UserDefaults/DefaultsStore.swift
@@ -25,7 +25,7 @@ enum DefaultsStore: String, CaseIterable, Identifiable, Sendable {
     /// The host application's own defaults — `UserDefaults.standard`.
     case app
 
-    /// Scyther's private preferences suite — ``UserDefaults/scyther``.
+    /// Scyther's private preferences suite — `UserDefaults.scyther`.
     case scyther
 
     /// Stable identifier, used for `Picker` selection and `ForEach`.

--- a/Sources/Scyther/Features/UserDefaults/DefaultsStore.swift
+++ b/Sources/Scyther/Features/UserDefaults/DefaultsStore.swift
@@ -1,0 +1,49 @@
+//
+//  DefaultsStore.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+import Foundation
+
+/// Identifies which `UserDefaults` store the UserDefaults browser is inspecting.
+///
+/// Scyther keeps its own settings in a private suite rather than the standard store, so the
+/// browser needs to be able to show either one.
+///
+/// ## Topics
+///
+/// ### Cases
+/// - ``app``
+/// - ``scyther``
+///
+/// ### Properties
+/// - ``title``
+/// - ``defaults``
+enum DefaultsStore: String, CaseIterable, Identifiable, Sendable {
+    /// The host application's own defaults — `UserDefaults.standard`.
+    case app
+
+    /// Scyther's private preferences suite — ``UserDefaults/scyther``.
+    case scyther
+
+    /// Stable identifier, used for `Picker` selection and `ForEach`.
+    var id: String { rawValue }
+
+    /// The human-readable name shown in the store picker.
+    var title: String {
+        switch self {
+        case .app: return "App"
+        case .scyther: return "Scyther"
+        }
+    }
+
+    /// The underlying store this case refers to.
+    var defaults: UserDefaults {
+        switch self {
+        case .app: return .standard
+        case .scyther: return .scyther
+        }
+    }
+}

--- a/Sources/Scyther/Features/UserDefaults/UserDefaultsView.swift
+++ b/Sources/Scyther/Features/UserDefaults/UserDefaultsView.swift
@@ -125,7 +125,7 @@ struct UserDefaultsView: View {
         switch item.valueType {
         case .array(let data):
             NavigationLink {
-                UserDefaultsArrayView(key: item.key, items: data, rootKey: item.key, keyPath: []) {
+                UserDefaultsArrayView(key: item.key, items: data, store: viewModel.store, rootKey: item.key, keyPath: []) {
                     Task { await viewModel.loadDefaults() }
                 }
             } label: {
@@ -134,7 +134,7 @@ struct UserDefaultsView: View {
 
         case .dictionary(let data):
             NavigationLink {
-                UserDefaultsDictionaryView(key: item.key, dictionary: data, rootKey: item.key, keyPath: []) {
+                UserDefaultsDictionaryView(key: item.key, dictionary: data, store: viewModel.store, rootKey: item.key, keyPath: []) {
                     Task { await viewModel.loadDefaults() }
                 }
             } label: {
@@ -200,13 +200,22 @@ struct UserDefaultsView: View {
 struct UserDefaultsArrayView: View {
     let key: String
     let items: [Any]
+
+    /// The store `rootKey` lives in.
+    ///
+    /// Read and write nested edits against this store rather than `UserDefaults.standard` —
+    /// the array being browsed may belong to Scyther's private suite. Threaded through every
+    /// recursive construction of ``UserDefaultsArrayView`` and ``UserDefaultsDictionaryView``
+    /// so a deeply nested edit always lands back in the store it was read from.
+    let store: DefaultsStore
     let rootKey: String
     let keyPath: [Any] // Can be String (dict key) or Int (array index)
     let onUpdate: () -> Void
 
-    init(key: String, items: [Any], rootKey: String? = nil, keyPath: [Any] = [], onUpdate: @escaping () -> Void = {}) {
+    init(key: String, items: [Any], store: DefaultsStore, rootKey: String? = nil, keyPath: [Any] = [], onUpdate: @escaping () -> Void = {}) {
         self.key = key
         self.items = items
+        self.store = store
         self.rootKey = rootKey ?? key
         self.keyPath = keyPath
         self.onUpdate = onUpdate
@@ -239,14 +248,14 @@ struct UserDefaultsArrayView: View {
         switch valueType {
         case .array(let nestedArray):
             NavigationLink {
-                UserDefaultsArrayView(key: "[\(index)]", items: nestedArray, rootKey: rootKey, keyPath: childPath, onUpdate: onUpdate)
+                UserDefaultsArrayView(key: "[\(index)]", items: nestedArray, store: store, rootKey: rootKey, keyPath: childPath, onUpdate: onUpdate)
             } label: {
                 LabeledContent("[\(index)]", value: displayValue)
             }
 
         case .dictionary(let nestedDict):
             NavigationLink {
-                UserDefaultsDictionaryView(key: "[\(index)]", dictionary: nestedDict, rootKey: rootKey, keyPath: childPath, onUpdate: onUpdate)
+                UserDefaultsDictionaryView(key: "[\(index)]", dictionary: nestedDict, store: store, rootKey: rootKey, keyPath: childPath, onUpdate: onUpdate)
             } label: {
                 LabeledContent("[\(index)]", value: displayValue)
             }
@@ -290,9 +299,9 @@ struct UserDefaultsArrayView: View {
     }
 
     private func updateNestedValue(_ newValue: Any, at path: [Any]) {
-        guard var rootValue = UserDefaults.standard.object(forKey: rootKey) else { return }
+        guard var rootValue = store.defaults.object(forKey: rootKey) else { return }
         rootValue = setNestedValue(in: rootValue, at: path, to: newValue)
-        UserDefaults.standard.set(rootValue, forKey: rootKey)
+        store.defaults.set(rootValue, forKey: rootKey)
         onUpdate()
     }
 
@@ -327,13 +336,23 @@ struct UserDefaultsArrayView: View {
 struct UserDefaultsDictionaryView: View {
     let key: String
     let dictionary: [String: Any]
+
+    /// The store `rootKey` lives in.
+    ///
+    /// Read and write nested edits against this store rather than `UserDefaults.standard` —
+    /// the dictionary being browsed may belong to Scyther's private suite. Threaded through
+    /// every recursive construction of ``UserDefaultsArrayView`` and
+    /// ``UserDefaultsDictionaryView`` so a deeply nested edit always lands back in the store
+    /// it was read from.
+    let store: DefaultsStore
     let rootKey: String
     let keyPath: [Any]
     let onUpdate: () -> Void
 
-    init(key: String, dictionary: [String: Any], rootKey: String? = nil, keyPath: [Any] = [], onUpdate: @escaping () -> Void = {}) {
+    init(key: String, dictionary: [String: Any], store: DefaultsStore, rootKey: String? = nil, keyPath: [Any] = [], onUpdate: @escaping () -> Void = {}) {
         self.key = key
         self.dictionary = dictionary
+        self.store = store
         self.rootKey = rootKey ?? key
         self.keyPath = keyPath
         self.onUpdate = onUpdate
@@ -372,14 +391,14 @@ struct UserDefaultsDictionaryView: View {
         switch valueType {
         case .array(let nestedArray):
             NavigationLink {
-                UserDefaultsArrayView(key: rowKey, items: nestedArray, rootKey: rootKey, keyPath: childPath, onUpdate: onUpdate)
+                UserDefaultsArrayView(key: rowKey, items: nestedArray, store: store, rootKey: rootKey, keyPath: childPath, onUpdate: onUpdate)
             } label: {
                 LabeledContent(rowKey, value: displayValue)
             }
 
         case .dictionary(let nestedDict):
             NavigationLink {
-                UserDefaultsDictionaryView(key: rowKey, dictionary: nestedDict, rootKey: rootKey, keyPath: childPath, onUpdate: onUpdate)
+                UserDefaultsDictionaryView(key: rowKey, dictionary: nestedDict, store: store, rootKey: rootKey, keyPath: childPath, onUpdate: onUpdate)
             } label: {
                 LabeledContent(rowKey, value: displayValue)
             }
@@ -423,9 +442,9 @@ struct UserDefaultsDictionaryView: View {
     }
 
     private func updateNestedValue(_ newValue: Any, at path: [Any]) {
-        guard var rootValue = UserDefaults.standard.object(forKey: rootKey) else { return }
+        guard var rootValue = store.defaults.object(forKey: rootKey) else { return }
         rootValue = setNestedValue(in: rootValue, at: path, to: newValue)
-        UserDefaults.standard.set(rootValue, forKey: rootKey)
+        store.defaults.set(rootValue, forKey: rootKey)
         onUpdate()
     }
 

--- a/Sources/Scyther/Features/UserDefaults/UserDefaultsView.swift
+++ b/Sources/Scyther/Features/UserDefaults/UserDefaultsView.swift
@@ -15,7 +15,8 @@ import Combine
 /// - Viewing and editing strings, numbers, booleans, dates, and data
 /// - Navigating nested arrays and dictionaries
 /// - Searching across keys and values
-/// - Deleting individual entries or resetting all non-Scyther values
+/// - Switching between the host app's defaults and Scyther's private suite
+/// - Deleting individual entries or resetting the selected store
 /// - Inline boolean toggle editing
 /// - Dedicated editors for strings and numbers
 ///
@@ -40,6 +41,20 @@ struct UserDefaultsView: View {
 
     var body: some View {
         List {
+            Section {
+                Picker("Store", selection: $viewModel.store) {
+                    ForEach(DefaultsStore.allCases) { store in
+                        Text(store.title).tag(store)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+            } footer: {
+                Text(viewModel.store == .app
+                     ? "Values your app stored in UserDefaults.standard."
+                     : "Values Scyther stored in its private com.scyther.settings suite.")
+            }
+
             Section("Key/Values") {
                 if viewModel.keyValues.isEmpty {
                     Text("No user defaults")
@@ -67,11 +82,16 @@ struct UserDefaultsView: View {
 
             if debouncedSearchText.isEmpty {
                 Section {
-                    Button("Reset UserDefaults.standard", role: .destructive) {
+                    Button(
+                        viewModel.store == .app ? "Reset UserDefaults.standard" : "Reset all Scyther settings",
+                        role: .destructive
+                    ) {
                         showingResetConfirmation = true
                     }
                 } footer: {
-                    Text("This will delete all values stored inside `UserDefaults.standard`, created by your app. This will not clear any values created internally by Scyther that are used for debug/feature purposes.")
+                    Text(viewModel.store == .app
+                         ? "This will delete all values stored inside `UserDefaults.standard`, created by your app. Scyther's own settings live in a separate store and are not affected."
+                         : "This will delete every setting Scyther has stored, including pinned menu items and feature flag overrides.")
                 }
             }
         }
@@ -85,17 +105,15 @@ struct UserDefaultsView: View {
                 .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
                 .sink { debouncedSearchText = $0 }
         }
-        .confirmationDialog(
-            "Reset UserDefaults?",
-            isPresented: $showingResetConfirmation,
-            titleVisibility: .visible
-        ) {
+        .alert("Reset UserDefaults?", isPresented: $showingResetConfirmation) {
             Button("Reset All", role: .destructive) {
                 viewModel.resetAllDefaults()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This action cannot be undone.")
+            Text(viewModel.store == .app
+                 ? "This will permanently delete your app's stored values. This action cannot be undone."
+                 : "This will permanently delete every Scyther setting, including pinned menu items and feature flag overrides. This action cannot be undone.")
         }
         .onFirstAppear {
             await viewModel.onFirstAppear()

--- a/Sources/Scyther/Features/UserDefaults/UserDefaultsViewModel.swift
+++ b/Sources/Scyther/Features/UserDefaults/UserDefaultsViewModel.swift
@@ -45,6 +45,9 @@ import SwiftUI
 /// ### Initialization
 /// - ``UserDefaultsViewModel``
 ///
+/// ### Store Selection
+/// - ``store``
+///
 /// ### Data Management
 /// - ``loadDefaults()``
 /// - ``keyValues``
@@ -60,8 +63,26 @@ import SwiftUI
 /// - ``displayString(for:)``
 @MainActor
 class UserDefaultsViewModel: ViewModel {
+    /// The store currently being browsed.
+    ///
+    /// Changing this reloads ``keyValues`` from the newly selected store.
+    @Published var store: DefaultsStore {
+        didSet {
+            guard oldValue != store else { return }
+            Task { await loadDefaults() }
+        }
+    }
+
     /// Published array of UserDefaults entries, sorted alphabetically by key.
     @Published var keyValues: [UserDefaultItem] = []
+
+    /// Creates a view model browsing the given store.
+    ///
+    /// - Parameter store: The store to browse. Defaults to the host app's own defaults.
+    init(store: DefaultsStore = .app) {
+        self.store = store
+        super.init()
+    }
 
     /// Called when the view first appears.
     ///
@@ -71,22 +92,27 @@ class UserDefaultsViewModel: ViewModel {
         await loadDefaults()
     }
 
-    /// Loads all UserDefaults entries from `UserDefaults.standard`.
+    /// Loads all entries from the currently selected store.
     ///
-    /// This method:
-    /// - Retrieves all key-value pairs from the dictionary representation
-    /// - Sorts entries alphabetically by key (case-insensitive)
-    /// - Detects value types and creates display-friendly representations
-    /// - Updates the ``keyValues`` published property
+    /// The application store is read via `dictionaryRepresentation()`, matching what the app
+    /// itself sees. Scyther's suite is read via `persistentDomain(forName:)` so only keys
+    /// actually written to the suite appear, without inherited global-domain noise.
     func loadDefaults() async {
-        let defaults = UserDefaults.standard.dictionaryRepresentation()
-            .sorted { $0.key.lowercased() < $1.key.lowercased() }
-
-        keyValues = defaults.map { key, value in
-            let valueType = Self.detectValueType(value)
-            let displayValue = Self.displayString(for: value)
-            return UserDefaultItem(key: key, rawValue: value, valueType: valueType, displayValue: displayValue)
+        let entries: [String: Any]
+        switch store {
+        case .app:
+            entries = UserDefaults.standard.dictionaryRepresentation()
+        case .scyther:
+            entries = UserDefaults.standard.persistentDomain(forName: ScytherDefaults.suiteName) ?? [:]
         }
+
+        keyValues = entries
+            .sorted { $0.key.lowercased() < $1.key.lowercased() }
+            .map { key, value in
+                let valueType = Self.detectValueType(value)
+                let displayValue = Self.displayString(for: value)
+                return UserDefaultItem(key: key, rawValue: value, valueType: valueType, displayValue: displayValue)
+            }
     }
 
     /// Detects the type of a UserDefaults value.
@@ -171,13 +197,16 @@ class UserDefaultsViewModel: ViewModel {
     /// - Returns: A two-way binding to the boolean value
     func boolBinding(for key: String, currentValue: Bool) -> Binding<Bool> {
         Binding(
-            get: {
-                UserDefaults.standard.bool(forKey: key)
+            get: { [weak self] in
+                // Read through `self` rather than capturing `store` by value, so the binding
+                // always reflects the currently selected store.
+                self?.store.defaults.bool(forKey: key) ?? currentValue
             },
             set: { [weak self] newValue in
-                UserDefaults.standard.set(newValue, forKey: key)
+                guard let self else { return }
+                self.store.defaults.set(newValue, forKey: key)
                 Task { @MainActor in
-                    await self?.loadDefaults()
+                    await self.loadDefaults()
                 }
             }
         )
@@ -191,7 +220,7 @@ class UserDefaultsViewModel: ViewModel {
     ///   - value: The new value to store
     ///   - key: The UserDefaults key
     func updateValue(_ value: Any, forKey key: String) {
-        UserDefaults.standard.set(value, forKey: key)
+        store.defaults.set(value, forKey: key)
         Task {
             await loadDefaults()
         }
@@ -203,26 +232,29 @@ class UserDefaultsViewModel: ViewModel {
     ///
     /// - Parameter key: The UserDefaults key to delete
     func deleteKey(_ key: String) {
-        UserDefaults.standard.removeObject(forKey: key)
+        store.defaults.removeObject(forKey: key)
         keyValues.removeAll { $0.key == key }
     }
 
-    /// Resets all UserDefaults values except Scyther-specific keys.
+    /// Clears the currently selected store.
     ///
-    /// This method:
-    /// - Iterates through all UserDefaults keys
-    /// - Filters out any keys starting with "scyther" (case-insensitive)
-    /// - Removes all non-Scyther keys
-    /// - Synchronizes UserDefaults to disk
-    /// - Reloads the defaults list
+    /// For ``DefaultsStore/app`` this removes every key the host app created, keeping the
+    /// `scyther` prefix filter as a safety net for any value an older Scyther left behind
+    /// before migration. For ``DefaultsStore/scyther`` the entire suite is removed, which
+    /// resets every Scyther setting including pinned items and feature flag overrides.
     ///
-    /// > Warning: This action cannot be undone. All app-specific UserDefaults
-    /// > values will be permanently deleted.
+    /// > Warning: This action cannot be undone.
     func resetAllDefaults() {
-        UserDefaults.standard.dictionaryRepresentation().keys
-            .filter { !$0.lowercased().hasPrefix("scyther") }
-            .forEach(UserDefaults.standard.removeObject(forKey:))
-        UserDefaults.standard.synchronize()
+        switch store {
+        case .app:
+            UserDefaults.standard.dictionaryRepresentation().keys
+                .filter { !$0.lowercased().hasPrefix(ScytherDefaults.keyPrefix) }
+                .forEach(UserDefaults.standard.removeObject(forKey:))
+            UserDefaults.standard.synchronize()
+
+        case .scyther:
+            UserDefaults.standard.removePersistentDomain(forName: ScytherDefaults.suiteName)
+        }
 
         Task {
             await loadDefaults()

--- a/Tests/ScytherTests/Core/ScytherDefaultsTests.swift
+++ b/Tests/ScytherTests/Core/ScytherDefaultsTests.swift
@@ -1,0 +1,140 @@
+//
+//  ScytherDefaultsTests.swift
+//  ScytherTests
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+#if !os(macOS)
+@testable import Scyther
+import XCTest
+
+final class ScytherDefaultsTests: XCTestCase {
+    private let sourceSuite = "com.scyther.tests.source"
+    private let destinationSuite = "com.scyther.tests.destination"
+    private var source: UserDefaults!
+    private var destination: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        wipeSuites()
+        source = UserDefaults(suiteName: sourceSuite)
+        destination = UserDefaults(suiteName: destinationSuite)
+    }
+
+    override func tearDown() {
+        source = nil
+        destination = nil
+        wipeSuites()
+        super.tearDown()
+    }
+
+    private func wipeSuites() {
+        UserDefaults.standard.removePersistentDomain(forName: sourceSuite)
+        UserDefaults.standard.removePersistentDomain(forName: destinationSuite)
+    }
+
+    // MARK: - Constants
+
+    func testSuiteNameIsStable() {
+        XCTAssertEqual(ScytherDefaults.suiteName, "com.scyther.settings")
+    }
+
+    func testMigrationKeyIsStable() {
+        XCTAssertEqual(ScytherDefaults.migrationKey, "Scyther.Defaults.DidMigrateFromStandard")
+    }
+
+    // MARK: - migrate(from:to:)
+
+    func testMigrationCopiesPrefixedKeysToDestination() {
+        source.set(true, forKey: "Scyther_grid_overlay_enabled")
+        source.set("preset-a", forKey: "Scyther_Location_Spoofing_Route_Id")
+
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        XCTAssertTrue(destination.bool(forKey: "Scyther_grid_overlay_enabled"))
+        XCTAssertEqual(destination.string(forKey: "Scyther_Location_Spoofing_Route_Id"), "preset-a")
+    }
+
+    func testMigrationRemovesPrefixedKeysFromSource() {
+        source.set(true, forKey: "Scyther_grid_overlay_enabled")
+
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        XCTAssertNil(source.object(forKey: "Scyther_grid_overlay_enabled"))
+    }
+
+    func testMigrationIgnoresKeysWithoutThePrefix() {
+        source.set("hunter2", forKey: "user_session_token")
+
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        XCTAssertEqual(source.string(forKey: "user_session_token"), "hunter2")
+        XCTAssertNil(destination.object(forKey: "user_session_token"))
+    }
+
+    func testMigrationMatchesPrefixCaseInsensitively() {
+        source.set(1, forKey: "scyther.servers.currentId")
+        source.set(2, forKey: "SCYTHER_shouting_key")
+
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        XCTAssertEqual(destination.integer(forKey: "scyther.servers.currentId"), 1)
+        XCTAssertEqual(destination.integer(forKey: "SCYTHER_shouting_key"), 2)
+    }
+
+    func testMigrationNeverOverwritesAnExistingDestinationValue() {
+        source.set("stale", forKey: "Scyther_appearance_color_scheme")
+        destination.set("fresh", forKey: "Scyther_appearance_color_scheme")
+
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        XCTAssertEqual(destination.string(forKey: "Scyther_appearance_color_scheme"), "fresh")
+        XCTAssertNil(source.object(forKey: "Scyther_appearance_color_scheme"))
+    }
+
+    func testMigrationIsIdempotent() {
+        source.set(true, forKey: "Scyther_fps_counter_enabled")
+
+        ScytherDefaults.migrate(from: source, to: destination)
+        destination.set(false, forKey: "Scyther_fps_counter_enabled")
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        XCTAssertFalse(destination.bool(forKey: "Scyther_fps_counter_enabled"))
+    }
+
+    // MARK: - migrateIfNeeded(from:to:)
+
+    func testMigrateIfNeededSetsTheMigrationFlag() {
+        ScytherDefaults.migrateIfNeeded(from: source, to: destination)
+
+        XCTAssertTrue(destination.bool(forKey: ScytherDefaults.migrationKey))
+    }
+
+    func testMigrateIfNeededRunsOnlyOnce() {
+        ScytherDefaults.migrateIfNeeded(from: source, to: destination)
+
+        // Seed the source *after* the first run. A second call must not pick it up.
+        source.set(true, forKey: "Scyther_grid_overlay_enabled")
+        ScytherDefaults.migrateIfNeeded(from: source, to: destination)
+
+        XCTAssertNil(destination.object(forKey: "Scyther_grid_overlay_enabled"))
+        XCTAssertTrue(source.bool(forKey: "Scyther_grid_overlay_enabled"))
+    }
+
+    // MARK: - Store
+
+    func testScytherStoreIsNotTheStandardStore() {
+        XCTAssertFalse(UserDefaults.scyther === UserDefaults.standard)
+    }
+
+    func testScytherStoreWritesAreInvisibleToStandard() {
+        let key = "Scyther_isolation_probe"
+        UserDefaults.scyther.set(true, forKey: key)
+        defer { UserDefaults.scyther.removeObject(forKey: key) }
+
+        XCTAssertTrue(UserDefaults.scyther.bool(forKey: key))
+        XCTAssertNil(UserDefaults.standard.persistentDomain(forName: Bundle.main.bundleIdentifier ?? "")?[key])
+    }
+}
+#endif

--- a/Tests/ScytherTests/Core/ScytherDefaultsTests.swift
+++ b/Tests/ScytherTests/Core/ScytherDefaultsTests.swift
@@ -94,13 +94,24 @@ final class ScytherDefaultsTests: XCTestCase {
     }
 
     func testMigrationIsIdempotent() {
-        source.set(true, forKey: "Scyther_fps_counter_enabled")
+        let key = "Scyther_fps_counter_enabled"
+        source.set(true, forKey: key)
+
+        // First run: the key moves across as usual.
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        // Re-seed the source with the *same* value it had originally, but give the
+        // destination a *different* value than what the source would supply. A second
+        // migration run must leave the destination's value alone - if `migrate` ever started
+        // unconditionally overwriting, this is what would catch it - while still sweeping the
+        // re-seeded key out of the source.
+        source.set(true, forKey: key)
+        destination.set(false, forKey: key)
 
         ScytherDefaults.migrate(from: source, to: destination)
-        destination.set(false, forKey: "Scyther_fps_counter_enabled")
-        ScytherDefaults.migrate(from: source, to: destination)
 
-        XCTAssertFalse(destination.bool(forKey: "Scyther_fps_counter_enabled"))
+        XCTAssertFalse(destination.bool(forKey: key), "the destination's existing value must survive a second migration run")
+        XCTAssertNil(source.object(forKey: key), "the source key must still be removed on the second run")
     }
 
     // MARK: - migrateIfNeeded(from:to:)
@@ -123,6 +134,22 @@ final class ScytherDefaultsTests: XCTestCase {
     }
 
     // MARK: - Store
+    //
+    // `UserDefaults.scyther` is a `nonisolated(unsafe) static let`, backed by the real,
+    // on-disk `com.scyther.settings` suite - not a throwaway suite like `source`/`destination`
+    // above. Because it is a `static`, the *first* access anywhere in this test binary's
+    // process runs `ScytherDefaults.makeStore()`'s one-time migration against the real
+    // `UserDefaults.standard`, once, for the lifetime of the process. Any `Scyther*` fixture a
+    // test seeds into `UserDefaults.standard` *after* that first access will never be picked
+    // up by a subsequent migration - it will just sit there looking like it "vanished" from
+    // the destination. Don't seed `Scyther*` keys into `UserDefaults.standard` expecting this
+    // store to observe them; use the `source`/`destination` throwaway suites for migration
+    // behaviour instead.
+    //
+    // The two tests below are the only ones in this file that touch the real suite, and
+    // nothing else in the suite ever cleans it. They must therefore leave it exactly as they
+    // found it - including when an assertion inside them fails - so state never leaks across
+    // test runs on the same simulator.
 
     func testScytherStoreIsNotTheStandardStore() {
         XCTAssertFalse(UserDefaults.scyther === UserDefaults.standard)
@@ -130,8 +157,14 @@ final class ScytherDefaultsTests: XCTestCase {
 
     func testScytherStoreWritesAreInvisibleToStandard() {
         let key = "Scyther_isolation_probe"
+
+        // Registered before the write, so it still runs - and removes the probe key - even if
+        // an assertion below fails or a future edit adds a path that returns early.
+        addTeardownBlock {
+            UserDefaults.scyther.removeObject(forKey: key)
+        }
+
         UserDefaults.scyther.set(true, forKey: key)
-        defer { UserDefaults.scyther.removeObject(forKey: key) }
 
         XCTAssertTrue(UserDefaults.scyther.bool(forKey: key))
         XCTAssertNil(UserDefaults.standard.persistentDomain(forName: Bundle.main.bundleIdentifier ?? "")?[key])

--- a/Tests/ScytherTests/Features/FeatureFlagsTests.swift
+++ b/Tests/ScytherTests/Features/FeatureFlagsTests.swift
@@ -217,6 +217,7 @@ final class FeatureFlagsTests: XCTestCase {
     @MainActor
     func testOverridesEnabledPropagatesToTheFeatureFlagsSubsystem() {
         let viewModel = FeatureFlagsViewModel()
+        defer { viewModel.overridesEnabled = false }
 
         viewModel.overridesEnabled = true
         XCTAssertTrue(Scyther.featureFlags.localOverridesEnabled)

--- a/Tests/ScytherTests/Features/FeatureFlagsTests.swift
+++ b/Tests/ScytherTests/Features/FeatureFlagsTests.swift
@@ -22,7 +22,7 @@ final class FeatureFlagsTests: XCTestCase {
     }
 
     private func cleanupUserDefaults() {
-        let defaults = UserDefaults.standard
+        let defaults = UserDefaults.scyther
         for key in defaults.dictionaryRepresentation().keys where key.hasPrefix("Scyther_toggler_local_value_") {
             defaults.removeObject(forKey: key)
         }
@@ -44,37 +44,37 @@ final class FeatureFlagsTests: XCTestCase {
 
     func testLocalOverrideReturnsNilWhenOverridesDisabled() {
         // A local value is stored, but overrides are globally off.
-        UserDefaults.standard.set(false, forKey: FeatureFlags.overridesEnabledKey)
-        UserDefaults.standard.set(true, forKey: FeatureToggle.localValueKey(for: "Flag A"))
+        UserDefaults.scyther.set(false, forKey: FeatureFlags.overridesEnabledKey)
+        UserDefaults.scyther.set(true, forKey: FeatureToggle.localValueKey(for: "Flag A"))
 
         XCTAssertNil(FeatureFlags.shared.localOverride(for: "Flag A"))
     }
 
     func testLocalOverrideReturnsNilWhenFlagNeverOverridden() {
         // Overrides on, but this flag has no stored value.
-        UserDefaults.standard.set(true, forKey: FeatureFlags.overridesEnabledKey)
+        UserDefaults.scyther.set(true, forKey: FeatureFlags.overridesEnabledKey)
 
         XCTAssertNil(FeatureFlags.shared.localOverride(for: "Never Set"))
     }
 
     func testLocalOverrideReturnsTrueWhenSet() {
-        UserDefaults.standard.set(true, forKey: FeatureFlags.overridesEnabledKey)
-        UserDefaults.standard.set(true, forKey: FeatureToggle.localValueKey(for: "Flag B"))
+        UserDefaults.scyther.set(true, forKey: FeatureFlags.overridesEnabledKey)
+        UserDefaults.scyther.set(true, forKey: FeatureToggle.localValueKey(for: "Flag B"))
 
         XCTAssertEqual(FeatureFlags.shared.localOverride(for: "Flag B"), true)
     }
 
     func testLocalOverrideReturnsFalseWhenSet() {
-        UserDefaults.standard.set(true, forKey: FeatureFlags.overridesEnabledKey)
-        UserDefaults.standard.set(false, forKey: FeatureToggle.localValueKey(for: "Flag C"))
+        UserDefaults.scyther.set(true, forKey: FeatureFlags.overridesEnabledKey)
+        UserDefaults.scyther.set(false, forKey: FeatureToggle.localValueKey(for: "Flag C"))
 
         XCTAssertEqual(FeatureFlags.shared.localOverride(for: "Flag C"), false)
     }
 
     func testLocalOverrideRoundTripsThroughToggleKeyDerivation() {
         // Writing under the derived key for a spaced name must be readable via the accessor.
-        UserDefaults.standard.set(true, forKey: FeatureFlags.overridesEnabledKey)
-        UserDefaults.standard.set(true, forKey: FeatureToggle.localValueKey(for: "New Dashboard"))
+        UserDefaults.scyther.set(true, forKey: FeatureFlags.overridesEnabledKey)
+        UserDefaults.scyther.set(true, forKey: FeatureToggle.localValueKey(for: "New Dashboard"))
 
         XCTAssertEqual(FeatureFlags.shared.localOverride(for: "New Dashboard"), true)
     }
@@ -83,7 +83,7 @@ final class FeatureFlagsTests: XCTestCase {
 
     @MainActor
     func testClearLocalValueRevertsToRemote() {
-        UserDefaults.standard.set(true, forKey: FeatureFlags.overridesEnabledKey)
+        UserDefaults.scyther.set(true, forKey: FeatureFlags.overridesEnabledKey)
         let flags = FeatureFlags.shared
         flags.register("Clearable Flag", remoteValue: true)
         flags.setLocalValue(false, for: "Clearable Flag")
@@ -107,7 +107,7 @@ final class FeatureFlagsTests: XCTestCase {
 
     @MainActor
     func testClearAllLocalValuesClearsEveryFlag() {
-        UserDefaults.standard.set(true, forKey: FeatureFlags.overridesEnabledKey)
+        UserDefaults.scyther.set(true, forKey: FeatureFlags.overridesEnabledKey)
         let flags = FeatureFlags.shared
         flags.register("Flag One", remoteValue: false)
         flags.register("Flag Two", remoteValue: true)
@@ -141,8 +141,8 @@ final class FeatureFlagsTests: XCTestCase {
         // Proves the whole path is usable off the main actor with no main-actor hop:
         // the `Scyther.featureFlags` facade is reachable from a detached (non-main) task and
         // `localOverride(for:)` reads correctly there.
-        UserDefaults.standard.set(true, forKey: FeatureFlags.overridesEnabledKey)
-        UserDefaults.standard.set(true, forKey: FeatureToggle.localValueKey(for: "Off Main"))
+        UserDefaults.scyther.set(true, forKey: FeatureFlags.overridesEnabledKey)
+        UserDefaults.scyther.set(true, forKey: FeatureToggle.localValueKey(for: "Off Main"))
 
         let value = await Task.detached { Scyther.featureFlags.localOverride(for: "Off Main") }.value
 

--- a/Tests/ScytherTests/Features/FeatureFlagsTests.swift
+++ b/Tests/ScytherTests/Features/FeatureFlagsTests.swift
@@ -148,5 +148,81 @@ final class FeatureFlagsTests: XCTestCase {
 
         XCTAssertEqual(value, true)
     }
+
+    // MARK: - Pinned toggles stay in the full list
+
+    /// Flags register into the shared `Scyther.featureFlags` singleton and there is no
+    /// public API to unregister them, so these tests use distinctive names and assert by
+    /// containment rather than whole-array equality. Another test registering its own flags
+    /// must not be able to break them.
+    @MainActor
+    private func makeSuite(named suiteName: String) -> UserDefaults {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        }
+        return UserDefaults(suiteName: suiteName)!
+    }
+
+    @MainActor
+    func testPinnedTogglesRemainInTheFullToggleList() async {
+        let defaults = makeSuite(named: "com.scyther.tests.featureflags")
+        Scyther.featureFlags.register("ScytherTestPinned", remoteValue: true)
+
+        let viewModel = FeatureFlagsViewModel(defaults: defaults)
+        await viewModel.onFirstAppear()
+        viewModel.togglePin(for: "ScytherTestPinned")
+
+        XCTAssertTrue(
+            viewModel.pinnedToggles.contains { $0.name == "ScytherTestPinned" },
+            "Pinned toggle is missing from the Pinned section"
+        )
+        XCTAssertTrue(
+            viewModel.toggles.contains { $0.name == "ScytherTestPinned" && $0.isPinned },
+            "Pinned toggle must remain in the full list, flagged as pinned"
+        )
+    }
+
+    @MainActor
+    func testPinnedTogglesAreOrderedAlphabeticallyNotByPinOrder() async {
+        let defaults = makeSuite(named: "com.scyther.tests.featureflags.order")
+        Scyther.featureFlags.register("ScytherTestOrderZulu", remoteValue: true)
+        Scyther.featureFlags.register("ScytherTestOrderAlpha", remoteValue: true)
+
+        let viewModel = FeatureFlagsViewModel(defaults: defaults)
+        await viewModel.onFirstAppear()
+
+        // Pin Zulu first. Alphabetical ordering must still put Alpha ahead of it.
+        viewModel.togglePin(for: "ScytherTestOrderZulu")
+        viewModel.togglePin(for: "ScytherTestOrderAlpha")
+
+        let names = viewModel.pinnedToggles.map(\.name).filter { $0.hasPrefix("ScytherTestOrder") }
+        XCTAssertEqual(names, ["ScytherTestOrderAlpha", "ScytherTestOrderZulu"])
+    }
+
+    @MainActor
+    func testUnpinningLeavesTheToggleInTheFullList() async {
+        let defaults = makeSuite(named: "com.scyther.tests.featureflags.unpin")
+        Scyther.featureFlags.register("ScytherTestUnpin", remoteValue: false)
+
+        let viewModel = FeatureFlagsViewModel(defaults: defaults)
+        await viewModel.onFirstAppear()
+        viewModel.togglePin(for: "ScytherTestUnpin")
+        viewModel.togglePin(for: "ScytherTestUnpin")
+
+        XCTAssertFalse(viewModel.pinnedToggles.contains { $0.name == "ScytherTestUnpin" })
+        XCTAssertTrue(viewModel.toggles.contains { $0.name == "ScytherTestUnpin" })
+    }
+
+    @MainActor
+    func testOverridesEnabledPropagatesToTheFeatureFlagsSubsystem() {
+        let viewModel = FeatureFlagsViewModel()
+
+        viewModel.overridesEnabled = true
+        XCTAssertTrue(Scyther.featureFlags.localOverridesEnabled)
+
+        viewModel.overridesEnabled = false
+        XCTAssertFalse(Scyther.featureFlags.localOverridesEnabled)
+    }
 }
 #endif

--- a/Tests/ScytherTests/Features/FeatureToggleTests.swift
+++ b/Tests/ScytherTests/Features/FeatureToggleTests.swift
@@ -24,7 +24,7 @@ final class FeatureToggleTests: XCTestCase {
 
     private func cleanupUserDefaults() {
         // Remove test-related keys
-        let defaults = UserDefaults.standard
+        let defaults = UserDefaults.scyther
         for key in defaults.dictionaryRepresentation().keys {
             if key.hasPrefix("Scyther_toggler_local_value_") {
                 defaults.removeObject(forKey: key)

--- a/Tests/ScytherTests/Features/HTTPRequestTests.swift
+++ b/Tests/ScytherTests/Features/HTTPRequestTests.swift
@@ -291,6 +291,39 @@ final class HTTPRequestTests: XCTestCase {
         XCTAssertEqual((dict["Variables"]?["id"]) as? String, "42")
     }
 
+    // MARK: - saveData / readRawData Round-Trip Tests
+
+    /// Regression test for a bug where `saveData(_:toFile:)` silently failed
+    /// whenever the target file's parent directory did not exist (e.g. a
+    /// factory-fresh simulator whose Documents directory hasn't been created
+    /// yet). Unlike `testGraphQLVariablesDictionaryWrapsVariables`, this test
+    /// deliberately targets a directory that is guaranteed not to exist yet,
+    /// so it fails deterministically regardless of simulator/machine state.
+    func testSaveDataCreatesMissingIntermediateDirectories() {
+        let model = HTTPRequest()
+
+        let directory = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent(UUID().uuidString)
+        let filePath = (directory as NSString).appendingPathComponent("body.txt")
+
+        // Runs on every exit path, including a mid-test assertion failure.
+        addTeardownBlock {
+            try? FileManager.default.removeItem(atPath: directory)
+        }
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: directory),
+            "Precondition: target directory must not already exist"
+        )
+
+        let content = "regression-test-body-\(UUID().uuidString)"
+        model.saveData(content as NSString, toFile: filePath)
+
+        let readBack = model.readRawData(filePath)
+        XCTAssertNotNil(readBack, "saveData should create missing intermediate directories and write successfully")
+        XCTAssertEqual(readBack.flatMap { String(data: $0, encoding: .utf8) }, content)
+    }
+
     func testRequestBodyDictionaryEmptyWhenNoBody() {
         let model = HTTPRequest()
         XCTAssertTrue(model.getRequestBodyDictionary().isEmpty)

--- a/Tests/ScytherTests/Features/MenuItemTests.swift
+++ b/Tests/ScytherTests/Features/MenuItemTests.swift
@@ -1,0 +1,104 @@
+//
+//  MenuItemTests.swift
+//  ScytherTests
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+#if !os(macOS)
+@testable import Scyther
+import XCTest
+
+final class MenuItemTests: XCTestCase {
+
+    // MARK: - Identity
+
+    func testAllStaticCaseIdentifiersAreUnique() {
+        let ids = MenuItem.allStaticCases.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "Two menu items share an identifier")
+    }
+
+    func testAllStaticCaseIdentifiersAreNonEmpty() {
+        for item in MenuItem.allStaticCases {
+            XCTAssertFalse(item.id.isEmpty, "\(item) has an empty identifier")
+        }
+    }
+
+    func testEveryStaticCaseRoundTripsThroughItsIdentifier() {
+        for item in MenuItem.allStaticCases {
+            XCTAssertEqual(MenuItem(id: item.id), item, "\(item) did not round-trip")
+        }
+    }
+
+    func testDeveloperOptionRoundTrips() {
+        let item = MenuItem.developerOption(name: "Reset Onboarding")
+        XCTAssertEqual(MenuItem(id: item.id), item)
+    }
+
+    func testDeveloperOptionRoundTripsWithAwkwardNames() {
+        let names = ["A.B.C", "has spaces", "emoji 🚀", "developerOption.nested"]
+        for name in names {
+            let item = MenuItem.developerOption(name: name)
+            XCTAssertEqual(MenuItem(id: item.id), item, "\(name) did not round-trip")
+        }
+    }
+
+    func testDeveloperOptionIdentifierIsNamespaced() {
+        XCTAssertEqual(MenuItem.developerOption(name: "Panel").id, "developerOption.Panel")
+    }
+
+    func testUnknownIdentifierReturnsNil() {
+        XCTAssertNil(MenuItem(id: "somethingThatWasRemovedInV2"))
+    }
+
+    func testEmptyDeveloperOptionNameReturnsNil() {
+        XCTAssertNil(MenuItem(id: "developerOption."))
+    }
+
+    func testPinnedRowIdentifierIsDistinctFromTheIdentifier() {
+        let item = MenuItem.featureFlags
+        XCTAssertNotEqual(item.pinnedRowID, item.id)
+        XCTAssertTrue(item.pinnedRowID.hasSuffix(item.id))
+    }
+
+    // MARK: - Presentation
+
+    func testEveryStaticCaseHasANonEmptyTitle() {
+        for item in MenuItem.allStaticCases {
+            XCTAssertFalse(item.title.isEmpty, "\(item) has no title")
+        }
+    }
+
+    func testDeveloperOptionTitleIsItsName() {
+        XCTAssertEqual(MenuItem.developerOption(name: "Reset Onboarding").title, "Reset Onboarding")
+    }
+
+    func testNavigationItemsCarryAnIcon() {
+        let navigationItems: [MenuItem] = [
+            .networkLogs, .serverConfiguration, .environmentVariables, .featureFlags,
+            .userDefaults, .cookies, .fileBrowser, .databaseBrowser, .keychainBrowser,
+            .locationSpoofer, .consoleLogs, .deepLinkTester, .crashLogs,
+            .notificationLogger, .notificationTester, .fonts, .interfaceComponents,
+            .gridOverlay, .fpsCounter, .touchVisualiser, .appearance
+        ]
+        for item in navigationItems {
+            XCTAssertNotNil(item.icon, "\(item) should have an icon")
+        }
+    }
+
+    func testDeviceAndApplicationInfoItemsHaveNoIcon() {
+        let infoItems: [MenuItem] = [
+            .osVersion, .hardware, .releaseYear, .uuid,
+            .appIdPrefix, .displayName, .bundleId, .processId,
+            .version, .buildNumber, .buildDate, .releaseType
+        ]
+        for item in infoItems {
+            XCTAssertNil(item.icon, "\(item) should not have an icon")
+        }
+    }
+
+    func testStaticCaseCountIsStable() {
+        XCTAssertEqual(MenuItem.allStaticCases.count, 39)
+    }
+}
+#endif

--- a/Tests/ScytherTests/Features/MenuViewModelTests.swift
+++ b/Tests/ScytherTests/Features/MenuViewModelTests.swift
@@ -230,6 +230,44 @@ final class MenuViewModelTests: XCTestCase {
         }
     }
 
+    // MARK: - Reloading pin state on reappearance
+
+    func testPinnedItemIDsReloadOnSubsequentAppear() async {
+        defer { wipeDefaults() }
+        let defaults = makeDefaults()
+
+        let viewModel = MenuViewModel(defaults: defaults)
+        viewModel.togglePin(for: .fonts)
+        XCTAssertEqual(viewModel.pinnedItemIDs, ["fonts"])
+
+        // Simulate the pin state changing underneath this view model while the menu is off
+        // screen -- e.g. "Reset all Scyther settings" in the UserDefaults browser, or a
+        // hand-edit of `Scyther.Menu.PinnedItems`. The view model's `@StateObject` survives
+        // this because `MenuView` sits at the root of a `UINavigationController`.
+        defaults.removeObject(forKey: MenuViewModel.pinnedItemsKey)
+
+        await viewModel.onSubsequentAppear()
+
+        XCTAssertTrue(
+            viewModel.pinnedItemIDs.isEmpty,
+            "Reappearing after the underlying store changed should reload pin state from disk"
+        )
+    }
+
+    func testPinnedItemIDsDoNotChangeBeforeTheFirstSubsequentAppear() {
+        defer { wipeDefaults() }
+        let defaults = makeDefaults()
+
+        let viewModel = MenuViewModel(defaults: defaults)
+        viewModel.togglePin(for: .fonts)
+
+        // A change made to the backing store between init and the first reappearance should
+        // not retroactively alter in-memory state until `onSubsequentAppear()` actually runs.
+        defaults.removeObject(forKey: MenuViewModel.pinnedItemsKey)
+
+        XCTAssertEqual(viewModel.pinnedItemIDs, ["fonts"])
+    }
+
     func testIsPinnedAgreesWithPinnedItemIdentifiers() {
         defer { wipeDefaults() }
         let viewModel = MenuViewModel(defaults: makeDefaults())

--- a/Tests/ScytherTests/Features/MenuViewModelTests.swift
+++ b/Tests/ScytherTests/Features/MenuViewModelTests.swift
@@ -59,5 +59,153 @@ final class MenuViewModelTests: XCTestCase {
         let ids = MenuSection.allSections(developerOptions: []).map(\.id)
         XCTAssertEqual(Set(ids).count, ids.count)
     }
+
+    // MARK: - Pinning
+
+    private var suiteName: String { "com.scyther.tests.menu" }
+
+    private func makeDefaults() -> UserDefaults {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        return UserDefaults(suiteName: suiteName)!
+    }
+
+    private func wipeDefaults() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+
+    func testNothingIsPinnedByDefault() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        XCTAssertTrue(viewModel.pinnedItemIDs.isEmpty)
+        XCTAssertTrue(viewModel.pinnedItems.isEmpty)
+    }
+
+    func testPinningAppendsTheItem() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        viewModel.togglePin(for: .featureFlags)
+
+        XCTAssertTrue(viewModel.isPinned(.featureFlags))
+        XCTAssertEqual(viewModel.pinnedItems, [.featureFlags])
+    }
+
+    func testUnpinningRemovesTheItem() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        viewModel.togglePin(for: .featureFlags)
+        viewModel.togglePin(for: .featureFlags)
+
+        XCTAssertFalse(viewModel.isPinned(.featureFlags))
+        XCTAssertTrue(viewModel.pinnedItems.isEmpty)
+    }
+
+    func testPinnedItemsAreOrderedOldestFirst() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        viewModel.togglePin(for: .crashLogs)
+        viewModel.togglePin(for: .featureFlags)
+        viewModel.togglePin(for: .fonts)
+
+        XCTAssertEqual(viewModel.pinnedItems, [.crashLogs, .featureFlags, .fonts])
+    }
+
+    func testUnpinningDoesNotDisturbTheOrderOfOtherItems() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        viewModel.togglePin(for: .crashLogs)
+        viewModel.togglePin(for: .featureFlags)
+        viewModel.togglePin(for: .fonts)
+        viewModel.togglePin(for: .featureFlags)
+
+        XCTAssertEqual(viewModel.pinnedItems, [.crashLogs, .fonts])
+    }
+
+    func testRepinningMovesTheItemToTheEnd() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        viewModel.togglePin(for: .crashLogs)
+        viewModel.togglePin(for: .fonts)
+        viewModel.togglePin(for: .crashLogs)
+        viewModel.togglePin(for: .crashLogs)
+
+        XCTAssertEqual(viewModel.pinnedItems, [.fonts, .crashLogs])
+    }
+
+    func testPinStateSurvivesANewViewModel() {
+        defer { wipeDefaults() }
+        let defaults = makeDefaults()
+
+        let first = MenuViewModel(defaults: defaults)
+        first.togglePin(for: .keychainBrowser)
+        first.togglePin(for: .cookies)
+
+        let second = MenuViewModel(defaults: defaults)
+        XCTAssertEqual(second.pinnedItems, [.keychainBrowser, .cookies])
+    }
+
+    func testPinsAreWrittenToTheInjectedStoreOnly() {
+        defer { wipeDefaults() }
+        let defaults = makeDefaults()
+
+        let viewModel = MenuViewModel(defaults: defaults)
+        viewModel.togglePin(for: .fonts)
+
+        XCTAssertEqual(defaults.stringArray(forKey: MenuViewModel.pinnedItemsKey), ["fonts"])
+    }
+
+    func testStoredIdentifiersThatNoLongerResolveAreDropped() {
+        defer { wipeDefaults() }
+        let defaults = makeDefaults()
+        defaults.set(["fonts", "removedInV2", "cookies"], forKey: MenuViewModel.pinnedItemsKey)
+
+        let viewModel = MenuViewModel(defaults: defaults)
+
+        XCTAssertEqual(viewModel.pinnedItems, [.fonts, .cookies])
+    }
+
+    func testPinnedDeveloperOptionThatNoLongerExistsIsDropped() {
+        defer {
+            wipeDefaults()
+            Scyther.developerOptions = []
+        }
+        let defaults = makeDefaults()
+        defaults.set(["developerOption.Gone", "fonts"], forKey: MenuViewModel.pinnedItemsKey)
+        Scyther.developerOptions = []
+
+        let viewModel = MenuViewModel(defaults: defaults)
+
+        XCTAssertEqual(viewModel.pinnedItems, [.fonts])
+    }
+
+    func testPinnedDeveloperOptionThatStillExistsIsKept() {
+        defer {
+            wipeDefaults()
+            Scyther.developerOptions = []
+        }
+        let defaults = makeDefaults()
+        defaults.set(["developerOption.Panel"], forKey: MenuViewModel.pinnedItemsKey)
+        Scyther.developerOptions = [DeveloperOption(name: "Panel", value: "x")]
+
+        let viewModel = MenuViewModel(defaults: defaults)
+
+        XCTAssertEqual(viewModel.pinnedItems, [.developerOption(name: "Panel")])
+    }
+
+    func testIsPinnedAgreesWithPinnedItemIdentifiers() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        viewModel.togglePin(for: .gridOverlay)
+
+        XCTAssertTrue(viewModel.isPinned(.gridOverlay))
+        XCTAssertFalse(viewModel.isPinned(.fpsCounter))
+        XCTAssertEqual(viewModel.pinnedItemIDs, [MenuItem.gridOverlay.id])
+    }
 }
 #endif

--- a/Tests/ScytherTests/Features/MenuViewModelTests.swift
+++ b/Tests/ScytherTests/Features/MenuViewModelTests.swift
@@ -1,0 +1,63 @@
+//
+//  MenuViewModelTests.swift
+//  ScytherTests
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+#if !os(macOS)
+@testable import Scyther
+import XCTest
+
+@MainActor
+final class MenuViewModelTests: XCTestCase {
+
+    // MARK: - Sections
+
+    func testEveryStaticItemAppearsInExactlyOneSection() {
+        let items = MenuSection.allSections(developerOptions: []).flatMap(\.items)
+
+        XCTAssertEqual(Set(items).count, items.count, "An item appears in more than one section")
+        XCTAssertEqual(Set(items), Set(MenuItem.allStaticCases), "Sections do not cover every item")
+    }
+
+    func testDeviceSectionIsFirst() {
+        XCTAssertEqual(MenuSection.allSections(developerOptions: []).first?.title, "Device")
+    }
+
+    func testDevelopmentToolsSectionIsOmittedWhenThereAreNoDeveloperOptions() {
+        let titles = MenuSection.allSections(developerOptions: []).map(\.title)
+        XCTAssertFalse(titles.contains("Development Tools"))
+    }
+
+    func testDevelopmentToolsSectionIsIncludedWhenDeveloperOptionsExist() {
+        let options = [DeveloperOption(name: "Reset Onboarding", value: "tap")]
+        let sections = MenuSection.allSections(developerOptions: options)
+
+        let developmentTools = sections.first { $0.title == "Development Tools" }
+        XCTAssertEqual(developmentTools?.items, [.developerOption(name: "Reset Onboarding")])
+    }
+
+    func testSectionTitlesAreInTheExpectedOrder() {
+        let options = [DeveloperOption(name: "Panel", value: "x")]
+        let titles = MenuSection.allSections(developerOptions: options).map(\.title)
+
+        XCTAssertEqual(titles, [
+            "Device",
+            "Application",
+            "Development Tools",
+            "Networking",
+            "Data",
+            "Security",
+            "System Tools",
+            "Notifications",
+            "UI/UX"
+        ])
+    }
+
+    func testSectionIdentifiersAreUnique() {
+        let ids = MenuSection.allSections(developerOptions: []).map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count)
+    }
+}
+#endif

--- a/Tests/ScytherTests/Features/MenuViewModelTests.swift
+++ b/Tests/ScytherTests/Features/MenuViewModelTests.swift
@@ -197,6 +197,39 @@ final class MenuViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.pinnedItems, [.developerOption(name: "Panel")])
     }
 
+    // MARK: - Consistency under a concurrent mutation
+
+    func testDeveloperOptionRowsListedBySectionsStayResolvableAfterHostMutatesDeveloperOptions() {
+        defer {
+            wipeDefaults()
+            Scyther.developerOptions = []
+        }
+        Scyther.developerOptions = [DeveloperOption(name: "Panel", value: "x")]
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        // This is the same item list `MenuView` uses to decide which rows to render (and to
+        // wrap in a live swipe action via `pinnableRow`).
+        let items = viewModel.sections.flatMap(\.items)
+        XCTAssertTrue(items.contains(.developerOption(name: "Panel")))
+
+        // A host app mutates `Scyther.developerOptions` while the menu is already on screen
+        // -- e.g. between the section list being computed and a lazily-materialised row
+        // actually being rendered.
+        Scyther.developerOptions = []
+
+        // Every developer-option row already committed to the item list above must still be
+        // resolvable by name. If it isn't, `rowContent` renders nothing for that row while
+        // `pinnableRow` has already wrapped it in a live swipe action -- a blank but
+        // swipeable row.
+        for item in items {
+            guard case .developerOption(let name) = item else { continue }
+            XCTAssertNotNil(
+                viewModel.developerOption(named: name),
+                "\"\(name)\" was listed by sections but can no longer be resolved for rendering"
+            )
+        }
+    }
+
     func testIsPinnedAgreesWithPinnedItemIdentifiers() {
         defer { wipeDefaults() }
         let viewModel = MenuViewModel(defaults: makeDefaults())

--- a/Tests/ScytherTests/Features/UserDefaultsViewModelTests.swift
+++ b/Tests/ScytherTests/Features/UserDefaultsViewModelTests.swift
@@ -1,0 +1,92 @@
+//
+//  UserDefaultsViewModelTests.swift
+//  ScytherTests
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+#if !os(macOS)
+@testable import Scyther
+import XCTest
+
+@MainActor
+final class UserDefaultsViewModelTests: XCTestCase {
+    private let appKey = "scyther_tests_app_only_key"
+    private let scytherKey = "Scyther_tests_suite_only_key"
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: appKey)
+        UserDefaults.scyther.removeObject(forKey: scytherKey)
+        super.tearDown()
+    }
+
+    func testAppStoreResolvesToStandard() {
+        XCTAssertTrue(DefaultsStore.app.defaults === UserDefaults.standard)
+    }
+
+    func testScytherStoreResolvesToTheSuite() {
+        XCTAssertTrue(DefaultsStore.scyther.defaults === UserDefaults.scyther)
+    }
+
+    func testEveryStoreHasATitle() {
+        for store in DefaultsStore.allCases {
+            XCTAssertFalse(store.title.isEmpty, "\(store) has no title")
+        }
+    }
+
+    func testAppStoreLoadsKeysFromStandard() async {
+        UserDefaults.standard.set("app", forKey: appKey)
+
+        let viewModel = UserDefaultsViewModel(store: .app)
+        await viewModel.loadDefaults()
+
+        XCTAssertTrue(viewModel.keyValues.contains { $0.key == appKey })
+    }
+
+    func testScytherStoreLoadsKeysFromTheSuite() async {
+        UserDefaults.scyther.set("suite", forKey: scytherKey)
+
+        let viewModel = UserDefaultsViewModel(store: .scyther)
+        await viewModel.loadDefaults()
+
+        XCTAssertTrue(viewModel.keyValues.contains { $0.key == scytherKey })
+    }
+
+    func testScytherStoreDoesNotLeakStandardKeys() async {
+        UserDefaults.standard.set("app", forKey: appKey)
+
+        let viewModel = UserDefaultsViewModel(store: .scyther)
+        await viewModel.loadDefaults()
+
+        XCTAssertFalse(viewModel.keyValues.contains { $0.key == appKey })
+    }
+
+    func testScytherStoreExcludesGlobalDomainKeys() async {
+        // AppleLanguages is inherited from NSGlobalDomain. Reading the suite via its
+        // persistent domain must not surface it.
+        let viewModel = UserDefaultsViewModel(store: .scyther)
+        await viewModel.loadDefaults()
+
+        XCTAssertFalse(viewModel.keyValues.contains { $0.key == "AppleLanguages" })
+    }
+
+    func testWritesRouteToTheSelectedStore() async {
+        let viewModel = UserDefaultsViewModel(store: .scyther)
+        viewModel.updateValue("written", forKey: scytherKey)
+
+        XCTAssertEqual(UserDefaults.scyther.string(forKey: scytherKey), "written")
+        XCTAssertNil(UserDefaults.standard.string(forKey: scytherKey))
+    }
+
+    func testDeletesRouteToTheSelectedStore() async {
+        UserDefaults.scyther.set("doomed", forKey: scytherKey)
+
+        let viewModel = UserDefaultsViewModel(store: .scyther)
+        await viewModel.loadDefaults()
+        viewModel.deleteKey(scytherKey)
+
+        XCTAssertNil(UserDefaults.scyther.object(forKey: scytherKey))
+        XCTAssertFalse(viewModel.keyValues.contains { $0.key == scytherKey })
+    }
+}
+#endif

--- a/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
+++ b/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
@@ -2359,19 +2359,14 @@ In `Sources/Scyther/Features/FeatureFlags/FeatureFlagsView.swift`, replace `filt
     }
 ```
 
-Replace `body` with a gated version. `.searchable` cannot be applied conditionally inline, so the list is extracted and the modifier applied on one branch only.
+Replace `body` with a gated version. **`.searchable` is applied unconditionally**, so `body` stays a single view shape.
 
-**The `Group` wrapper is load-bearing — do not remove it.** Flipping `overridesEnabled` swaps which branch is rendered, which destroys the branch's view identity along with any `.onChange`, `.onAppear` or `@State` attached inside it. Attaching the lifecycle modifiers to the `Group` gives them a stable identity that survives the swap, so the "clear the search text" handler actually fires. Attached to `list` instead, it would silently never run on the very transition it exists to handle.
+This is deliberate. An earlier draft applied `.searchable` only while overrides were on, which forced `body` to branch between two shapes — and flipping `overridesEnabled` then swapped which branch rendered, destroying that branch's view identity along with any `.onChange`, `.onAppear` or `@State` attached inside it. The search-clearing handler would have silently never fired on the exact transition it exists to handle, and no test would have caught it. Keeping one unconditional shape removes that failure mode rather than engineering around it with a stabilising `Group` wrapper. The cost is a search field that is briefly inert while the list is hidden.
 
 ```swift
     var body: some View {
-        Group {
-            if viewModel.overridesEnabled {
-                list.searchable(text: $searchText, prompt: "Search toggles")
-            } else {
-                list
-            }
-        }
+        list
+        .searchable(text: $searchText, prompt: "Search toggles")
         .navigationTitle("Feature Flags")
         .onChange(of: searchText) { newValue in
             searchSubject.send(newValue)
@@ -2474,9 +2469,10 @@ Update the view's DocC comment, which currently claims pinning moves toggles to 
 /// - Search toggles by name
 /// - Reset all toggles back to their remote values
 ///
-/// While **Enable overrides** is off, the toggle list, the reset button and the search field
-/// are hidden — local overrides have no effect in that state, so presenting an interactive
-/// list would be misleading.
+/// While **Enable overrides** is off, the toggle list and the reset button are hidden —
+/// local overrides have no effect in that state, so presenting an interactive list would be
+/// misleading. The search field remains visible; `.searchable` is applied unconditionally so
+/// that `body` keeps a single view shape.
 ```
 
 - [ ] **Step 6: Build and run the full test suite**
@@ -2490,8 +2486,8 @@ Expected: `** TEST SUCCEEDED **`.
 - [ ] **Step 7: Verify the Feature Flags screen visually**
 
 Run `Example/ScytherExample`, navigate to **Data → Feature Flags**, and confirm:
-1. With overrides off: only "Enable overrides" is visible, with the explanatory footer beneath it. No reset button, no sections, no search field.
-2. Turning overrides on reveals the reset button, the Toggles section and the search field.
+1. With overrides off: only "Enable overrides" is visible, with the explanatory footer beneath it. No reset button and no sections. The search field IS still present — that is intended.
+2. Turning overrides on reveals the reset button and the Toggles section. The search field was already there and does not move or resize the navigation bar.
 3. Pinning a toggle adds a Pinned section **and** leaves the toggle in the Toggles list.
 4. Both copies show "Unpin" when swiped, and unpinning from either removes the Pinned section entry.
 5. Typing a search term, then turning overrides off and back on, leaves the search field empty and the full list visible.
@@ -2502,7 +2498,8 @@ In the `### Feature Flags` section of `README.md`, add a note after the override
 
 ```markdown
 The flag list is only shown while **Enable overrides** is on. With overrides off, local
-values have no effect, so the list, the reset button and the search field are hidden.
+values have no effect, so the list and the reset button are hidden. The search field stays
+visible.
 
 Toggles can be pinned via a left swipe. Pinned toggles appear in a **Pinned** section at the
 top of the list and also remain in the main list. Pins persist across launches in Scyther's

--- a/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
+++ b/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
@@ -2522,13 +2522,23 @@ git commit -m "Gate the feature flag list behind the overrides toggle"
 
 **Files:** none modified unless a check fails.
 
-- [ ] **Step 1: Confirm no Scyther code writes to the standard store**
+- [ ] **Step 1: Confirm no Scyther *setting* is written to the standard store**
 
 ```bash
-grep -rn "UserDefaults.standard" --include="*.swift" Sources/
+grep -rln "UserDefaults.standard" --include="*.swift" Sources/
 ```
 
-Expected: exactly two results — `Shared/Extensions/UserDefaults+Extensions.swift` and `Features/CookieBrowser/CookieDetailsViewModel.swift`. Both are correct; see Task 2.
+Expected: exactly these four files, all of which reference the standard store legitimately:
+
+| File | Why it is correct |
+| --- | --- |
+| `Core/ScytherDefaults.swift` | Names `.standard` as the migration *source*, as the fallback when the suite cannot be created, and in its DocC examples |
+| `Features/UserDefaults/UserDefaultsViewModel.swift` | The browser reads the host app's defaults for the `.app` store |
+| `Features/UserDefaults/UserDefaultsView.swift` | Store-selection copy naming the app's defaults |
+| `Shared/Extensions/UserDefaults+Extensions.swift` | Display helper, called against whichever store is shown |
+| `Features/CookieBrowser/CookieDetailsViewModel.swift` | `synchronize()` flushing `HTTPCookieStorage` |
+
+The gate that actually matters: **none of the 12 files migrated in Task 2 may appear in this list.**
 
 - [ ] **Step 2: Confirm no confirmation dialogs remain**
 

--- a/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
+++ b/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
@@ -1942,6 +1942,25 @@ Add these two methods immediately after `body`, before the existing `row(withLab
             }
     }
 
+    /// Builds a row that pushes a destination view.
+    ///
+    /// The label is derived entirely from the item, so every navigation row in the menu is
+    /// laid out identically and only the destination varies.
+    ///
+    /// - Parameters:
+    ///   - item: The row to render.
+    ///   - destination: The view to push when the row is tapped. Built lazily.
+    private func navigationRow<Destination: View>(
+        for item: MenuItem,
+        @ViewBuilder destination: @escaping () -> Destination
+    ) -> some View {
+        NavigationLink {
+            destination()
+        } label: {
+            row(withLabel: item.title, icon: item.icon)
+        }
+    }
+
     /// The single definition of every menu row.
     ///
     /// ``MenuItem`` supplies each row's title and icon; this method supplies everything
@@ -1994,103 +2013,43 @@ Add these two methods immediately after `body`, before the existing `row(withLab
                 andLoadingState: viewModel.isLoadingIPAddress
             )
         case .networkLogs:
-            NavigationLink {
-                NetworkLogsView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { NetworkLogsView() }
         case .serverConfiguration:
-            NavigationLink {
-                ServerConfigurationView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { ServerConfigurationView() }
         case .environmentVariables:
-            NavigationLink {
-                EnvironmentVariablesView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { EnvironmentVariablesView() }
 
         // MARK: Data
         case .featureFlags:
-            NavigationLink {
-                FeatureFlagsView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { FeatureFlagsView() }
         case .userDefaults:
-            NavigationLink {
-                UserDefaultsView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { UserDefaultsView() }
         case .cookies:
-            NavigationLink {
-                CookieBrowserView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { CookieBrowserView() }
         case .fileBrowser:
-            NavigationLink {
-                FileBrowserView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { FileBrowserView() }
         case .databaseBrowser:
-            NavigationLink {
-                DatabaseBrowserView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { DatabaseBrowserView() }
 
         // MARK: Security
         case .keychainBrowser:
-            NavigationLink {
-                KeychainBrowserView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { KeychainBrowserView() }
 
         // MARK: System Tools
         case .locationSpoofer:
-            NavigationLink {
-                LocationSpooferView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { LocationSpooferView() }
         case .consoleLogs:
-            NavigationLink {
-                ConsoleLoggerView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { ConsoleLoggerView() }
         case .deepLinkTester:
-            NavigationLink {
-                DeepLinkTesterView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { DeepLinkTesterView() }
         case .crashLogs:
-            NavigationLink {
-                CrashLogsView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { CrashLogsView() }
 
         // MARK: Notifications
         case .notificationLogger:
-            NavigationLink {
-                NotificationLoggerView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { NotificationLoggerView() }
         case .notificationTester:
-            NavigationLink {
-                NotificationTesterView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { NotificationTesterView() }
         case .apnsToken:
             row(withLabel: item.title, icon: item.icon)
         case .fcmToken:
@@ -2098,41 +2057,17 @@ Add these two methods immediately after `body`, before the existing `row(withLab
 
         // MARK: UI/UX
         case .fonts:
-            NavigationLink {
-                FontsView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { FontsView() }
         case .interfaceComponents:
-            NavigationLink {
-                InterfacePreviewsView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { InterfacePreviewsView() }
         case .gridOverlay:
-            NavigationLink {
-                GridOverlaySettingsView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { GridOverlaySettingsView() }
         case .fpsCounter:
-            NavigationLink {
-                FPSCounterSettingsView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { FPSCounterSettingsView() }
         case .touchVisualiser:
-            NavigationLink {
-                TouchVisualiserView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { TouchVisualiserView() }
         case .appearance:
-            NavigationLink {
-                AppearanceOverridesView()
-            } label: {
-                row(withLabel: item.title, icon: item.icon)
-            }
+            navigationRow(for: item) { AppearanceOverridesView() }
         case .slowAnimations:
             toggleRow(item.title, icon: item.icon, isOn: $viewModel.slowAnimationsEnabled)
         case .showViewFrames:

--- a/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
+++ b/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
@@ -1,0 +1,2632 @@
+# Pinnable Menu Items & Private Preferences Suite — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move all of Scyther's persisted settings into a private `UserDefaults` suite that survives a host app wiping the standard domain, and make every row of the main menu pinnable to a new "Pinned" section.
+
+**Architecture:** A `ScytherDefaults` enum vends `UserDefaults.scyther` (suite `com.scyther.settings`) and runs a one-time prefix-based migration out of `UserDefaults.standard`. The hardcoded `MenuView` is refactored into a `MenuItem` / `MenuSection` data model so rows have stable identities that can be persisted as pins and rendered in two places. Feature Flags is aligned to the same "pinned rows stay in place" semantics and its list is gated behind the overrides toggle.
+
+**Tech Stack:** Swift 6 (language mode v6), SwiftUI, XCTest, iOS 16+, Swift Package Manager.
+
+## Global Constraints
+
+- **iOS only.** Never build or test for macOS. `swift build` does not work — this target requires UIKit.
+- **No simulator is currently booted.** Use the fallback destination in every build/test command: `-destination 'platform=iOS Simulator,name=iPhone 17 Pro'`. If one is booted by the time you run, prefer `-destination 'platform=iOS Simulator,id=<booted-udid>'`.
+- **Swift 6 language mode** is enforced on both targets. `UserDefaults` is `@_nonSendable(_assumed)` in the iOS SDK — this is verified, not assumed. Any global/static of type `UserDefaults` **must** be declared `nonisolated(unsafe)` or it will not compile.
+- **Minimum deployment target is iOS 16.** Use the two-parameter-free `onChange(of:) { newValue in }` form already used throughout the codebase, not the iOS 17 zero/two-parameter forms.
+- **MVVM + Repository, Separation of Concerns.** View models live in their own files. New models get their own files.
+- **DocC documentation is mandatory** on every new type, property and method, matching the density of the surrounding code (the codebase uses extensive `///` blocks with `## Features`, `## Usage`, `## Topics` sections).
+- **README must be updated** to reflect user-visible changes.
+- **Never use `.confirmationDialog`** — the project rule is alerts only. Existing `.confirmationDialog` usage in a file you are modifying should be converted to `.alert`.
+- Suite name is exactly `com.scyther.settings`. Migration key is exactly `Scyther.Defaults.DidMigrateFromStandard`. Menu pin key is exactly `Scyther.Menu.PinnedItems`. Key prefix matched for migration is `scyther`, compared case-insensitively.
+- All test files start with `#if !os(macOS)` and end with `#endif`, matching existing tests.
+
+## Deviation from the spec (already agreed, recorded here)
+
+The spec says migration enumerates `persistentDomain(forName: Bundle.main.bundleIdentifier)`. This plan uses `dictionaryRepresentation()` filtered by the `scyther` prefix instead. Reason: the prefix filter already excludes inherited global-domain keys (nothing in `NSGlobalDomain` begins with `scyther`), so the precision `persistentDomain` bought is redundant — and `persistentDomain` would force a domain-name parameter through the API purely to make it testable, plus `Bundle.main.bundleIdentifier` is optional and unreliable in a test host. The simpler signature is fully testable with throwaway suites.
+
+---
+
+## File Structure
+
+**Created:**
+
+| Path | Responsibility |
+| --- | --- |
+| `Sources/Scyther/Core/ScytherDefaults.swift` | Suite construction, key prefix, one-time migration, `UserDefaults.scyther` |
+| `Sources/Scyther/Features/UserDefaults/DefaultsStore.swift` | Enum identifying which store the browser is showing |
+| `Sources/Scyther/Features/Menu/MenuItem.swift` | Stable identity, title and icon for every menu row |
+| `Sources/Scyther/Features/Menu/MenuSection.swift` | Ordered section layout of `MenuItem`s |
+| `Tests/ScytherTests/Core/ScytherDefaultsTests.swift` | Migration behaviour |
+| `Tests/ScytherTests/Features/MenuItemTests.swift` | Identity round-tripping, titles |
+| `Tests/ScytherTests/Features/MenuViewModelTests.swift` | Section coverage, pin state, persistence |
+| `Tests/ScytherTests/Features/UserDefaultsViewModelTests.swift` | Store switching and routing |
+
+**Modified:**
+
+| Path | Change |
+| --- | --- |
+| 12 files listed in Task 2 | `UserDefaults.standard` → `UserDefaults.scyther` |
+| `Sources/Scyther/Features/UserDefaults/UserDefaultsViewModel.swift` | Store selection, store-aware CRUD and reset |
+| `Sources/Scyther/Features/UserDefaults/UserDefaultsView.swift` | Store picker, alert conversion, store-aware copy |
+| `Sources/Scyther/Features/Menu/MenuViewModel.swift` | Sections, pin state, injectable defaults |
+| `Sources/Scyther/Features/Menu/MenuView.swift` | Data-driven body, Pinned section, swipe actions |
+| `Sources/Scyther/Features/FeatureFlags/FeatureFlagsViewModel.swift` | Drop `unpinnedToggles`, injectable defaults |
+| `Sources/Scyther/Features/FeatureFlags/FeatureFlagsView.swift` | Gate on overrides, pinned rows stay in list |
+| `Tests/ScytherTests/Features/FeatureFlagsTests.swift` | Clean the Scyther suite, not standard |
+| `README.md` | "Preferences Storage" and "Pinning menu items" |
+
+---
+
+## Task 1: `ScytherDefaults` and the private suite
+
+**Files:**
+- Create: `Sources/Scyther/Core/ScytherDefaults.swift`
+- Create: `Tests/ScytherTests/Core/ScytherDefaultsTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `UserDefaults.scyther` → `UserDefaults` (public, `nonisolated(unsafe) static let`)
+  - `ScytherDefaults.suiteName` → `String` = `"com.scyther.settings"` (internal)
+  - `ScytherDefaults.keyPrefix` → `String` = `"scyther"` (internal)
+  - `ScytherDefaults.migrationKey` → `String` = `"Scyther.Defaults.DidMigrateFromStandard"` (internal)
+  - `ScytherDefaults.migrate(from: UserDefaults, to: UserDefaults)` (internal, static)
+  - `ScytherDefaults.migrateIfNeeded(from: UserDefaults, to: UserDefaults)` (internal, static)
+  - `ScytherDefaults.makeStore()` → `UserDefaults` (internal, static)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/ScytherTests/Core/ScytherDefaultsTests.swift`:
+
+```swift
+//
+//  ScytherDefaultsTests.swift
+//  ScytherTests
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+#if !os(macOS)
+@testable import Scyther
+import XCTest
+
+final class ScytherDefaultsTests: XCTestCase {
+    private let sourceSuite = "com.scyther.tests.source"
+    private let destinationSuite = "com.scyther.tests.destination"
+    private var source: UserDefaults!
+    private var destination: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        wipeSuites()
+        source = UserDefaults(suiteName: sourceSuite)
+        destination = UserDefaults(suiteName: destinationSuite)
+    }
+
+    override func tearDown() {
+        source = nil
+        destination = nil
+        wipeSuites()
+        super.tearDown()
+    }
+
+    private func wipeSuites() {
+        UserDefaults.standard.removePersistentDomain(forName: sourceSuite)
+        UserDefaults.standard.removePersistentDomain(forName: destinationSuite)
+    }
+
+    // MARK: - Constants
+
+    func testSuiteNameIsStable() {
+        XCTAssertEqual(ScytherDefaults.suiteName, "com.scyther.settings")
+    }
+
+    func testMigrationKeyIsStable() {
+        XCTAssertEqual(ScytherDefaults.migrationKey, "Scyther.Defaults.DidMigrateFromStandard")
+    }
+
+    // MARK: - migrate(from:to:)
+
+    func testMigrationCopiesPrefixedKeysToDestination() {
+        source.set(true, forKey: "Scyther_grid_overlay_enabled")
+        source.set("preset-a", forKey: "Scyther_Location_Spoofing_Route_Id")
+
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        XCTAssertTrue(destination.bool(forKey: "Scyther_grid_overlay_enabled"))
+        XCTAssertEqual(destination.string(forKey: "Scyther_Location_Spoofing_Route_Id"), "preset-a")
+    }
+
+    func testMigrationRemovesPrefixedKeysFromSource() {
+        source.set(true, forKey: "Scyther_grid_overlay_enabled")
+
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        XCTAssertNil(source.object(forKey: "Scyther_grid_overlay_enabled"))
+    }
+
+    func testMigrationIgnoresKeysWithoutThePrefix() {
+        source.set("hunter2", forKey: "user_session_token")
+
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        XCTAssertEqual(source.string(forKey: "user_session_token"), "hunter2")
+        XCTAssertNil(destination.object(forKey: "user_session_token"))
+    }
+
+    func testMigrationMatchesPrefixCaseInsensitively() {
+        source.set(1, forKey: "scyther.servers.currentId")
+        source.set(2, forKey: "SCYTHER_shouting_key")
+
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        XCTAssertEqual(destination.integer(forKey: "scyther.servers.currentId"), 1)
+        XCTAssertEqual(destination.integer(forKey: "SCYTHER_shouting_key"), 2)
+    }
+
+    func testMigrationNeverOverwritesAnExistingDestinationValue() {
+        source.set("stale", forKey: "Scyther_appearance_color_scheme")
+        destination.set("fresh", forKey: "Scyther_appearance_color_scheme")
+
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        XCTAssertEqual(destination.string(forKey: "Scyther_appearance_color_scheme"), "fresh")
+        XCTAssertNil(source.object(forKey: "Scyther_appearance_color_scheme"))
+    }
+
+    func testMigrationIsIdempotent() {
+        source.set(true, forKey: "Scyther_fps_counter_enabled")
+
+        ScytherDefaults.migrate(from: source, to: destination)
+        destination.set(false, forKey: "Scyther_fps_counter_enabled")
+        ScytherDefaults.migrate(from: source, to: destination)
+
+        XCTAssertFalse(destination.bool(forKey: "Scyther_fps_counter_enabled"))
+    }
+
+    // MARK: - migrateIfNeeded(from:to:)
+
+    func testMigrateIfNeededSetsTheMigrationFlag() {
+        ScytherDefaults.migrateIfNeeded(from: source, to: destination)
+
+        XCTAssertTrue(destination.bool(forKey: ScytherDefaults.migrationKey))
+    }
+
+    func testMigrateIfNeededRunsOnlyOnce() {
+        ScytherDefaults.migrateIfNeeded(from: source, to: destination)
+
+        // Seed the source *after* the first run. A second call must not pick it up.
+        source.set(true, forKey: "Scyther_grid_overlay_enabled")
+        ScytherDefaults.migrateIfNeeded(from: source, to: destination)
+
+        XCTAssertNil(destination.object(forKey: "Scyther_grid_overlay_enabled"))
+        XCTAssertTrue(source.bool(forKey: "Scyther_grid_overlay_enabled"))
+    }
+
+    // MARK: - Store
+
+    func testScytherStoreIsNotTheStandardStore() {
+        XCTAssertFalse(UserDefaults.scyther === UserDefaults.standard)
+    }
+
+    func testScytherStoreWritesAreInvisibleToStandard() {
+        let key = "Scyther_isolation_probe"
+        UserDefaults.scyther.set(true, forKey: key)
+        defer { UserDefaults.scyther.removeObject(forKey: key) }
+
+        XCTAssertTrue(UserDefaults.scyther.bool(forKey: key))
+        XCTAssertNil(UserDefaults.standard.persistentDomain(forName: Bundle.main.bundleIdentifier ?? "")?[key])
+    }
+}
+#endif
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:ScytherTests/ScytherDefaultsTests
+```
+
+Expected: **compile failure**, `cannot find 'ScytherDefaults' in scope` and `type 'UserDefaults' has no member 'scyther'`. That is the correct failure at this stage.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/Scyther/Core/ScytherDefaults.swift`:
+
+```swift
+//
+//  ScytherDefaults.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+import Foundation
+
+/// Scyther's private preferences store.
+///
+/// Every setting, override and preference Scyther persists is written here rather than to
+/// `UserDefaults.standard`, so that a host app clearing its own defaults does not destroy
+/// Scyther's state.
+///
+/// ## Why a separate suite
+///
+/// Apps commonly wipe their preferences when a user signs out, using either of:
+///
+/// ```swift
+/// UserDefaults.standard.dictionaryRepresentation().keys
+///     .forEach(UserDefaults.standard.removeObject(forKey:))
+///
+/// UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+/// ```
+///
+/// Both operate on the **application domain** only. A named suite is a separate persistent
+/// domain, so neither touches it. On iOS the suite is written to
+/// `<container>/Library/Preferences/com.scyther.settings.plist`, inside the app's own
+/// sandbox — a fixed suite name therefore carries no cross-app collision risk.
+///
+/// ## Migration
+///
+/// Earlier versions of Scyther wrote to `UserDefaults.standard`. The first time
+/// ``UserDefaults/scyther`` is accessed, ``migrateIfNeeded(from:to:)`` moves every key
+/// prefixed `scyther` (compared case-insensitively) into the suite and removes it from the
+/// standard store, so existing overrides, pins and spoofed locations survive the upgrade.
+///
+/// ## Topics
+///
+/// ### Configuration
+/// - ``suiteName``
+/// - ``keyPrefix``
+/// - ``migrationKey``
+///
+/// ### Migration
+/// - ``migrate(from:to:)``
+/// - ``migrateIfNeeded(from:to:)``
+///
+/// ### Construction
+/// - ``makeStore()``
+internal enum ScytherDefaults {
+    /// The name of the `UserDefaults` suite backing ``UserDefaults/scyther``.
+    static let suiteName = "com.scyther.settings"
+
+    /// The prefix every Scyther-owned defaults key carries, compared case-insensitively.
+    ///
+    /// Scyther's keys are consistently namespaced (`Scyther_*`, `Scyther.*`, `scyther.*`),
+    /// which makes this a safe predicate for deciding what belongs to Scyther during
+    /// migration.
+    static let keyPrefix = "scyther"
+
+    /// The key recording that the one-time migration out of `UserDefaults.standard` has run.
+    ///
+    /// Stored in the destination suite so that clearing the standard store can never cause
+    /// the migration to run a second time.
+    static let migrationKey = "Scyther.Defaults.DidMigrateFromStandard"
+
+    /// Builds the Scyther preferences store and runs the one-time migration.
+    ///
+    /// - Returns: The `com.scyther.settings` suite, or `UserDefaults.standard` if the suite
+    ///   could not be created. Falling back keeps Scyther functional rather than trapping;
+    ///   the only consequence is the loss of isolation.
+    static func makeStore() -> UserDefaults {
+        guard let store = UserDefaults(suiteName: suiteName) else {
+            return .standard
+        }
+        migrateIfNeeded(from: .standard, to: store)
+        return store
+    }
+
+    /// Runs ``migrate(from:to:)`` once, then records that it has happened.
+    ///
+    /// Subsequent calls return immediately. This guard lives here rather than inside
+    /// ``migrate(from:to:)`` so the migration itself stays a pure, directly testable
+    /// operation.
+    ///
+    /// - Parameters:
+    ///   - source: The store to migrate legacy keys out of.
+    ///   - destination: The store to migrate legacy keys into, and where the completion
+    ///     flag is recorded.
+    static func migrateIfNeeded(from source: UserDefaults, to destination: UserDefaults) {
+        guard !destination.bool(forKey: migrationKey) else { return }
+        migrate(from: source, to: destination)
+        destination.set(true, forKey: migrationKey)
+    }
+
+    /// Moves every ``keyPrefix``-prefixed key from one store to another.
+    ///
+    /// A key already present in `destination` is left alone — newer state is never
+    /// clobbered by a stale value — but is still removed from `source`, so the migration
+    /// always leaves the source clean.
+    ///
+    /// - Parameters:
+    ///   - source: The store to read from and remove keys from.
+    ///   - destination: The store to write keys into.
+    ///
+    /// - Note: `dictionaryRepresentation()` also returns inherited global-domain keys. That
+    ///   is harmless here because no `NSGlobalDomain` key carries the `scyther` prefix, so
+    ///   the filter excludes them.
+    static func migrate(from source: UserDefaults, to destination: UserDefaults) {
+        let legacyKeys = source.dictionaryRepresentation().keys
+            .filter { $0.lowercased().hasPrefix(keyPrefix) }
+
+        for key in legacyKeys {
+            if destination.object(forKey: key) == nil {
+                destination.set(source.object(forKey: key), forKey: key)
+            }
+            source.removeObject(forKey: key)
+        }
+    }
+}
+
+public extension UserDefaults {
+    /// Scyther's private preferences store, isolated from `UserDefaults.standard`.
+    ///
+    /// Backed by the `com.scyther.settings` suite. Host apps that clear their standard
+    /// defaults — a common sign-out behaviour — leave this store untouched, so feature flag
+    /// overrides, pinned items, spoofed locations and every other Scyther setting persist.
+    ///
+    /// On first access, any Scyther keys left behind in `UserDefaults.standard` by an
+    /// earlier version are migrated across automatically.
+    ///
+    /// ```swift
+    /// UserDefaults.scyther.set(true, forKey: "Scyther_grid_overlay_enabled")
+    /// ```
+    ///
+    /// - Note: Declared `nonisolated(unsafe)` because the iOS SDK marks `UserDefaults` as
+    ///   non-`Sendable`. `UserDefaults` is documented as thread-safe, and this property is
+    ///   an immutable `let`, so unsynchronised access from any actor is safe. This mirrors
+    ///   the `nonisolated` accessors already used across Scyther to avoid main-actor hops.
+    nonisolated(unsafe) static let scyther: UserDefaults = ScytherDefaults.makeStore()
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:ScytherTests/ScytherDefaultsTests
+```
+
+Expected: `** TEST SUCCEEDED **`, 12 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Scyther/Core/ScytherDefaults.swift Tests/ScytherTests/Core/ScytherDefaultsTests.swift
+git commit -m "Add private UserDefaults suite with one-time migration from standard"
+```
+
+---
+
+## Task 2: Point every Scyther call site at the new suite
+
+**Files:**
+- Modify (mechanical replacement of `UserDefaults.standard` → `UserDefaults.scyther`):
+  - `Sources/Scyther/Features/LocationSpoofer/LocationSpoofer.swift` (23)
+  - `Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift` (10)
+  - `Sources/Scyther/Features/GridOverlay/GridOverlay.swift` (8)
+  - `Sources/Scyther/Core/InterfaceToolkit.swift` (8)
+  - `Sources/Scyther/Features/TouchVisualiser/TouchVisualiserConfiguration.swift` (6)
+  - `Sources/Scyther/Core/Scyther.swift` (5)
+  - `Sources/Scyther/Features/FPSCounter/FPSCounter.swift` (4)
+  - `Sources/Scyther/Features/FeatureFlags/FeatureToggle.swift` (4)
+  - `Sources/Scyther/Features/DeepLinkTester/DeepLinkTester.swift` (4)
+  - `Sources/Scyther/Features/CrashLogs/CrashLogger.swift` (4)
+  - `Sources/Scyther/Features/FeatureFlags/FeatureFlagsViewModel.swift` (2)
+  - `Sources/Scyther/Core/UIView+InterfaceToolkit.swift` (2)
+- Modify: `Tests/ScytherTests/Features/FeatureFlagsTests.swift`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: `UserDefaults.scyther` from Task 1.
+- Produces: no new API. After this task, no Scyther-owned value is written to `UserDefaults.standard`.
+
+**Do NOT change these two files** — their `UserDefaults.standard` references are correct:
+- `Sources/Scyther/Shared/Extensions/UserDefaults+Extensions.swift` — `stringStringDictionaryRepresentation` is a display helper called against whichever store the browser is showing.
+- `Sources/Scyther/Features/CookieBrowser/CookieDetailsViewModel.swift` — its `synchronize()` flushes `HTTPCookieStorage`, unrelated to Scyther settings.
+
+- [ ] **Step 1: Perform the replacement**
+
+Every occurrence in these 12 files is a real code reference — none appear inside doc comments — so a blanket replacement is safe:
+
+```bash
+for f in \
+  Sources/Scyther/Features/LocationSpoofer/LocationSpoofer.swift \
+  Sources/Scyther/Features/AppearanceOverrides/AppearanceOverrides.swift \
+  Sources/Scyther/Features/GridOverlay/GridOverlay.swift \
+  Sources/Scyther/Core/InterfaceToolkit.swift \
+  Sources/Scyther/Features/TouchVisualiser/TouchVisualiserConfiguration.swift \
+  Sources/Scyther/Core/Scyther.swift \
+  Sources/Scyther/Features/FPSCounter/FPSCounter.swift \
+  Sources/Scyther/Features/FeatureFlags/FeatureToggle.swift \
+  Sources/Scyther/Features/DeepLinkTester/DeepLinkTester.swift \
+  Sources/Scyther/Features/CrashLogs/CrashLogger.swift \
+  Sources/Scyther/Features/FeatureFlags/FeatureFlagsViewModel.swift \
+  Sources/Scyther/Core/UIView+InterfaceToolkit.swift ; do
+  sed -i '' 's/UserDefaults\.standard/UserDefaults.scyther/g' "$f"
+done
+```
+
+- [ ] **Step 2: Verify the replacement is complete and correctly scoped**
+
+```bash
+grep -rn "UserDefaults.standard" --include="*.swift" Sources/
+```
+
+Expected: exactly two results, one in `Shared/Extensions/UserDefaults+Extensions.swift` and one in `Features/CookieBrowser/CookieDetailsViewModel.swift`. Any other result is a miss — fix it before continuing.
+
+- [ ] **Step 3: Update the doc comments that now name the wrong store**
+
+Several `///` blocks say "persisted to `UserDefaults`" or "stored in `UserDefaults.standard`". Update any that specifically name `UserDefaults.standard` to name `UserDefaults.scyther` instead:
+
+```bash
+grep -rn "UserDefaults.standard\|UserDefaults\`" --include="*.swift" Sources/Scyther/Features Sources/Scyther/Core | grep "///"
+```
+
+For each hit in the 12 migrated files, reword to reference Scyther's private store, e.g. in `Sources/Scyther/Core/Scyther.swift`:
+
+```swift
+/// This value is persisted across app launches in ``UserDefaults/scyther``, Scyther's
+/// private preferences suite, so it survives the host app clearing its own defaults.
+```
+
+- [ ] **Step 4: Fix the Feature Flags test fixture, which still cleans the wrong store**
+
+`Tests/ScytherTests/Features/FeatureFlagsTests.swift` currently wipes `UserDefaults.standard` in `setUp`/`tearDown`, and seeds values there. Since `FeatureToggle` and `FeatureFlags` now read the suite, every one of these tests would break. Replace `cleanupUserDefaults()` and every `UserDefaults.standard` reference in this file:
+
+```swift
+    private func cleanupUserDefaults() {
+        let defaults = UserDefaults.scyther
+        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix("Scyther_toggler_local_value_") {
+            defaults.removeObject(forKey: key)
+        }
+        defaults.removeObject(forKey: FeatureFlags.overridesEnabledKey)
+    }
+```
+
+Then apply the same replacement to the seeding calls in the test bodies:
+
+```bash
+sed -i '' 's/UserDefaults\.standard/UserDefaults.scyther/g' Tests/ScytherTests/Features/FeatureFlagsTests.swift
+```
+
+- [ ] **Step 5: Build and run the full test suite**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `** TEST SUCCEEDED **`. If `FeatureFlagsTests` fails, a `UserDefaults.standard` reference was missed in Step 4.
+
+- [ ] **Step 6: Document the new storage in the README**
+
+Add a top-level `## Preferences Storage` section to `README.md`, placed after `## Swift 6 Compatibility` and before `## Installation`, and add a matching entry to the Table of Contents:
+
+```markdown
+## Preferences Storage
+
+Scyther never writes to `UserDefaults.standard`. Every setting it persists — feature flag
+overrides, pinned menu items, spoofed locations, grid overlay configuration, appearance
+overrides and the rest — lives in a private suite named `com.scyther.settings`.
+
+This matters because apps commonly clear their own defaults when a user signs out:
+
+```swift
+// Both of these wipe the application domain only.
+UserDefaults.standard.dictionaryRepresentation().keys
+    .forEach(UserDefaults.standard.removeObject(forKey:))
+
+UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+```
+
+A named suite is a separate persistent domain, so neither call touches Scyther's state.
+Your debugging setup survives sign-out.
+
+The store is exposed if you need it directly:
+
+```swift
+UserDefaults.scyther.bool(forKey: "Scyther_grid_overlay_enabled")
+```
+
+### Migration from earlier versions
+
+Versions before this change stored settings in `UserDefaults.standard`. The first time
+Scyther's store is accessed it moves every key prefixed `scyther` (case-insensitive) out of
+the standard store and into the suite, skipping any key the suite already has a value for,
+then records that it has done so. Existing overrides and preferences carry across
+automatically, and your app's standard domain is left cleaner than it was.
+
+You can inspect and edit the suite from **Data → UserDefaults**, using the store picker at
+the top of the screen.
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A Sources/ Tests/ README.md
+git commit -m "Store all Scyther settings in the private preferences suite"
+```
+
+---
+
+## Task 3: UserDefaults browser store picker
+
+**Files:**
+- Create: `Sources/Scyther/Features/UserDefaults/DefaultsStore.swift`
+- Create: `Tests/ScytherTests/Features/UserDefaultsViewModelTests.swift`
+- Modify: `Sources/Scyther/Features/UserDefaults/UserDefaultsViewModel.swift`
+- Modify: `Sources/Scyther/Features/UserDefaults/UserDefaultsView.swift`
+
+**Interfaces:**
+- Consumes: `ScytherDefaults.suiteName`, `ScytherDefaults.keyPrefix`, `UserDefaults.scyther`.
+- Produces:
+  - `DefaultsStore` enum, cases `.app` and `.scyther`, conforming to `String, CaseIterable, Identifiable, Sendable`, with `var title: String` and `var defaults: UserDefaults`
+  - `UserDefaultsViewModel.store` → `@Published var store: DefaultsStore`
+  - `UserDefaultsViewModel.init(store: DefaultsStore = .app)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/ScytherTests/Features/UserDefaultsViewModelTests.swift`:
+
+```swift
+//
+//  UserDefaultsViewModelTests.swift
+//  ScytherTests
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+#if !os(macOS)
+@testable import Scyther
+import XCTest
+
+@MainActor
+final class UserDefaultsViewModelTests: XCTestCase {
+    private let appKey = "scyther_tests_app_only_key"
+    private let scytherKey = "Scyther_tests_suite_only_key"
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: appKey)
+        UserDefaults.scyther.removeObject(forKey: scytherKey)
+        super.tearDown()
+    }
+
+    func testAppStoreResolvesToStandard() {
+        XCTAssertTrue(DefaultsStore.app.defaults === UserDefaults.standard)
+    }
+
+    func testScytherStoreResolvesToTheSuite() {
+        XCTAssertTrue(DefaultsStore.scyther.defaults === UserDefaults.scyther)
+    }
+
+    func testEveryStoreHasATitle() {
+        for store in DefaultsStore.allCases {
+            XCTAssertFalse(store.title.isEmpty, "\(store) has no title")
+        }
+    }
+
+    func testAppStoreLoadsKeysFromStandard() async {
+        UserDefaults.standard.set("app", forKey: appKey)
+
+        let viewModel = UserDefaultsViewModel(store: .app)
+        await viewModel.loadDefaults()
+
+        XCTAssertTrue(viewModel.keyValues.contains { $0.key == appKey })
+    }
+
+    func testScytherStoreLoadsKeysFromTheSuite() async {
+        UserDefaults.scyther.set("suite", forKey: scytherKey)
+
+        let viewModel = UserDefaultsViewModel(store: .scyther)
+        await viewModel.loadDefaults()
+
+        XCTAssertTrue(viewModel.keyValues.contains { $0.key == scytherKey })
+    }
+
+    func testScytherStoreDoesNotLeakStandardKeys() async {
+        UserDefaults.standard.set("app", forKey: appKey)
+
+        let viewModel = UserDefaultsViewModel(store: .scyther)
+        await viewModel.loadDefaults()
+
+        XCTAssertFalse(viewModel.keyValues.contains { $0.key == appKey })
+    }
+
+    func testScytherStoreExcludesGlobalDomainKeys() async {
+        // AppleLanguages is inherited from NSGlobalDomain. Reading the suite via its
+        // persistent domain must not surface it.
+        let viewModel = UserDefaultsViewModel(store: .scyther)
+        await viewModel.loadDefaults()
+
+        XCTAssertFalse(viewModel.keyValues.contains { $0.key == "AppleLanguages" })
+    }
+
+    func testWritesRouteToTheSelectedStore() async {
+        let viewModel = UserDefaultsViewModel(store: .scyther)
+        viewModel.updateValue("written", forKey: scytherKey)
+
+        XCTAssertEqual(UserDefaults.scyther.string(forKey: scytherKey), "written")
+        XCTAssertNil(UserDefaults.standard.string(forKey: scytherKey))
+    }
+
+    func testDeletesRouteToTheSelectedStore() async {
+        UserDefaults.scyther.set("doomed", forKey: scytherKey)
+
+        let viewModel = UserDefaultsViewModel(store: .scyther)
+        await viewModel.loadDefaults()
+        viewModel.deleteKey(scytherKey)
+
+        XCTAssertNil(UserDefaults.scyther.object(forKey: scytherKey))
+        XCTAssertFalse(viewModel.keyValues.contains { $0.key == scytherKey })
+    }
+}
+#endif
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:ScytherTests/UserDefaultsViewModelTests
+```
+
+Expected: **compile failure**, `cannot find type 'DefaultsStore' in scope`.
+
+- [ ] **Step 3: Create `DefaultsStore`**
+
+Create `Sources/Scyther/Features/UserDefaults/DefaultsStore.swift`:
+
+```swift
+//
+//  DefaultsStore.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+import Foundation
+
+/// Identifies which `UserDefaults` store the UserDefaults browser is inspecting.
+///
+/// Scyther keeps its own settings in a private suite rather than the standard store, so the
+/// browser needs to be able to show either one.
+///
+/// ## Topics
+///
+/// ### Cases
+/// - ``app``
+/// - ``scyther``
+///
+/// ### Properties
+/// - ``title``
+/// - ``defaults``
+enum DefaultsStore: String, CaseIterable, Identifiable, Sendable {
+    /// The host application's own defaults — `UserDefaults.standard`.
+    case app
+
+    /// Scyther's private preferences suite — ``UserDefaults/scyther``.
+    case scyther
+
+    /// Stable identifier, used for `Picker` selection and `ForEach`.
+    var id: String { rawValue }
+
+    /// The human-readable name shown in the store picker.
+    var title: String {
+        switch self {
+        case .app: return "App"
+        case .scyther: return "Scyther"
+        }
+    }
+
+    /// The underlying store this case refers to.
+    var defaults: UserDefaults {
+        switch self {
+        case .app: return .standard
+        case .scyther: return .scyther
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Make the view model store-aware**
+
+In `Sources/Scyther/Features/UserDefaults/UserDefaultsViewModel.swift`, add the `store` property and an initialiser above `keyValues`:
+
+```swift
+    /// The store currently being browsed.
+    ///
+    /// Changing this reloads ``keyValues`` from the newly selected store.
+    @Published var store: DefaultsStore {
+        didSet {
+            guard oldValue != store else { return }
+            Task { await loadDefaults() }
+        }
+    }
+
+    /// Creates a view model browsing the given store.
+    ///
+    /// - Parameter store: The store to browse. Defaults to the host app's own defaults.
+    init(store: DefaultsStore = .app) {
+        self.store = store
+        super.init()
+    }
+```
+
+Replace `loadDefaults()` so `.scyther` reads the suite's persistent domain — `dictionaryRepresentation()` on a suite also returns inherited global-domain keys, which are not Scyther's and must not be shown or edited here:
+
+```swift
+    /// Loads all entries from the currently selected store.
+    ///
+    /// The application store is read via `dictionaryRepresentation()`, matching what the app
+    /// itself sees. Scyther's suite is read via `persistentDomain(forName:)` so only keys
+    /// actually written to the suite appear, without inherited global-domain noise.
+    func loadDefaults() async {
+        let entries: [String: Any]
+        switch store {
+        case .app:
+            entries = UserDefaults.standard.dictionaryRepresentation()
+        case .scyther:
+            entries = UserDefaults.standard.persistentDomain(forName: ScytherDefaults.suiteName) ?? [:]
+        }
+
+        keyValues = entries
+            .sorted { $0.key.lowercased() < $1.key.lowercased() }
+            .map { key, value in
+                let valueType = Self.detectValueType(value)
+                let displayValue = Self.displayString(for: value)
+                return UserDefaultItem(key: key, rawValue: value, valueType: valueType, displayValue: displayValue)
+            }
+    }
+```
+
+Route the three mutating paths through `store.defaults`:
+
+```swift
+    func boolBinding(for key: String, currentValue: Bool) -> Binding<Bool> {
+        Binding(
+            get: { [weak self] in
+                // Read through `self` rather than capturing `store` by value, so the binding
+                // always reflects the currently selected store.
+                self?.store.defaults.bool(forKey: key) ?? currentValue
+            },
+            set: { [weak self] newValue in
+                guard let self else { return }
+                self.store.defaults.set(newValue, forKey: key)
+                Task { @MainActor in
+                    await self.loadDefaults()
+                }
+            }
+        )
+    }
+
+    func updateValue(_ value: Any, forKey key: String) {
+        store.defaults.set(value, forKey: key)
+        Task {
+            await loadDefaults()
+        }
+    }
+
+    func deleteKey(_ key: String) {
+        store.defaults.removeObject(forKey: key)
+        keyValues.removeAll { $0.key == key }
+    }
+```
+
+Make the reset store-aware:
+
+```swift
+    /// Clears the currently selected store.
+    ///
+    /// For ``DefaultsStore/app`` this removes every key the host app created, keeping the
+    /// `scyther` prefix filter as a safety net for any value an older Scyther left behind
+    /// before migration. For ``DefaultsStore/scyther`` the entire suite is removed, which
+    /// resets every Scyther setting including pinned items and feature flag overrides.
+    ///
+    /// > Warning: This action cannot be undone.
+    func resetAllDefaults() {
+        switch store {
+        case .app:
+            UserDefaults.standard.dictionaryRepresentation().keys
+                .filter { !$0.lowercased().hasPrefix(ScytherDefaults.keyPrefix) }
+                .forEach(UserDefaults.standard.removeObject(forKey:))
+            UserDefaults.standard.synchronize()
+
+        case .scyther:
+            UserDefaults.standard.removePersistentDomain(forName: ScytherDefaults.suiteName)
+        }
+
+        Task {
+            await loadDefaults()
+        }
+    }
+```
+
+Add `DefaultsStore` and `resetAllDefaults()` notes to the type's existing `## Topics` block so the DocC page stays accurate:
+
+```swift
+/// ### Store Selection
+/// - ``store``
+```
+
+- [ ] **Step 5: Run the tests and verify they pass**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:ScytherTests/UserDefaultsViewModelTests
+```
+
+Expected: `** TEST SUCCEEDED **`, 9 tests passing.
+
+- [ ] **Step 6: Add the picker to the view and convert the confirmation dialog to an alert**
+
+In `Sources/Scyther/Features/UserDefaults/UserDefaultsView.swift`, add a store picker as the first section of the `List`, above `Section("Key/Values")`:
+
+```swift
+            Section {
+                Picker("Store", selection: $viewModel.store) {
+                    ForEach(DefaultsStore.allCases) { store in
+                        Text(store.title).tag(store)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+            } footer: {
+                Text(viewModel.store == .app
+                     ? "Values your app stored in UserDefaults.standard."
+                     : "Values Scyther stored in its private com.scyther.settings suite.")
+            }
+```
+
+Make the reset button and its footer reflect the selected store:
+
+```swift
+            if debouncedSearchText.isEmpty {
+                Section {
+                    Button(
+                        viewModel.store == .app ? "Reset UserDefaults.standard" : "Reset all Scyther settings",
+                        role: .destructive
+                    ) {
+                        showingResetConfirmation = true
+                    }
+                } footer: {
+                    Text(viewModel.store == .app
+                         ? "This will delete all values stored inside `UserDefaults.standard`, created by your app. Scyther's own settings live in a separate store and are not affected."
+                         : "This will delete every setting Scyther has stored, including pinned menu items and feature flag overrides.")
+                }
+            }
+```
+
+Replace the `.confirmationDialog` block entirely — the project rule is alerts only:
+
+```swift
+        .alert("Reset UserDefaults?", isPresented: $showingResetConfirmation) {
+            Button("Reset All", role: .destructive) {
+                viewModel.resetAllDefaults()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(viewModel.store == .app
+                 ? "This will permanently delete your app's stored values. This action cannot be undone."
+                 : "This will permanently delete every Scyther setting, including pinned menu items and feature flag overrides. This action cannot be undone.")
+        }
+```
+
+Update the view's DocC comment, which currently says "resetting all non-Scyther values":
+
+```swift
+/// - Switching between the host app's defaults and Scyther's private suite
+/// - Deleting individual entries or resetting the selected store
+```
+
+- [ ] **Step 7: Build and run the full suite**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/Scyther/Features/UserDefaults/ Tests/ScytherTests/Features/UserDefaultsViewModelTests.swift
+git commit -m "Add store picker to the UserDefaults browser"
+```
+
+---
+
+## Task 4: `MenuItem`
+
+**Files:**
+- Create: `Sources/Scyther/Features/Menu/MenuItem.swift`
+- Create: `Tests/ScytherTests/Features/MenuItemTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `enum MenuItem: Hashable, Identifiable` with 39 static cases plus `case developerOption(name: String)`
+  - `MenuItem.id` → `String`
+  - `MenuItem.init?(id: String)`
+  - `MenuItem.title` → `String`
+  - `MenuItem.icon` → `String?` (SF Symbol name, `nil` for rows that show no icon)
+  - `MenuItem.pinnedRowID` → `String`
+  - `MenuItem.allStaticCases` → `[MenuItem]`
+  - `MenuItem.developerOptionPrefix` → `String` = `"developerOption."`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/ScytherTests/Features/MenuItemTests.swift`:
+
+```swift
+//
+//  MenuItemTests.swift
+//  ScytherTests
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+#if !os(macOS)
+@testable import Scyther
+import XCTest
+
+final class MenuItemTests: XCTestCase {
+
+    // MARK: - Identity
+
+    func testAllStaticCaseIdentifiersAreUnique() {
+        let ids = MenuItem.allStaticCases.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "Two menu items share an identifier")
+    }
+
+    func testAllStaticCaseIdentifiersAreNonEmpty() {
+        for item in MenuItem.allStaticCases {
+            XCTAssertFalse(item.id.isEmpty, "\(item) has an empty identifier")
+        }
+    }
+
+    func testEveryStaticCaseRoundTripsThroughItsIdentifier() {
+        for item in MenuItem.allStaticCases {
+            XCTAssertEqual(MenuItem(id: item.id), item, "\(item) did not round-trip")
+        }
+    }
+
+    func testDeveloperOptionRoundTrips() {
+        let item = MenuItem.developerOption(name: "Reset Onboarding")
+        XCTAssertEqual(MenuItem(id: item.id), item)
+    }
+
+    func testDeveloperOptionRoundTripsWithAwkwardNames() {
+        let names = ["A.B.C", "has spaces", "emoji 🚀", "developerOption.nested"]
+        for name in names {
+            let item = MenuItem.developerOption(name: name)
+            XCTAssertEqual(MenuItem(id: item.id), item, "\(name) did not round-trip")
+        }
+    }
+
+    func testDeveloperOptionIdentifierIsNamespaced() {
+        XCTAssertEqual(MenuItem.developerOption(name: "Panel").id, "developerOption.Panel")
+    }
+
+    func testUnknownIdentifierReturnsNil() {
+        XCTAssertNil(MenuItem(id: "somethingThatWasRemovedInV2"))
+    }
+
+    func testEmptyDeveloperOptionNameReturnsNil() {
+        XCTAssertNil(MenuItem(id: "developerOption."))
+    }
+
+    func testPinnedRowIdentifierIsDistinctFromTheIdentifier() {
+        let item = MenuItem.featureFlags
+        XCTAssertNotEqual(item.pinnedRowID, item.id)
+        XCTAssertTrue(item.pinnedRowID.hasSuffix(item.id))
+    }
+
+    // MARK: - Presentation
+
+    func testEveryStaticCaseHasANonEmptyTitle() {
+        for item in MenuItem.allStaticCases {
+            XCTAssertFalse(item.title.isEmpty, "\(item) has no title")
+        }
+    }
+
+    func testDeveloperOptionTitleIsItsName() {
+        XCTAssertEqual(MenuItem.developerOption(name: "Reset Onboarding").title, "Reset Onboarding")
+    }
+
+    func testNavigationItemsCarryAnIcon() {
+        let navigationItems: [MenuItem] = [
+            .networkLogs, .serverConfiguration, .environmentVariables, .featureFlags,
+            .userDefaults, .cookies, .fileBrowser, .databaseBrowser, .keychainBrowser,
+            .locationSpoofer, .consoleLogs, .deepLinkTester, .crashLogs,
+            .notificationLogger, .notificationTester, .fonts, .interfaceComponents,
+            .gridOverlay, .fpsCounter, .touchVisualiser, .appearance
+        ]
+        for item in navigationItems {
+            XCTAssertNotNil(item.icon, "\(item) should have an icon")
+        }
+    }
+
+    func testDeviceAndApplicationInfoItemsHaveNoIcon() {
+        let infoItems: [MenuItem] = [
+            .osVersion, .hardware, .releaseYear, .uuid,
+            .appIdPrefix, .displayName, .bundleId, .processId,
+            .version, .buildNumber, .buildDate, .releaseType
+        ]
+        for item in infoItems {
+            XCTAssertNil(item.icon, "\(item) should not have an icon")
+        }
+    }
+
+    func testStaticCaseCountIsStable() {
+        XCTAssertEqual(MenuItem.allStaticCases.count, 39)
+    }
+}
+#endif
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:ScytherTests/MenuItemTests
+```
+
+Expected: **compile failure**, `cannot find type 'MenuItem' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/Scyther/Features/Menu/MenuItem.swift`:
+
+```swift
+//
+//  MenuItem.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+import Foundation
+
+/// A single row in the Scyther main menu.
+///
+/// Giving every row a stable identity is what makes pinning possible: an identifier can be
+/// persisted, and the same case can be rendered both in its home section and in the "Pinned"
+/// section without duplicating its definition.
+///
+/// ## Features
+///
+/// - Stable, persistable ``id`` for every row
+/// - Lossless round-tripping via ``init(id:)``, returning `nil` for rows that no longer exist
+/// - Single source of truth for each row's ``title`` and ``icon``
+/// - Support for host-supplied rows via ``developerOption(name:)``
+///
+/// ## Usage
+///
+/// ```swift
+/// let item = MenuItem.featureFlags
+/// item.id       // "featureFlags"
+/// item.title    // "Feature Flags"
+/// item.icon     // "flag"
+///
+/// MenuItem(id: "featureFlags")   // .featureFlags
+/// MenuItem(id: "removedInV2")    // nil
+/// ```
+///
+/// ## Implementation Details
+///
+/// Dynamic values — a value row's description, a navigation row's destination, a toggle
+/// row's binding — deliberately live in ``MenuView`` rather than here. This type owns only
+/// what is stable across renders.
+///
+/// The device header shown at the top of the menu is not a `MenuItem`; it is a plain header
+/// view and is not pinnable.
+///
+/// ## Topics
+///
+/// ### Identity
+/// - ``id``
+/// - ``init(id:)``
+/// - ``pinnedRowID``
+/// - ``allStaticCases``
+///
+/// ### Presentation
+/// - ``title``
+/// - ``icon``
+enum MenuItem: Hashable, Identifiable {
+    // Device
+    case osVersion, hardware, releaseYear, uuid
+
+    // Application
+    case appIdPrefix, displayName, bundleId, processId
+    case version, buildNumber, buildDate, releaseType
+
+    // Development Tools
+    case developerOption(name: String)
+
+    // Networking
+    case ipAddress, networkLogs, serverConfiguration, environmentVariables
+
+    // Data
+    case featureFlags, userDefaults, cookies, fileBrowser, databaseBrowser
+
+    // Security
+    case keychainBrowser
+
+    // System Tools
+    case locationSpoofer, consoleLogs, deepLinkTester, crashLogs
+
+    // Notifications
+    case notificationLogger, notificationTester, apnsToken, fcmToken
+
+    // UI/UX
+    case fonts, interfaceComponents, gridOverlay, fpsCounter
+    case touchVisualiser, appearance
+    case slowAnimations, showViewFrames, showViewSizes
+
+    /// The identifier prefix distinguishing host-supplied rows from built-in ones.
+    static let developerOptionPrefix = "developerOption."
+
+    /// Every built-in row, in menu order.
+    ///
+    /// Excludes ``developerOption(name:)``, which is supplied at runtime by the host app via
+    /// `Scyther.developerOptions`.
+    static let allStaticCases: [MenuItem] = [
+        .osVersion, .hardware, .releaseYear, .uuid,
+        .appIdPrefix, .displayName, .bundleId, .processId,
+        .version, .buildNumber, .buildDate, .releaseType,
+        .ipAddress, .networkLogs, .serverConfiguration, .environmentVariables,
+        .featureFlags, .userDefaults, .cookies, .fileBrowser, .databaseBrowser,
+        .keychainBrowser,
+        .locationSpoofer, .consoleLogs, .deepLinkTester, .crashLogs,
+        .notificationLogger, .notificationTester, .apnsToken, .fcmToken,
+        .fonts, .interfaceComponents, .gridOverlay, .fpsCounter,
+        .touchVisualiser, .appearance,
+        .slowAnimations, .showViewFrames, .showViewSizes
+    ]
+
+    /// A stable identifier, safe to persist across app launches and Scyther versions.
+    var id: String {
+        switch self {
+        case .osVersion: return "osVersion"
+        case .hardware: return "hardware"
+        case .releaseYear: return "releaseYear"
+        case .uuid: return "uuid"
+        case .appIdPrefix: return "appIdPrefix"
+        case .displayName: return "displayName"
+        case .bundleId: return "bundleId"
+        case .processId: return "processId"
+        case .version: return "version"
+        case .buildNumber: return "buildNumber"
+        case .buildDate: return "buildDate"
+        case .releaseType: return "releaseType"
+        case .developerOption(let name): return Self.developerOptionPrefix + name
+        case .ipAddress: return "ipAddress"
+        case .networkLogs: return "networkLogs"
+        case .serverConfiguration: return "serverConfiguration"
+        case .environmentVariables: return "environmentVariables"
+        case .featureFlags: return "featureFlags"
+        case .userDefaults: return "userDefaults"
+        case .cookies: return "cookies"
+        case .fileBrowser: return "fileBrowser"
+        case .databaseBrowser: return "databaseBrowser"
+        case .keychainBrowser: return "keychainBrowser"
+        case .locationSpoofer: return "locationSpoofer"
+        case .consoleLogs: return "consoleLogs"
+        case .deepLinkTester: return "deepLinkTester"
+        case .crashLogs: return "crashLogs"
+        case .notificationLogger: return "notificationLogger"
+        case .notificationTester: return "notificationTester"
+        case .apnsToken: return "apnsToken"
+        case .fcmToken: return "fcmToken"
+        case .fonts: return "fonts"
+        case .interfaceComponents: return "interfaceComponents"
+        case .gridOverlay: return "gridOverlay"
+        case .fpsCounter: return "fpsCounter"
+        case .touchVisualiser: return "touchVisualiser"
+        case .appearance: return "appearance"
+        case .slowAnimations: return "slowAnimations"
+        case .showViewFrames: return "showViewFrames"
+        case .showViewSizes: return "showViewSizes"
+        }
+    }
+
+    /// A namespaced identifier for rendering this item inside the "Pinned" section.
+    ///
+    /// Pinned rows remain in their home section, so the same item appears twice in one
+    /// `List`. Namespacing the pinned copy keeps SwiftUI's row identity unambiguous.
+    var pinnedRowID: String { "pinned.\(id)" }
+
+    /// Reconstructs an item from a persisted identifier.
+    ///
+    /// - Parameter id: An identifier previously produced by ``id``.
+    /// - Returns: The matching item, or `nil` if no such row exists. A `nil` result is
+    ///   expected and harmless — it means a stored pin refers to a row removed in a later
+    ///   version of Scyther.
+    init?(id: String) {
+        if id.hasPrefix(Self.developerOptionPrefix) {
+            let name = String(id.dropFirst(Self.developerOptionPrefix.count))
+            guard !name.isEmpty else { return nil }
+            self = .developerOption(name: name)
+            return
+        }
+
+        guard let match = Self.allStaticCases.first(where: { $0.id == id }) else { return nil }
+        self = match
+    }
+
+    /// The row's display label.
+    var title: String {
+        switch self {
+        case .osVersion: return "OS Version"
+        case .hardware: return "Hardware"
+        case .releaseYear: return "Release Year"
+        case .uuid: return "UUID"
+        case .appIdPrefix: return "App ID Prefix"
+        case .displayName: return "Display Name"
+        case .bundleId: return "Bundle ID"
+        case .processId: return "Process ID"
+        case .version: return "Version"
+        case .buildNumber: return "Build Number"
+        case .buildDate: return "Build Date"
+        case .releaseType: return "Release Type"
+        case .developerOption(let name): return name
+        case .ipAddress: return "IP Address"
+        case .networkLogs: return "Network Logs"
+        case .serverConfiguration: return "Server Configuration"
+        case .environmentVariables: return "Environment Variables"
+        case .featureFlags: return "Feature Flags"
+        case .userDefaults: return "UserDefaults"
+        case .cookies: return "Cookies"
+        case .fileBrowser: return "File Browser"
+        case .databaseBrowser: return "Database Browser"
+        case .keychainBrowser: return "Keychain Browser"
+        case .locationSpoofer: return "Location Spoofer"
+        case .consoleLogs: return "Console Logs"
+        case .deepLinkTester: return "Deep Link Tester"
+        case .crashLogs: return "Crash Logs"
+        case .notificationLogger: return "Notification Logger"
+        case .notificationTester: return "Notification Tester"
+        case .apnsToken: return "APNS Token"
+        case .fcmToken: return "FCM Token"
+        case .fonts: return "Fonts"
+        case .interfaceComponents: return "Interface Components"
+        case .gridOverlay: return "Grid Overlay"
+        case .fpsCounter: return "FPS Counter"
+        case .touchVisualiser: return "Touch Visualiser"
+        case .appearance: return "Appearance"
+        case .slowAnimations: return "Slow Animations"
+        case .showViewFrames: return "Show View Frames"
+        case .showViewSizes: return "Show View Sizes"
+        }
+    }
+
+    /// The SF Symbol shown alongside the row, or `nil` for rows that display no icon.
+    ///
+    /// Device and application information rows intentionally have no icon, matching the
+    /// menu's existing appearance. ``developerOption(name:)`` also returns `nil` here — its
+    /// icon comes from the host-supplied `DeveloperOption`, which may be a `UIImage` rather
+    /// than an SF Symbol.
+    var icon: String? {
+        switch self {
+        case .osVersion, .hardware, .releaseYear, .uuid,
+             .appIdPrefix, .displayName, .bundleId, .processId,
+             .version, .buildNumber, .buildDate, .releaseType,
+             .developerOption:
+            return nil
+        case .ipAddress: return "network"
+        case .networkLogs: return "text.page.badge.magnifyingglass"
+        case .serverConfiguration: return "server.rack"
+        case .environmentVariables: return "x.squareroot"
+        case .featureFlags: return "flag"
+        case .userDefaults: return "face.dashed"
+        case .cookies: return "info.circle"
+        case .fileBrowser: return "folder"
+        case .databaseBrowser: return "cylinder.split.1x2"
+        case .keychainBrowser: return "key"
+        case .locationSpoofer: return "location.circle"
+        case .consoleLogs: return "terminal"
+        case .deepLinkTester: return "link"
+        case .crashLogs: return "exclamationmark.triangle"
+        case .notificationLogger: return "list.bullet"
+        case .notificationTester: return "bell"
+        case .apnsToken: return "applelogo"
+        case .fcmToken: return "flame"
+        case .fonts: return "textformat"
+        case .interfaceComponents: return "apps.iphone"
+        case .gridOverlay: return "rectangle.split.3x3"
+        case .fpsCounter: return "speedometer"
+        case .touchVisualiser: return "hand.point.up"
+        case .appearance: return "paintbrush"
+        case .slowAnimations: return "tortoise"
+        case .showViewFrames: return "rectangle.dashed"
+        case .showViewSizes: return "ruler"
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:ScytherTests/MenuItemTests
+```
+
+Expected: `** TEST SUCCEEDED **`, 14 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Scyther/Features/Menu/MenuItem.swift Tests/ScytherTests/Features/MenuItemTests.swift
+git commit -m "Add MenuItem model giving every menu row a stable identity"
+```
+
+---
+
+## Task 5: `MenuSection`
+
+**Files:**
+- Create: `Sources/Scyther/Features/Menu/MenuSection.swift`
+- Create: `Tests/ScytherTests/Features/MenuViewModelTests.swift` (section tests only; pin tests are added in Task 6)
+
+**Interfaces:**
+- Consumes: `MenuItem` from Task 4.
+- Produces:
+  - `struct MenuSection: Identifiable` with `id: String`, `title: String`, `items: [MenuItem]`
+  - `MenuSection.allSections(developerOptions: [DeveloperOption]) -> [MenuSection]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/ScytherTests/Features/MenuViewModelTests.swift`:
+
+```swift
+//
+//  MenuViewModelTests.swift
+//  ScytherTests
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+#if !os(macOS)
+@testable import Scyther
+import XCTest
+
+@MainActor
+final class MenuViewModelTests: XCTestCase {
+
+    // MARK: - Sections
+
+    func testEveryStaticItemAppearsInExactlyOneSection() {
+        let items = MenuSection.allSections(developerOptions: []).flatMap(\.items)
+
+        XCTAssertEqual(Set(items).count, items.count, "An item appears in more than one section")
+        XCTAssertEqual(Set(items), Set(MenuItem.allStaticCases), "Sections do not cover every item")
+    }
+
+    func testDeviceSectionIsFirst() {
+        XCTAssertEqual(MenuSection.allSections(developerOptions: []).first?.title, "Device")
+    }
+
+    func testDevelopmentToolsSectionIsOmittedWhenThereAreNoDeveloperOptions() {
+        let titles = MenuSection.allSections(developerOptions: []).map(\.title)
+        XCTAssertFalse(titles.contains("Development Tools"))
+    }
+
+    func testDevelopmentToolsSectionIsIncludedWhenDeveloperOptionsExist() {
+        let options = [DeveloperOption(name: "Reset Onboarding", value: "tap")]
+        let sections = MenuSection.allSections(developerOptions: options)
+
+        let developmentTools = sections.first { $0.title == "Development Tools" }
+        XCTAssertEqual(developmentTools?.items, [.developerOption(name: "Reset Onboarding")])
+    }
+
+    func testSectionTitlesAreInTheExpectedOrder() {
+        let options = [DeveloperOption(name: "Panel", value: "x")]
+        let titles = MenuSection.allSections(developerOptions: options).map(\.title)
+
+        XCTAssertEqual(titles, [
+            "Device",
+            "Application",
+            "Development Tools",
+            "Networking",
+            "Data",
+            "Security",
+            "System Tools",
+            "Notifications",
+            "UI/UX"
+        ])
+    }
+
+    func testSectionIdentifiersAreUnique() {
+        let ids = MenuSection.allSections(developerOptions: []).map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count)
+    }
+}
+#endif
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:ScytherTests/MenuViewModelTests
+```
+
+Expected: **compile failure**, `cannot find 'MenuSection' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/Scyther/Features/Menu/MenuSection.swift`:
+
+```swift
+//
+//  MenuSection.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 22/7/2026.
+//
+
+import Foundation
+
+/// A titled group of rows in the Scyther main menu.
+///
+/// Describing the menu as data rather than as literal SwiftUI sections is what lets
+/// ``MenuView`` render the same ``MenuItem`` in both its home section and the "Pinned"
+/// section from a single row definition.
+///
+/// ## Usage
+///
+/// ```swift
+/// for section in MenuSection.allSections(developerOptions: Scyther.developerOptions) {
+///     print(section.title, section.items.count)
+/// }
+/// ```
+///
+/// ## Topics
+///
+/// ### Properties
+/// - ``id``
+/// - ``title``
+/// - ``items``
+///
+/// ### Layout
+/// - ``allSections(developerOptions:)``
+struct MenuSection: Identifiable {
+    /// Stable identifier, derived from the section's title.
+    var id: String { title }
+
+    /// The section header text.
+    let title: String
+
+    /// The rows in this section, in display order.
+    let items: [MenuItem]
+
+    /// The full menu layout, in display order.
+    ///
+    /// "Device" is always first — ``MenuView`` renders the device header inside it and
+    /// inserts the "Pinned" section immediately afterwards.
+    ///
+    /// - Parameter developerOptions: The host app's custom options, from
+    ///   `Scyther.developerOptions`. When empty, the "Development Tools" section is omitted
+    ///   entirely rather than rendered blank.
+    /// - Returns: Every section that should be displayed.
+    static func allSections(developerOptions: [DeveloperOption]) -> [MenuSection] {
+        var sections: [MenuSection] = [
+            MenuSection(title: "Device", items: [
+                .osVersion, .hardware, .releaseYear, .uuid
+            ]),
+            MenuSection(title: "Application", items: [
+                .appIdPrefix, .displayName, .bundleId, .processId,
+                .version, .buildNumber, .buildDate, .releaseType
+            ])
+        ]
+
+        if !developerOptions.isEmpty {
+            sections.append(
+                MenuSection(
+                    title: "Development Tools",
+                    items: developerOptions.map { .developerOption(name: $0.name) }
+                )
+            )
+        }
+
+        sections.append(contentsOf: [
+            MenuSection(title: "Networking", items: [
+                .ipAddress, .networkLogs, .serverConfiguration, .environmentVariables
+            ]),
+            MenuSection(title: "Data", items: [
+                .featureFlags, .userDefaults, .cookies, .fileBrowser, .databaseBrowser
+            ]),
+            MenuSection(title: "Security", items: [
+                .keychainBrowser
+            ]),
+            MenuSection(title: "System Tools", items: [
+                .locationSpoofer, .consoleLogs, .deepLinkTester, .crashLogs
+            ]),
+            MenuSection(title: "Notifications", items: [
+                .notificationLogger, .notificationTester, .apnsToken, .fcmToken
+            ]),
+            MenuSection(title: "UI/UX", items: [
+                .fonts, .interfaceComponents, .gridOverlay, .fpsCounter,
+                .touchVisualiser, .appearance,
+                .slowAnimations, .showViewFrames, .showViewSizes
+            ])
+        ])
+
+        return sections
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:ScytherTests/MenuViewModelTests
+```
+
+Expected: `** TEST SUCCEEDED **`, 6 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Scyther/Features/Menu/MenuSection.swift Tests/ScytherTests/Features/MenuViewModelTests.swift
+git commit -m "Describe the main menu layout as data"
+```
+
+---
+
+## Task 6: Pin state in `MenuViewModel`
+
+**Files:**
+- Modify: `Sources/Scyther/Features/Menu/MenuViewModel.swift`
+- Modify: `Tests/ScytherTests/Features/MenuViewModelTests.swift`
+
+**Interfaces:**
+- Consumes: `MenuItem`, `MenuSection`, `UserDefaults.scyther`.
+- Produces:
+  - `MenuViewModel.init(defaults: UserDefaults = .scyther)`
+  - `MenuViewModel.pinnedItemsKey` → `String` = `"Scyther.Menu.PinnedItems"` (static, internal)
+  - `MenuViewModel.pinnedItemIDs` → `@Published private(set) var [String]`
+  - `MenuViewModel.sections` → `[MenuSection]`
+  - `MenuViewModel.pinnedItems` → `[MenuItem]`
+  - `MenuViewModel.isPinned(_ item: MenuItem) -> Bool`
+  - `MenuViewModel.togglePin(for item: MenuItem)`
+
+- [ ] **Step 1: Add the failing pin tests**
+
+Append to `Tests/ScytherTests/Features/MenuViewModelTests.swift`, inside the `MenuViewModelTests` class, after the section tests:
+
+```swift
+    // MARK: - Pinning
+
+    private var suiteName: String { "com.scyther.tests.menu" }
+
+    private func makeDefaults() -> UserDefaults {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        return UserDefaults(suiteName: suiteName)!
+    }
+
+    private func wipeDefaults() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+
+    func testNothingIsPinnedByDefault() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        XCTAssertTrue(viewModel.pinnedItemIDs.isEmpty)
+        XCTAssertTrue(viewModel.pinnedItems.isEmpty)
+    }
+
+    func testPinningAppendsTheItem() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        viewModel.togglePin(for: .featureFlags)
+
+        XCTAssertTrue(viewModel.isPinned(.featureFlags))
+        XCTAssertEqual(viewModel.pinnedItems, [.featureFlags])
+    }
+
+    func testUnpinningRemovesTheItem() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        viewModel.togglePin(for: .featureFlags)
+        viewModel.togglePin(for: .featureFlags)
+
+        XCTAssertFalse(viewModel.isPinned(.featureFlags))
+        XCTAssertTrue(viewModel.pinnedItems.isEmpty)
+    }
+
+    func testPinnedItemsAreOrderedOldestFirst() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        viewModel.togglePin(for: .crashLogs)
+        viewModel.togglePin(for: .featureFlags)
+        viewModel.togglePin(for: .fonts)
+
+        XCTAssertEqual(viewModel.pinnedItems, [.crashLogs, .featureFlags, .fonts])
+    }
+
+    func testUnpinningDoesNotDisturbTheOrderOfOtherItems() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        viewModel.togglePin(for: .crashLogs)
+        viewModel.togglePin(for: .featureFlags)
+        viewModel.togglePin(for: .fonts)
+        viewModel.togglePin(for: .featureFlags)
+
+        XCTAssertEqual(viewModel.pinnedItems, [.crashLogs, .fonts])
+    }
+
+    func testRepinningMovesTheItemToTheEnd() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        viewModel.togglePin(for: .crashLogs)
+        viewModel.togglePin(for: .fonts)
+        viewModel.togglePin(for: .crashLogs)
+        viewModel.togglePin(for: .crashLogs)
+
+        XCTAssertEqual(viewModel.pinnedItems, [.fonts, .crashLogs])
+    }
+
+    func testPinStateSurvivesANewViewModel() {
+        defer { wipeDefaults() }
+        let defaults = makeDefaults()
+
+        let first = MenuViewModel(defaults: defaults)
+        first.togglePin(for: .keychainBrowser)
+        first.togglePin(for: .cookies)
+
+        let second = MenuViewModel(defaults: defaults)
+        XCTAssertEqual(second.pinnedItems, [.keychainBrowser, .cookies])
+    }
+
+    func testPinsAreWrittenToTheInjectedStoreOnly() {
+        defer { wipeDefaults() }
+        let defaults = makeDefaults()
+
+        let viewModel = MenuViewModel(defaults: defaults)
+        viewModel.togglePin(for: .fonts)
+
+        XCTAssertEqual(defaults.stringArray(forKey: MenuViewModel.pinnedItemsKey), ["fonts"])
+    }
+
+    func testStoredIdentifiersThatNoLongerResolveAreDropped() {
+        defer { wipeDefaults() }
+        let defaults = makeDefaults()
+        defaults.set(["fonts", "removedInV2", "cookies"], forKey: MenuViewModel.pinnedItemsKey)
+
+        let viewModel = MenuViewModel(defaults: defaults)
+
+        XCTAssertEqual(viewModel.pinnedItems, [.fonts, .cookies])
+    }
+
+    func testPinnedDeveloperOptionThatNoLongerExistsIsDropped() {
+        defer {
+            wipeDefaults()
+            Scyther.developerOptions = []
+        }
+        let defaults = makeDefaults()
+        defaults.set(["developerOption.Gone", "fonts"], forKey: MenuViewModel.pinnedItemsKey)
+        Scyther.developerOptions = []
+
+        let viewModel = MenuViewModel(defaults: defaults)
+
+        XCTAssertEqual(viewModel.pinnedItems, [.fonts])
+    }
+
+    func testPinnedDeveloperOptionThatStillExistsIsKept() {
+        defer {
+            wipeDefaults()
+            Scyther.developerOptions = []
+        }
+        let defaults = makeDefaults()
+        defaults.set(["developerOption.Panel"], forKey: MenuViewModel.pinnedItemsKey)
+        Scyther.developerOptions = [DeveloperOption(name: "Panel", value: "x")]
+
+        let viewModel = MenuViewModel(defaults: defaults)
+
+        XCTAssertEqual(viewModel.pinnedItems, [.developerOption(name: "Panel")])
+    }
+
+    func testIsPinnedAgreesWithPinnedItemIdentifiers() {
+        defer { wipeDefaults() }
+        let viewModel = MenuViewModel(defaults: makeDefaults())
+
+        viewModel.togglePin(for: .gridOverlay)
+
+        XCTAssertTrue(viewModel.isPinned(.gridOverlay))
+        XCTAssertFalse(viewModel.isPinned(.fpsCounter))
+        XCTAssertEqual(viewModel.pinnedItemIDs, [MenuItem.gridOverlay.id])
+    }
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:ScytherTests/MenuViewModelTests
+```
+
+Expected: **compile failure**, `argument passed to call that takes no arguments` on `MenuViewModel(defaults:)`.
+
+- [ ] **Step 3: Implement pin state**
+
+In `Sources/Scyther/Features/Menu/MenuViewModel.swift`, add a `// MARK: - Menu Structure` block above `// MARK: - Network Properties`, and an initialiser. The existing `ViewModel` base class has a no-argument `init()` that calls `setup()`, so the new initialiser must assign stored properties before calling `super.init()`:
+
+```swift
+    // MARK: - Menu Structure
+
+    /// The key backing ``pinnedItemIDs`` in Scyther's preferences store.
+    static let pinnedItemsKey = "Scyther.Menu.PinnedItems"
+
+    /// The store pinned item identifiers are read from and written to.
+    private let defaults: UserDefaults
+
+    /// The identifiers of pinned rows, in the order they were pinned.
+    ///
+    /// An array rather than a `Set` so that oldest-first pin order survives a relaunch.
+    @Published private(set) var pinnedItemIDs: [String]
+
+    /// The full menu layout, including any host-supplied developer options.
+    var sections: [MenuSection] {
+        MenuSection.allSections(developerOptions: Scyther.developerOptions)
+    }
+
+    /// The pinned rows, oldest pin first.
+    ///
+    /// Stored identifiers that no longer resolve to a row currently present in ``sections``
+    /// are dropped. This covers both a feature removed in a later version of Scyther and a
+    /// developer option the host app no longer registers.
+    var pinnedItems: [MenuItem] {
+        let available = Set(sections.flatMap(\.items))
+        return pinnedItemIDs
+            .compactMap(MenuItem.init(id:))
+            .filter { available.contains($0) }
+    }
+
+    /// Creates a menu view model.
+    ///
+    /// - Parameter defaults: The store backing pin state. Defaults to Scyther's private
+    ///   preferences suite; tests inject a throwaway suite.
+    init(defaults: UserDefaults = .scyther) {
+        self.defaults = defaults
+        self.pinnedItemIDs = defaults.stringArray(forKey: Self.pinnedItemsKey) ?? []
+        super.init()
+    }
+
+    /// Whether the given row is pinned.
+    ///
+    /// - Parameter item: The row to check.
+    /// - Returns: `true` when the row appears in the "Pinned" section.
+    func isPinned(_ item: MenuItem) -> Bool {
+        pinnedItemIDs.contains(item.id)
+    }
+
+    /// Pins or unpins a row, persisting the change immediately.
+    ///
+    /// Pinning appends the row to the end of the pinned list, so the "Pinned" section reads
+    /// oldest pin first. Unpinning leaves the order of the remaining rows untouched.
+    ///
+    /// - Parameter item: The row to pin or unpin.
+    func togglePin(for item: MenuItem) {
+        if let index = pinnedItemIDs.firstIndex(of: item.id) {
+            pinnedItemIDs.remove(at: index)
+        } else {
+            pinnedItemIDs.append(item.id)
+        }
+        defaults.set(pinnedItemIDs, forKey: Self.pinnedItemsKey)
+    }
+```
+
+Extend the type's DocC comment with the new capability and topics:
+
+```swift
+/// - **Menu Structure**: Supplies the ordered section layout and the set of pinned rows
+/// - **Pinning**: Persists pinned rows to Scyther's preferences suite, oldest pin first
+```
+
+```swift
+/// ### Menu Structure
+///
+/// - ``sections``
+/// - ``pinnedItems``
+/// - ``pinnedItemIDs``
+/// - ``isPinned(_:)``
+/// - ``togglePin(for:)``
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:ScytherTests/MenuViewModelTests
+```
+
+Expected: `** TEST SUCCEEDED **`, 18 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Scyther/Features/Menu/MenuViewModel.swift Tests/ScytherTests/Features/MenuViewModelTests.swift
+git commit -m "Track and persist pinned main menu items"
+```
+
+---
+
+## Task 7: Render the menu from data, with a Pinned section
+
+**Files:**
+- Modify: `Sources/Scyther/Features/Menu/MenuView.swift`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: `MenuItem`, `MenuSection`, `MenuViewModel.sections`, `.pinnedItems`, `.isPinned(_:)`, `.togglePin(for:)`.
+- Produces: no new API.
+
+- [ ] **Step 1: Replace the `body` with a data-driven layout**
+
+In `Sources/Scyther/Features/Menu/MenuView.swift`, replace the entire `public var body: some View { ... }` — all eight hardcoded sections — with:
+
+```swift
+    public var body: some View {
+        List {
+            if let deviceSection = viewModel.sections.first {
+                Section {
+                    header
+                    ForEach(deviceSection.items) { item in
+                        pinnableRow(for: item)
+                    }
+                } header: {
+                    Text(deviceSection.title)
+                }
+            }
+
+            if !viewModel.pinnedItems.isEmpty {
+                Section {
+                    ForEach(viewModel.pinnedItems, id: \.pinnedRowID) { item in
+                        pinnableRow(for: item)
+                    }
+                } header: {
+                    Text("Pinned")
+                }
+            }
+
+            ForEach(Array(viewModel.sections.dropFirst())) { section in
+                Section {
+                    ForEach(section.items) { item in
+                        pinnableRow(for: item)
+                    }
+                } header: {
+                    Text(section.title)
+                }
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    Scyther.hideMenu()
+                } label: {
+                    Image(systemName: "xmark")
+                }
+            }
+        }
+        .onFirstAppear {
+            await viewModel.onFirstAppear()
+        }
+        .navigationTitle("Scyther")
+        .interactiveDismissDisabled()
+    }
+```
+
+- [ ] **Step 2: Add the row builders**
+
+Add these two methods immediately after `body`, before the existing `row(withLabel:...)` helper:
+
+```swift
+    /// Wraps a row in its pin/unpin swipe action.
+    ///
+    /// The action's label is derived from the row's current pin state rather than from which
+    /// section it is being rendered in, because pinned rows remain in their home section — a
+    /// pinned row therefore reads "Unpin" in both places.
+    @ViewBuilder
+    private func pinnableRow(for item: MenuItem) -> some View {
+        rowContent(for: item)
+            .swipeActions(edge: .trailing) {
+                Button {
+                    viewModel.togglePin(for: item)
+                } label: {
+                    Label(
+                        viewModel.isPinned(item) ? "Unpin" : "Pin",
+                        systemImage: viewModel.isPinned(item) ? "pin.slash" : "pin"
+                    )
+                }
+                .tint(.blue)
+            }
+    }
+
+    /// The single definition of every menu row.
+    ///
+    /// ``MenuItem`` supplies each row's title and icon; this method supplies everything
+    /// dynamic — a value row's description, a navigation row's destination, a toggle row's
+    /// binding. Because there is one definition, the "Pinned" section and a row's home
+    /// section always render identically.
+    @ViewBuilder
+    private func rowContent(for item: MenuItem) -> some View {
+        switch item {
+        // MARK: Device
+        case .osVersion:
+            row(withLabel: item.title, description: UIDevice.current.systemVersion)
+        case .hardware:
+            row(withLabel: item.title, description: UIDevice.current.modelName)
+        case .releaseYear:
+            row(withLabel: item.title, description: UIDevice.current.generation.withoutDecimals)
+        case .uuid:
+            row(withLabel: item.title, description: UIDevice.current.identifierForVendor?.uuidString)
+
+        // MARK: Application
+        case .appIdPrefix:
+            row(withLabel: item.title, description: Bundle.main.seedId)
+        case .displayName:
+            row(withLabel: item.title, description: String(UIApplication.shared.appName))
+        case .bundleId:
+            row(withLabel: item.title, description: Bundle.main.bundleIdentifier)
+        case .processId:
+            row(withLabel: item.title, description: String(getpid()))
+        case .version:
+            row(withLabel: item.title, description: Bundle.main.versionNumber)
+        case .buildNumber:
+            row(withLabel: item.title, description: Bundle.main.buildNumber)
+        case .buildDate:
+            row(withLabel: item.title, description: Bundle.main.buildDate.formatted())
+        case .releaseType:
+            row(withLabel: item.title, description: AppEnvironment.configuration().rawValue)
+
+        // MARK: Development Tools
+        case .developerOption(let name):
+            if let option = Scyther.developerOptions.first(where: { $0.name == name }) {
+                developerOptionRow(option)
+            }
+
+        // MARK: Networking
+        case .ipAddress:
+            row(
+                withLabel: item.title,
+                description: viewModel.ipAddress,
+                icon: item.icon,
+                andLoadingState: viewModel.isLoadingIPAddress
+            )
+        case .networkLogs:
+            NavigationLink {
+                NetworkLogsView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .serverConfiguration:
+            NavigationLink {
+                ServerConfigurationView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .environmentVariables:
+            NavigationLink {
+                EnvironmentVariablesView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+
+        // MARK: Data
+        case .featureFlags:
+            NavigationLink {
+                FeatureFlagsView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .userDefaults:
+            NavigationLink {
+                UserDefaultsView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .cookies:
+            NavigationLink {
+                CookieBrowserView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .fileBrowser:
+            NavigationLink {
+                FileBrowserView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .databaseBrowser:
+            NavigationLink {
+                DatabaseBrowserView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+
+        // MARK: Security
+        case .keychainBrowser:
+            NavigationLink {
+                KeychainBrowserView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+
+        // MARK: System Tools
+        case .locationSpoofer:
+            NavigationLink {
+                LocationSpooferView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .consoleLogs:
+            NavigationLink {
+                ConsoleLoggerView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .deepLinkTester:
+            NavigationLink {
+                DeepLinkTesterView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .crashLogs:
+            NavigationLink {
+                CrashLogsView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+
+        // MARK: Notifications
+        case .notificationLogger:
+            NavigationLink {
+                NotificationLoggerView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .notificationTester:
+            NavigationLink {
+                NotificationTesterView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .apnsToken:
+            row(withLabel: item.title, icon: item.icon)
+        case .fcmToken:
+            row(withLabel: item.title, icon: item.icon)
+
+        // MARK: UI/UX
+        case .fonts:
+            NavigationLink {
+                FontsView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .interfaceComponents:
+            NavigationLink {
+                InterfacePreviewsView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .gridOverlay:
+            NavigationLink {
+                GridOverlaySettingsView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .fpsCounter:
+            NavigationLink {
+                FPSCounterSettingsView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .touchVisualiser:
+            NavigationLink {
+                TouchVisualiserView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .appearance:
+            NavigationLink {
+                AppearanceOverridesView()
+            } label: {
+                row(withLabel: item.title, icon: item.icon)
+            }
+        case .slowAnimations:
+            toggleRow(item.title, icon: item.icon, isOn: $viewModel.slowAnimationsEnabled)
+        case .showViewFrames:
+            toggleRow(item.title, icon: item.icon, isOn: $viewModel.showViewFrames)
+        case .showViewSizes:
+            toggleRow(item.title, icon: item.icon, isOn: $viewModel.showViewSizes)
+        }
+    }
+```
+
+- [ ] **Step 2b: Widen `toggleRow` to accept an optional icon**
+
+`MenuItem.icon` is `String?`, but the existing `toggleRow` takes a non-optional `String`. Replace it:
+
+```swift
+    func toggleRow(_ label: String, icon: String?, isOn: Binding<Bool>) -> some View {
+        Toggle(isOn: isOn) {
+            if let icon {
+                Label {
+                    Text(label)
+                } icon: {
+                    Image(systemName: icon)
+                        .foregroundStyle(Color.accentColor)
+                }
+            } else {
+                Text(label)
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Update the view's DocC comment**
+
+The existing comment lists the sections. Add the pinning behaviour:
+
+```swift
+/// Any row can be pinned via a trailing swipe action. Pinned rows appear in a "Pinned"
+/// section rendered directly beneath **Device**, and also remain in their home section, so
+/// the menu's structure never changes shape as rows are pinned. Pins are ordered oldest
+/// first and persist across launches in ``UserDefaults/scyther``.
+```
+
+- [ ] **Step 4: Build and run the full test suite**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 5: Verify the menu visually in the example app**
+
+The pinning behaviour is not covered by unit tests, so check it by hand:
+
+```bash
+xcodebuild build -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO
+```
+
+Then run `Example/ScytherExample`, open the menu, and confirm each of:
+1. Sections appear in the order Device, Application, (Development Tools), Networking, Data, Security, System Tools, Notifications, UI/UX — matching the menu before this change.
+2. Swiping left on any row reveals a blue "Pin" action.
+3. Pinning a row makes a "Pinned" section appear directly beneath Device, and the row **also stays** in its original section.
+4. Both copies of the pinned row show "Unpin" when swiped.
+5. Pinning a second and third row appends them below the first.
+6. Unpinning from either copy removes the row from Pinned and leaves the others in order.
+7. Pinning a toggle row (Slow Animations) puts a working switch in the Pinned section.
+8. Force-quitting and relaunching preserves the pins in the same order.
+
+- [ ] **Step 6: Document pinning in the README**
+
+In `README.md`, under the section that documents the menu, add:
+
+```markdown
+### Pinning menu items
+
+Any row in the main menu can be pinned. Swipe left on a row and tap **Pin**; a **Pinned**
+section appears directly beneath **Device** containing your shortcuts.
+
+Pinned rows stay in their original section as well, so the menu never changes shape — the
+Pinned section is purely an additional shortcut. Rows appear in the order you pinned them,
+oldest first. Swipe and tap **Unpin** on either copy to remove one.
+
+Everything is pinnable, including information rows such as **Bundle ID**, inline toggles
+such as **Slow Animations**, and any custom options you register via
+`Scyther.developerOptions`.
+
+Pins persist across launches in Scyther's private preferences suite, so they survive your
+app clearing its own `UserDefaults`. See [Preferences Storage](#preferences-storage).
+```
+
+Add a matching Table of Contents entry.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/Scyther/Features/Menu/MenuView.swift README.md
+git commit -m "Make every main menu row pinnable"
+```
+
+---
+
+## Task 8: Feature Flags — gate on overrides, keep pinned rows in place
+
+**Files:**
+- Modify: `Sources/Scyther/Features/FeatureFlags/FeatureFlagsViewModel.swift`
+- Modify: `Sources/Scyther/Features/FeatureFlags/FeatureFlagsView.swift`
+- Modify: `Tests/ScytherTests/Features/FeatureFlagsTests.swift`
+
+**Interfaces:**
+- Consumes: `UserDefaults.scyther`.
+- Produces:
+  - `FeatureFlagsViewModel.init(defaults: UserDefaults = .scyther)`
+  - `FeatureToggleItem.pinnedRowID` → `String`
+  - Removes `FeatureFlagsViewModel.unpinnedToggles` — nothing else references it.
+
+Pin **ordering and storage are unchanged**: pins stay a `Set<String>` and the Pinned section
+stays alphabetical, inherited from `toggles` being sorted by name. This is deliberately
+different from the menu's oldest-first ordering.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `FeatureFlagsTests` class in `Tests/ScytherTests/Features/FeatureFlagsTests.swift`:
+
+```swift
+    // MARK: - Pinned toggles stay in the full list
+
+    /// Flags register into the shared `Scyther.featureFlags` singleton and there is no
+    /// public API to unregister them, so these tests use distinctive names and assert by
+    /// containment rather than whole-array equality. Another test registering its own flags
+    /// must not be able to break them.
+    @MainActor
+    private func makeSuite(named suiteName: String) -> UserDefaults {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        }
+        return UserDefaults(suiteName: suiteName)!
+    }
+
+    @MainActor
+    func testPinnedTogglesRemainInTheFullToggleList() async {
+        let defaults = makeSuite(named: "com.scyther.tests.featureflags")
+        Scyther.featureFlags.register("ScytherTestPinned", remoteValue: true)
+
+        let viewModel = FeatureFlagsViewModel(defaults: defaults)
+        await viewModel.onFirstAppear()
+        viewModel.togglePin(for: "ScytherTestPinned")
+
+        XCTAssertTrue(
+            viewModel.pinnedToggles.contains { $0.name == "ScytherTestPinned" },
+            "Pinned toggle is missing from the Pinned section"
+        )
+        XCTAssertTrue(
+            viewModel.toggles.contains { $0.name == "ScytherTestPinned" && $0.isPinned },
+            "Pinned toggle must remain in the full list, flagged as pinned"
+        )
+    }
+
+    @MainActor
+    func testPinnedTogglesAreOrderedAlphabeticallyNotByPinOrder() async {
+        let defaults = makeSuite(named: "com.scyther.tests.featureflags.order")
+        Scyther.featureFlags.register("ScytherTestOrderZulu", remoteValue: true)
+        Scyther.featureFlags.register("ScytherTestOrderAlpha", remoteValue: true)
+
+        let viewModel = FeatureFlagsViewModel(defaults: defaults)
+        await viewModel.onFirstAppear()
+
+        // Pin Zulu first. Alphabetical ordering must still put Alpha ahead of it.
+        viewModel.togglePin(for: "ScytherTestOrderZulu")
+        viewModel.togglePin(for: "ScytherTestOrderAlpha")
+
+        let names = viewModel.pinnedToggles.map(\.name).filter { $0.hasPrefix("ScytherTestOrder") }
+        XCTAssertEqual(names, ["ScytherTestOrderAlpha", "ScytherTestOrderZulu"])
+    }
+
+    @MainActor
+    func testUnpinningLeavesTheToggleInTheFullList() async {
+        let defaults = makeSuite(named: "com.scyther.tests.featureflags.unpin")
+        Scyther.featureFlags.register("ScytherTestUnpin", remoteValue: false)
+
+        let viewModel = FeatureFlagsViewModel(defaults: defaults)
+        await viewModel.onFirstAppear()
+        viewModel.togglePin(for: "ScytherTestUnpin")
+        viewModel.togglePin(for: "ScytherTestUnpin")
+
+        XCTAssertFalse(viewModel.pinnedToggles.contains { $0.name == "ScytherTestUnpin" })
+        XCTAssertTrue(viewModel.toggles.contains { $0.name == "ScytherTestUnpin" })
+    }
+
+    @MainActor
+    func testOverridesEnabledPropagatesToTheFeatureFlagsSubsystem() {
+        let viewModel = FeatureFlagsViewModel()
+
+        viewModel.overridesEnabled = true
+        XCTAssertTrue(Scyther.featureFlags.localOverridesEnabled)
+
+        viewModel.overridesEnabled = false
+        XCTAssertFalse(Scyther.featureFlags.localOverridesEnabled)
+    }
+```
+
+Note `overridesEnabled` writes through to the shared `Scyther.featureFlags` singleton and
+therefore to the real suite, not the injected one — injection covers pin state only. The
+existing `cleanupUserDefaults()` in `tearDown` already removes `FeatureFlags.overridesEnabledKey`,
+so this leaves no residue.
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:ScytherTests/FeatureFlagsTests
+```
+
+Expected: **compile failure**, `argument passed to call that takes no arguments` on `FeatureFlagsViewModel(defaults:)`.
+
+- [ ] **Step 3: Update the view model**
+
+In `Sources/Scyther/Features/FeatureFlags/FeatureFlagsViewModel.swift`:
+
+Add `pinnedRowID` to `FeatureToggleItem`:
+
+```swift
+    /// A namespaced identifier for rendering this toggle inside the "Pinned" section.
+    ///
+    /// Pinned toggles remain in the main list, so the same toggle appears twice in one
+    /// `List`. Namespacing the pinned copy keeps SwiftUI's row identity unambiguous.
+    var pinnedRowID: String { "pinned.\(name)" }
+```
+
+Delete `unpinnedToggles` entirely — it is now unused:
+
+```swift
+    /// Toggles that are not pinned.
+    var unpinnedToggles: [FeatureToggleItem] {
+        toggles.filter { !$0.isPinned }
+    }
+```
+
+Replace the hardcoded store with an injected one. Change the `pinnedToggleNames` accessors to use `defaults` and add the initialiser:
+
+```swift
+    /// The store pinned toggle names are read from and written to.
+    private let defaults: UserDefaults
+
+    /// Creates a feature flags view model.
+    ///
+    /// - Parameter defaults: The store backing pin state. Defaults to Scyther's private
+    ///   preferences suite; tests inject a throwaway suite.
+    init(defaults: UserDefaults = .scyther) {
+        self.defaults = defaults
+        super.init()
+    }
+
+    private var pinnedToggleNames: Set<String> {
+        get {
+            Set(defaults.stringArray(forKey: Self.pinnedTogglesKey) ?? [])
+        }
+        set {
+            defaults.set(Array(newValue), forKey: Self.pinnedTogglesKey)
+        }
+    }
+```
+
+Update the type's DocC `## Topics` block to drop `unpinnedToggles` and the "Implementation Details" paragraph that names `UserDefaults`:
+
+```swift
+/// Pin state is persisted to ``UserDefaults/scyther`` using the key
+/// `Scyther.FeatureFlags.PinnedToggles` and is automatically restored when the view model
+/// loads. Pinned toggles remain in the full ``toggles`` list, so a pinned toggle is shown
+/// both in the "Pinned" section and in the main list.
+```
+
+- [ ] **Step 4: Run the view model tests and verify they pass**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:ScytherTests/FeatureFlagsTests
+```
+
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 5: Gate the view on `overridesEnabled` and keep pinned rows in the list**
+
+In `Sources/Scyther/Features/FeatureFlags/FeatureFlagsView.swift`, replace `filteredUnpinnedToggles` with a filter over the whole list:
+
+```swift
+    private var filteredToggles: [FeatureToggleItem] {
+        guard !debouncedSearchText.isEmpty else { return viewModel.toggles }
+        let search = debouncedSearchText.lowercased()
+        return viewModel.toggles.filter { $0.name.lowercased().contains(search) }
+    }
+```
+
+Replace `body` with a gated version. `.searchable` cannot be applied conditionally inline, so the list is extracted and the modifier applied on one branch only.
+
+**The `Group` wrapper is load-bearing — do not remove it.** Flipping `overridesEnabled` swaps which branch is rendered, which destroys the branch's view identity along with any `.onChange`, `.onAppear` or `@State` attached inside it. Attaching the lifecycle modifiers to the `Group` gives them a stable identity that survives the swap, so the "clear the search text" handler actually fires. Attached to `list` instead, it would silently never run on the very transition it exists to handle.
+
+```swift
+    var body: some View {
+        Group {
+            if viewModel.overridesEnabled {
+                list.searchable(text: $searchText, prompt: "Search toggles")
+            } else {
+                list
+            }
+        }
+        .navigationTitle("Feature Flags")
+        .onChange(of: searchText) { newValue in
+            searchSubject.send(newValue)
+        }
+        .onChange(of: viewModel.overridesEnabled) { enabled in
+            guard !enabled else { return }
+            searchText = ""
+            debouncedSearchText = ""
+        }
+        .onAppear {
+            cancellable = searchSubject
+                .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+                .sink { debouncedSearchText = $0 }
+        }
+        .onFirstAppear {
+            await viewModel.onFirstAppear()
+        }
+    }
+
+    private var list: some View {
+        List {
+            Section {
+                Toggle("Enable overrides", isOn: $viewModel.overridesEnabled)
+
+                if viewModel.overridesEnabled {
+                    Button("Reset all to Remote") {
+                        viewModel.resetAllToRemote()
+                    }
+                }
+            } header: {
+                Text("Global Settings")
+            } footer: {
+                if !viewModel.overridesEnabled {
+                    Text("Enable overrides to view and modify feature flags.")
+                }
+            }
+
+            if viewModel.overridesEnabled {
+                if !filteredPinnedToggles.isEmpty {
+                    Section("Pinned") {
+                        ForEach(filteredPinnedToggles, id: \.pinnedRowID) { toggle in
+                            toggleRow(for: toggle)
+                                .swipeActions(edge: .trailing) {
+                                    pinButton(for: toggle)
+                                }
+                        }
+                    }
+                }
+
+                Section("Toggles") {
+                    if viewModel.toggles.isEmpty {
+                        Text("No toggles configured")
+                            .fontWeight(.bold)
+                            .foregroundStyle(.gray)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    } else if filteredToggles.isEmpty {
+                        Text("No matching toggles")
+                            .fontWeight(.bold)
+                            .foregroundStyle(.gray)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    } else {
+                        ForEach(filteredToggles) { toggle in
+                            toggleRow(for: toggle)
+                                .swipeActions(edge: .trailing) {
+                                    pinButton(for: toggle)
+                                }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// The pin/unpin swipe action for a toggle.
+    ///
+    /// The label reflects the toggle's pin state rather than which section it is rendered
+    /// in, because pinned toggles remain in the main list.
+    @ViewBuilder
+    private func pinButton(for toggle: FeatureToggleItem) -> some View {
+        Button {
+            viewModel.togglePin(for: toggle.name)
+        } label: {
+            Label(
+                toggle.isPinned ? "Unpin" : "Pin",
+                systemImage: toggle.isPinned ? "pin.slash" : "pin"
+            )
+        }
+        .tint(.blue)
+    }
+```
+
+Note the "All toggles are pinned" branch is gone — it is now unreachable, because pinned
+toggles remain in `filteredToggles`.
+
+Update the view's DocC comment, which currently claims pinning moves toggles to the top:
+
+```swift
+/// - Pin frequently used toggles to an additional section at the top; pinned toggles remain
+///   in the main list as well
+/// - Search toggles by name
+/// - Reset all toggles back to their remote values
+///
+/// While **Enable overrides** is off, the toggle list, the reset button and the search field
+/// are hidden — local overrides have no effect in that state, so presenting an interactive
+/// list would be misleading.
+```
+
+- [ ] **Step 6: Build and run the full test suite**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 7: Verify the Feature Flags screen visually**
+
+Run `Example/ScytherExample`, navigate to **Data → Feature Flags**, and confirm:
+1. With overrides off: only "Enable overrides" is visible, with the explanatory footer beneath it. No reset button, no sections, no search field.
+2. Turning overrides on reveals the reset button, the Toggles section and the search field.
+3. Pinning a toggle adds a Pinned section **and** leaves the toggle in the Toggles list.
+4. Both copies show "Unpin" when swiped, and unpinning from either removes the Pinned section entry.
+5. Typing a search term, then turning overrides off and back on, leaves the search field empty and the full list visible.
+
+- [ ] **Step 8: Update the README**
+
+In the `### Feature Flags` section of `README.md`, add a note after the overrides documentation:
+
+```markdown
+The flag list is only shown while **Enable overrides** is on. With overrides off, local
+values have no effect, so the list, the reset button and the search field are hidden.
+
+Toggles can be pinned via a left swipe. Pinned toggles appear in a **Pinned** section at the
+top of the list and also remain in the main list. Pins persist across launches in Scyther's
+private preferences suite.
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/Scyther/Features/FeatureFlags/ Tests/ScytherTests/Features/FeatureFlagsTests.swift README.md
+git commit -m "Gate the feature flag list behind the overrides toggle"
+```
+
+---
+
+## Task 9: Final verification
+
+**Files:** none modified unless a check fails.
+
+- [ ] **Step 1: Confirm no Scyther code writes to the standard store**
+
+```bash
+grep -rn "UserDefaults.standard" --include="*.swift" Sources/
+```
+
+Expected: exactly two results — `Shared/Extensions/UserDefaults+Extensions.swift` and `Features/CookieBrowser/CookieDetailsViewModel.swift`. Both are correct; see Task 2.
+
+- [ ] **Step 2: Confirm no confirmation dialogs remain**
+
+```bash
+grep -rn "confirmationDialog" --include="*.swift" Sources/
+```
+
+Expected: no results. If any remain outside the files touched by this plan, leave them — they are out of scope — but note them in the final report.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+xcodebuild test -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `** TEST SUCCEEDED **`, with all of `ScytherDefaultsTests`, `MenuItemTests`, `MenuViewModelTests`, `UserDefaultsViewModelTests` and `FeatureFlagsTests` passing.
+
+- [ ] **Step 4: Build the documentation**
+
+```bash
+xcodebuild docbuild -scheme Scyther -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath ./docbuild
+```
+
+Expected: `** BUILD SUCCEEDED **` with no DocC warnings about unresolved symbol links. A warning naming `unpinnedToggles` means a `## Topics` block still references the deleted property.
+
+- [ ] **Step 5: Confirm the README is accurate**
+
+Check that `README.md` contains a `## Preferences Storage` section, a `### Pinning menu items` section, the Feature Flags note, and that every new section has a Table of Contents entry.
+
+- [ ] **Step 6: Commit anything outstanding**
+
+```bash
+git status --short
+```
+
+Expected: clean. If not, commit the remaining changes with a descriptive message.

--- a/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
+++ b/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
@@ -2525,13 +2525,14 @@ git commit -m "Gate the feature flag list behind the overrides toggle"
 grep -rln "UserDefaults.standard" --include="*.swift" Sources/
 ```
 
-Expected: exactly these five files, all of which reference the standard store legitimately:
+Expected: exactly these six files, all of which reference the standard store legitimately:
 
 | File | Why it is correct |
 | --- | --- |
 | `Core/ScytherDefaults.swift` | Names `.standard` as the migration *source*, as the fallback when the suite cannot be created, and in its DocC examples |
 | `Features/UserDefaults/UserDefaultsViewModel.swift` | The browser reads the host app's defaults for the `.app` store |
 | `Features/UserDefaults/UserDefaultsView.swift` | Store-selection copy naming the app's defaults |
+| `Features/UserDefaults/DefaultsStore.swift` | DocC comment describing what the `.app` case refers to (added in Task 3) |
 | `Shared/Extensions/UserDefaults+Extensions.swift` | Display helper, called against whichever store is shown |
 | `Features/CookieBrowser/CookieDetailsViewModel.swift` | `synchronize()` flushing `HTTPCookieStorage` |
 

--- a/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
+++ b/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
@@ -2528,7 +2528,7 @@ git commit -m "Gate the feature flag list behind the overrides toggle"
 grep -rln "UserDefaults.standard" --include="*.swift" Sources/
 ```
 
-Expected: exactly these four files, all of which reference the standard store legitimately:
+Expected: exactly these five files, all of which reference the standard store legitimately:
 
 | File | Why it is correct |
 | --- | --- |

--- a/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
+++ b/docs/superpowers/plans/2026-07-22-menu-pinning-and-defaults-suite.md
@@ -2546,7 +2546,18 @@ The gate that actually matters: **none of the 12 files migrated in Task 2 may ap
 grep -rn "confirmationDialog" --include="*.swift" Sources/
 ```
 
-Expected: no results. If any remain outside the files touched by this plan, leave them — they are out of scope — but note them in the final report.
+Expected: `Features/UserDefaults/UserDefaultsView.swift` must NOT appear — Task 3 converted it to `.alert`.
+
+Five pre-existing violations of the project's alerts-only rule remain in files this plan does not touch, and are deliberately left alone as out of scope:
+
+| File | Line |
+| --- | --- |
+| `Features/CookieBrowser/CookieBrowserView.swift` | 63 |
+| `Features/KeychainBrowser/KeychainBrowserView.swift` | 100, 216 |
+| `Features/FileBrowser/FileBrowserView.swift` | 70 |
+| `Features/FileBrowser/FileDetailView.swift` | 112 |
+
+Report these in the final summary as pre-existing debt rather than fixing them here — converting five unrelated views would balloon this branch's diff and its review surface.
 
 - [ ] **Step 3: Run the full test suite**
 

--- a/docs/superpowers/specs/2026-07-22-menu-pinning-and-defaults-suite-design.md
+++ b/docs/superpowers/specs/2026-07-22-menu-pinning-and-defaults-suite-design.md
@@ -255,9 +255,17 @@ hidden:
 
 - The "Pinned" and "Toggles" sections are omitted entirely.
 - The "Reset all to Remote" button is hidden, leaving "Global Settings" with a single row.
-- `.searchable` is not applied, so no dead search field filters an invisible list. `searchText`
-  and `debouncedSearchText` are cleared when overrides are switched off, so re-enabling never
-  reveals a list silently filtered by a stale query.
+- `.searchable` **is** applied unconditionally — the search field stays visible even while the
+  list is hidden. `searchText` and `debouncedSearchText` are still cleared when overrides are
+  switched off, so re-enabling never reveals a list silently filtered by a stale query.
+
+  Rationale for keeping the search field always present: applying `.searchable` conditionally
+  forces `body` to branch between two view shapes, and flipping the toggle then swaps which
+  branch renders — destroying that branch's view identity along with any `.onChange`,
+  `.onAppear` or `@State` attached inside it. The search-clearing handler would silently
+  never fire on the exact transition it exists to handle, and no test would catch it. A
+  single unconditional shape removes that failure mode entirely. A momentarily inert search
+  field is a smaller cost than structurally fragile view identity.
 - The "Global Settings" section gains a **footer** reading along the lines of
   "Enable overrides to view and modify feature flags." The footer is shown only while
   overrides are off; once enabled the flags are visible and self-explanatory, so it is

--- a/docs/superpowers/specs/2026-07-22-menu-pinning-and-defaults-suite-design.md
+++ b/docs/superpowers/specs/2026-07-22-menu-pinning-and-defaults-suite-design.md
@@ -1,0 +1,323 @@
+# Pinnable Main Menu Items & Private Preferences Suite
+
+**Date:** 2026-07-22
+**Status:** Approved
+
+## Overview
+
+Two changes to Scyther:
+
+1. **Private preferences suite** — all of Scyther's persisted settings move out of
+   `UserDefaults.standard` into a dedicated suite, so host apps that wipe the standard
+   domain on sign-out no longer destroy Scyther's state.
+2. **Pinnable main menu items** — any row in `MenuView` can be pinned to a new "Pinned"
+   section rendered second in the list, mirroring the existing Feature Flags pinning UX.
+
+Part 1 lands first: menu pin state is persisted into the new suite.
+
+---
+
+## Part 1 — Private Preferences Suite
+
+### Problem
+
+Scyther persists roughly 82 values across 13 files into `UserDefaults.standard`. Apps
+commonly clear the entire standard domain when a user signs out, using either:
+
+- iterating `UserDefaults.standard.dictionaryRepresentation()` and removing each key, or
+- `UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)`
+
+Both operate on the **app domain only**. A named suite is a separate persistent domain and
+is untouched by either, so moving Scyther's state into one fully solves the problem.
+
+### Design
+
+**New file: `Sources/Scyther/Core/ScytherDefaults.swift`**
+
+```swift
+public extension UserDefaults {
+    /// Scyther's private preferences store, isolated from `UserDefaults.standard`.
+    static let scyther: UserDefaults = ScytherDefaults.makeStore()
+}
+
+internal enum ScytherDefaults {
+    static let suiteName = "com.scyther.settings"
+    static let keyPrefix = "scyther"                              // matched case-insensitively
+    static let migrationKey = "Scyther.Defaults.DidMigrateFromStandard"
+
+    static func makeStore() -> UserDefaults
+    static func migrate(from source: UserDefaults, to destination: UserDefaults)
+}
+```
+
+`makeStore()` returns `UserDefaults(suiteName: suiteName)`, falling back to
+`UserDefaults.standard` if initialisation returns `nil`. Before returning, it runs the
+one-time migration.
+
+On iOS a named suite is written to `<container>/Library/Preferences/com.scyther.settings.plist`
+inside the app's own sandbox, so a fixed name carries no cross-app collision risk.
+
+### Migration
+
+`migrate(from:to:)` is a pure function over two stores so it can be driven by tests with
+throwaway suites. It is invoked once, guarded by `migrationKey` stored in the destination:
+
+1. Read `source.persistentDomain(forName: Bundle.main.bundleIdentifier)`. This is used in
+   preference to `dictionaryRepresentation()`, which would also return inherited
+   global-domain keys that do not belong to the app.
+2. For each key whose lowercased form has the prefix `scyther`:
+   - write it to the destination **only if the destination has no existing value for that
+     key** — never clobber newer state;
+   - remove it from the source.
+3. Set `migrationKey` to `true` in the destination.
+
+All of Scyther's existing keys are consistently prefixed (`Scyther_*`, `Scyther.*`,
+`scyther.*`), which the existing `UserDefaultsViewModel.resetAllDefaults()` filter already
+relies on, so prefix matching is a safe migration predicate.
+
+### Call-site changes
+
+`UserDefaults.standard` → `UserDefaults.scyther` across:
+
+| File | Sites |
+| --- | --- |
+| `Features/LocationSpoofer/LocationSpoofer.swift` | 23 |
+| `Features/AppearanceOverrides/AppearanceOverrides.swift` | 10 |
+| `Features/GridOverlay/GridOverlay.swift` | 8 |
+| `Core/InterfaceToolkit.swift` | 8 |
+| `Features/TouchVisualiser/TouchVisualiserConfiguration.swift` | 6 |
+| `Core/Scyther.swift` | 5 |
+| `Features/FPSCounter/FPSCounter.swift` | 4 |
+| `Features/FeatureFlags/FeatureToggle.swift` | 4 |
+| `Features/DeepLinkTester/DeepLinkTester.swift` | 4 |
+| `Features/CrashLogs/CrashLogger.swift` | 4 |
+| `Features/FeatureFlags/FeatureFlagsViewModel.swift` | 2 |
+| `Core/UIView+InterfaceToolkit.swift` | 2 |
+
+Two sites deliberately stay on `.standard`:
+
+- `Shared/Extensions/UserDefaults+Extensions.swift` — `stringStringDictionaryRepresentation`
+  is a browser display helper invoked against whichever store is being shown.
+- `Features/CookieBrowser/CookieDetailsViewModel.swift` — its `synchronize()` call flushes
+  `HTTPCookieStorage`, unrelated to Scyther settings.
+
+`UserDefaults.scyther` is a `static let` on an extension, so it is reachable from the
+`nonisolated` accessors in `Scyther.swift`, `InterfaceToolkit.swift` and
+`UIView+InterfaceToolkit.swift` without a main-actor hop, preserving the existing
+concurrency design. If Foundation's `UserDefaults` does not carry a `Sendable` conformance
+under this SDK, the property is declared `nonisolated(unsafe) static let` — `UserDefaults`
+is documented as thread-safe.
+
+### UserDefaults browser store picker
+
+Once Scyther's settings leave the standard domain they become invisible in the browser, so
+`UserDefaultsView` gains a store selector.
+
+- New `DefaultsStore` enum with cases `.app` and `.scyther`, exposed as a `@Published`
+  property on `UserDefaultsViewModel` and rendered as a segmented `Picker` above the list.
+- `.app` loads via `UserDefaults.standard.dictionaryRepresentation()` (unchanged behaviour).
+- `.scyther` loads via `persistentDomain(forName: ScytherDefaults.suiteName)` so only
+  Scyther's own keys appear, without inherited global-domain noise.
+- Reads, writes, boolean bindings and deletes all route to the selected store.
+- `resetAllDefaults()` becomes store-aware:
+  - `.app` — current behaviour retained, including the `!hasPrefix("scyther")` filter, which
+    remains as a safety net for any un-migrated stragglers.
+  - `.scyther` — offers "Reset all Scyther settings", clearing the suite, behind its own
+    alert with distinct copy.
+
+---
+
+## Part 2 — Pinnable Main Menu Items
+
+### Problem
+
+`MenuView.swift` is approximately 40 literal `NavigationLink` / row declarations across 8
+hardcoded sections. Rows have no identity, so they cannot be persisted as pins or rendered
+outside their home section.
+
+### Design decisions
+
+| Decision | Choice |
+| --- | --- |
+| What is pinnable | Every row, including static info rows, inline toggles and custom developer options |
+| Pinned row behaviour | Stays in its home section; the Pinned section is an additional shortcut |
+| Gesture | Trailing swipe action, matching Feature Flags |
+| Pinned section position | Second — after "Device", before "Application" |
+| Pinned section ordering | Order pinned, oldest first |
+
+### `MenuItem`
+
+**New file: `Sources/Scyther/Features/Menu/MenuItem.swift`**
+
+```swift
+enum MenuItem: Hashable, Identifiable {
+    case osVersion, hardware, releaseYear, uuid                      // Device
+    case appIdPrefix, displayName, bundleId, processId,
+         version, buildNumber, buildDate, releaseType                // Application
+    case developerOption(name: String)                               // Development Tools
+    case ipAddress, networkLogs, serverConfiguration,
+         environmentVariables                                        // Networking
+    case featureFlags, userDefaults, cookies, fileBrowser,
+         databaseBrowser                                             // Data
+    case keychainBrowser                                             // Security
+    case locationSpoofer, consoleLogs, deepLinkTester, crashLogs     // System Tools
+    case notificationLogger, notificationTester, apnsToken, fcmToken // Notifications
+    case fonts, interfaceComponents, gridOverlay, fpsCounter,
+         touchVisualiser, appearance, slowAnimations,
+         showViewFrames, showViewSizes                               // UI/UX
+
+    var id: String              // stable identifier, persisted
+    init?(id: String)           // round-trips; returns nil for unknown identifiers
+    var title: String
+    var icon: String?
+}
+```
+
+39 static items plus dynamic `developerOption(name:)`, whose id is `"developerOption.<name>"`.
+
+The device header (app icon, device name, model) is **not** a `MenuItem` — it remains a
+plain header view inside the Device section and is not pinnable.
+
+`MenuItem` owns `title` and `icon` so they have a single definition and can be asserted in
+tests. Everything genuinely dynamic — a value row's description, a navigation row's
+destination, a toggle row's binding — is supplied by the view.
+
+### `MenuSection`
+
+**New file: `Sources/Scyther/Features/Menu/MenuSection.swift`**
+
+```swift
+struct MenuSection: Identifiable {
+    var id: String { title }
+    let title: String
+    let items: [MenuItem]
+}
+```
+
+The ordered section layout (Device, Application, Development Tools, Networking, Data,
+Security, System Tools, Notifications, UI/UX) is built here. The Development Tools section
+is populated from `Scyther.developerOptions` at build time and omitted when empty, matching
+current behaviour.
+
+### `MenuViewModel` additions
+
+```swift
+@Published private(set) var pinnedItemIDs: [String]   // array preserves pin order
+var sections: [MenuSection]
+var pinnedItems: [MenuItem]                           // ids → items, dropping unknown ids
+func isPinned(_ item: MenuItem) -> Bool
+func togglePin(for item: MenuItem)                    // append on pin, remove on unpin
+init(defaults: UserDefaults = .scyther)               // injectable for tests
+```
+
+Pin state persists to key `Scyther.Menu.PinnedItems` in `UserDefaults.scyther` as a
+`[String]`. An array rather than a `Set` is used so oldest-first pin order survives a
+relaunch.
+
+`pinnedItems` maps stored ids back through `MenuItem.init?(id:)` and silently drops any that
+no longer resolve. This covers a removed feature after an upgrade and a renamed developer
+option in the host app.
+
+### `MenuView` changes
+
+The body becomes data-driven. A single `@ViewBuilder func rowContent(for: MenuItem)` switch
+holds one definition per row and is rendered from both the home section and the Pinned
+section:
+
+```
+Section("Device")  { header; ForEach(sections[0].items) { rowContent(for:) } }
+Section("Pinned")  { ForEach(pinnedItems) { rowContent(for:) } }   // only when non-empty
+ForEach(sections.dropFirst()) { section in
+    Section(section.title) { ForEach(section.items) { rowContent(for:) } }
+}
+```
+
+Every row carries the same trailing swipe action. Its label is derived from
+`isPinned(item)`, so a pinned row reads "Unpin" (`pin.slash`) in both the Pinned section and
+its home section, and an unpinned row reads "Pin" (`pin`). Tint is `.blue`, matching
+Feature Flags.
+
+Because pinned items remain in their home section, the same `MenuItem` renders twice in one
+`List`. The Pinned `ForEach` uses a namespaced row identifier (`"pinned.<id>"`) so SwiftUI's
+row identity is unambiguous.
+
+The existing `row(withLabel:description:icon:andLoadingState:)`, `toggleRow(_:icon:isOn:)`,
+`developerOptionRow(_:)` and `developerOptionLabel(_:)` helpers are retained and called from
+`rowContent(for:)`.
+
+### Feature Flags alignment
+
+Only one behavioural change, to match the menu's "stays in place" semantics:
+
+- `FeatureFlagsViewModel.unpinnedToggles` is removed.
+- `FeatureFlagsView`'s "Toggles" section renders all toggles (search-filtered), so a pinned
+  flag appears in both "Pinned" and "Toggles".
+- The now-unreachable "All toggles are pinned" empty state is deleted. The "No toggles
+  configured" and "No matching toggles" states are retained.
+
+Feature Flags pin **ordering and storage are unchanged**: pins remain a `Set<String>` and
+the Pinned section remains alphabetical, inherited from `toggles` being sorted by name. The
+menu's oldest-first ordering is intentionally different; the two lists have different
+character and this was an explicit decision.
+
+`FeatureFlagsViewModel` does gain `init(defaults: UserDefaults = .scyther)` so its pin
+persistence can be tested without touching the real suite, and its pin key moves into the
+new suite along with everything else.
+
+---
+
+## Testing
+
+New test files:
+
+- **`Tests/ScytherTests/Core/ScytherDefaultsTests.swift`**
+  - migration copies `scyther`-prefixed keys from source to destination
+  - migration removes the copied keys from the source
+  - migration ignores keys without the prefix, in both directions
+  - migration never overwrites an existing destination value
+  - migration is idempotent — a second run is a no-op
+  - prefix matching is case-insensitive (`Scyther_`, `scyther.`)
+
+- **`Tests/ScytherTests/Features/MenuItemTests.swift`**
+  - all ids are unique across every case
+  - `init?(id:)` round-trips every case, including `developerOption` names containing dots
+    and spaces
+  - `init?(id:)` returns `nil` for an unrecognised id
+  - every item has a non-empty title
+
+- **`Tests/ScytherTests/Features/MenuViewModelTests.swift`**
+  - every `MenuItem` case appears in exactly one section — guards against a case being added
+    without being rendered
+  - Development Tools section is omitted when `Scyther.developerOptions` is empty and
+    populated when it is not
+  - pinning appends; unpinning removes; order is oldest-first and stable across further pins
+  - pin state round-trips through an injected `UserDefaults` store
+  - stored ids that no longer resolve are dropped from `pinnedItems` without affecting the
+    rest
+  - `isPinned` agrees with `pinnedItemIDs`
+
+Updated test files:
+
+- **`FeatureFlagsViewModelTests`** — pinned toggles remain present in the full `toggles`
+  array; pinned ordering stays alphabetical.
+- **`UserDefaultsViewModelTests`** (new if absent) — switching `DefaultsStore` loads from the
+  correct domain; writes and deletes land in the selected store; `.scyther` enumeration
+  excludes global-domain keys.
+
+Both `MenuViewModel` and `FeatureFlagsViewModel` take an injectable `UserDefaults` so no test
+mutates the real `com.scyther.settings` suite.
+
+## Documentation
+
+- DocC comments on `ScytherDefaults`, `UserDefaults.scyther`, `MenuItem`, `MenuSection`,
+  `DefaultsStore` and every new view model member, matching the density of surrounding code.
+- README: a "Pinning menu items" subsection under the menu documentation, and a new
+  "Preferences Storage" section covering the suite name, the isolation guarantee against
+  standard-domain wipes, and the automatic one-time migration.
+
+## Out of Scope
+
+- Reordering pinned items by drag.
+- A public API for host apps to override the suite name or point Scyther at an app group.
+- Pinning anything outside the main menu and Feature Flags.
+- Changing Feature Flags' pin ordering or storage representation.

--- a/docs/superpowers/specs/2026-07-22-menu-pinning-and-defaults-suite-design.md
+++ b/docs/superpowers/specs/2026-07-22-menu-pinning-and-defaults-suite-design.md
@@ -247,6 +247,27 @@ The existing `row(withLabel:description:icon:andLoadingState:)`, `toggleRow(_:ic
 
 ### Feature Flags alignment
 
+#### Gating the list on `overridesEnabled`
+
+While `overridesEnabled` is `false`, local overrides have no effect, so presenting an
+interactive flag list is misleading. Everything except the "Enable overrides" toggle is
+hidden:
+
+- The "Pinned" and "Toggles" sections are omitted entirely.
+- The "Reset all to Remote" button is hidden, leaving "Global Settings" with a single row.
+- `.searchable` is not applied, so no dead search field filters an invisible list. `searchText`
+  and `debouncedSearchText` are cleared when overrides are switched off, so re-enabling never
+  reveals a list silently filtered by a stale query.
+- The "Global Settings" section gains a **footer** reading along the lines of
+  "Enable overrides to view and modify feature flags." The footer is shown only while
+  overrides are off; once enabled the flags are visible and self-explanatory, so it is
+  omitted.
+
+The placeholder rows inside the "Toggles" section ("No toggles configured", "No matching
+toggles") are unaffected — they only ever render when overrides are on.
+
+#### Pinned rows stay in place
+
 Only one behavioural change, to match the menu's "stays in place" semantics:
 
 - `FeatureFlagsViewModel.unpinnedToggles` is removed.
@@ -299,7 +320,9 @@ New test files:
 Updated test files:
 
 - **`FeatureFlagsViewModelTests`** — pinned toggles remain present in the full `toggles`
-  array; pinned ordering stays alphabetical.
+  array; pinned ordering stays alphabetical; toggling `overridesEnabled` propagates to
+  `Scyther.featureFlags.localOverridesEnabled` in both directions, which is the value the
+  view's gating reads.
 - **`UserDefaultsViewModelTests`** (new if absent) — switching `DefaultsStore` loads from the
   correct domain; writes and deletes land in the selected store; `.scyther` enumeration
   excludes global-domain keys.


### PR DESCRIPTION
Two changes, requested together.

## 1. Scyther settings moved to a private `UserDefaults` suite

Apps commonly clear the entire standard domain when a user signs out, which destroyed Scyther's state. All ~82 persisted settings now live in `com.scyther.settings`, exposed as `UserDefaults.scyther`.

A named suite is a separate persistent domain, so neither of the two common wipe patterns touches it:

```swift
UserDefaults.standard.dictionaryRepresentation().keys.forEach(UserDefaults.standard.removeObject(forKey:))
UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
```

Existing settings migrate automatically on first access: every key prefixed `scyther` (case-insensitive) moves across, skipping any the suite already has, then is removed from the standard store. Runs once, guarded by a flag in the destination.

The UserDefaults browser gained an **App / Scyther** store picker so both remain inspectable — without it, Scyther's own state would have become invisible.

## 2. Pinnable main-menu items

Every row is pinnable via a trailing swipe, matching the existing Feature Flags interaction. Pinned rows appear in a **Pinned** section rendered second, directly under Device, **and stay in their home section** — the menu never changes shape. Order is oldest-pinned-first, persisted to the new suite.

This required rewriting `MenuView` from ~40 hardcoded rows into a data-driven form: `MenuItem` (stable id, title, icon) and `MenuSection` (layout). Everything is pinnable, including info rows, inline toggles, and host-registered `Scyther.developerOptions`.

Feature Flags was aligned to the same "stays in place" semantics, and its list is now gated behind the **Enable overrides** toggle — local overrides do nothing while it's off, so presenting an interactive list was misleading.

## Deliberate decisions

- **Feature Flags pin order stays alphabetical** (`Set<String>`); the menu is oldest-first (`[String]`). Intentionally different.
- **`.searchable` is unconditional** on Feature Flags. Applying it conditionally forced `body` to branch between two view shapes; flipping the toggle then swapped branches and destroyed view identity, silently killing the `.onChange` that clears the search text. One shape removes the failure mode rather than stabilising it with a wrapper.
- **`Scyther.developerOptions` is snapshotted once** in `MenuViewModel.init`. Options registered while the menu is already open won't appear until it's reopened — this closes a multi-read inconsistency that could render a blank-but-swipeable row.
- `.confirmationDialog` in the UserDefaults browser converted to `.alert` per the project's alerts-only rule.

## Verification

- **390 tests passing** (was 342 on `main`; +48)
- `xcodebuild build` and `docbuild` both succeed
- **Zero new DocC warnings** — measured by building docs at the branch base and diffing warning sets: 31 before, 31 after, set difference empty
- Migration verified end-to-end against a real bundle, including: existing settings, none, values in both stores, and suite-construction failure. No path loses data.
- Public API surface: exactly one addition, `UserDefaults.scyther`

Two bugs found by whole-branch review and fixed here, both only visible across a feature boundary:
- Nested value edits in the browser ignored the store picker, silently discarding edits made against the Scyther store
- Resetting the Scyther store left menu pins in stale memory; the next pin wrote them back, undoing the reset

## Outstanding manual QA

Pinning is UI behaviour and isn't covered by tests. Worth checking in `Example/ScytherExample`: swipe-to-pin reveals the right action on both copies of a pinned row; pins survive a force-quit; and the always-visible search field looks right above a gated Feature Flags list.

## Not in scope

Five pre-existing `.confirmationDialog` uses remain in CookieBrowser, KeychainBrowser (×2), FileBrowser and FileDetail. They violate the same project rule but sit in files this branch doesn't touch.
