### PR TITLE
Add filter chips to Network Logs and an export button to Request Details

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A comprehensive iOS debugging toolkit that helps you cut through bugs in your iO
 - **Network Logging**: Automatically intercept and log all HTTP requests/responses
 - **Request Details**: View headers, body, timing, and response codes
 - **cURL Export**: Generate cURL commands for any captured request
+- **Filter Chips**: Narrow the network log by method, status class, host, content type, API kind, GraphQL operation, duration, exact status code, or recency from glass chips pinned above the list, or edit every filter at once from the all-filters sheet
 - **Server Configuration**: Switch between development, staging, and production environments
 - **IP Address**: Display the device's public IP address
 
@@ -401,7 +402,16 @@ Network requests are displayed in the Scyther UI under **Network Logs**. Each re
 - Request/response headers
 - Request/response body — both a structured **Browse** view (JSON tree) and a raw **View** view
 - Status code and timing
-- cURL command for reproduction
+- cURL command for reproduction, shareable from the export button in the navigation bar or the "Export cURL request" row at the bottom of the page
+
+Above the list, a row of filter chips narrows the log: Method, Status, Host, Type, API, GraphQL,
+Duration, Code, and Recency. Tapping a chip opens a sheet with a multi-select checklist;
+selections apply immediately and combine with the search field. Active chips are fully tinted
+and show the selected value, or a count when several are selected; the Clear chip is red. Method, host, and exact status code options are built from the
+captured requests, so you only ever choose from values that exist. The Host list has an Include /
+Exclude control in its header, so the selected hosts can act as an allow list or a deny list. An icon-only chip at the start
+of the row opens a Filters sheet listing every dimension, grouped into Request, Response, and Timing, with
+its current selection; each row pushes that dimension's checklist. A Clear chip appears whenever a filter is active.
 
 #### GraphQL Support
 

--- a/Sources/Scyther/Features/NetworkLogger/LogDetailsView.swift
+++ b/Sources/Scyther/Features/NetworkLogger/LogDetailsView.swift
@@ -28,9 +28,25 @@ struct LogDetailsView: View {
             developerSection
         }
         .navigationTitle("Request Details")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                exportButton
+            }
+        }
         .onFirstAppear {
             await viewModel.onFirstAppear()
         }
+    }
+
+    /// Shares the request as a cURL command from the navigation bar.
+    ///
+    /// Presents the same system share sheet as the "Export cURL request" row in the
+    /// developer section, using ``LogDetailsViewModel/curlRequest`` as the shared item.
+    private var exportButton: some View {
+        ShareLink(item: viewModel.curlRequest) {
+            Image(systemName: "square.and.arrow.up")
+        }
+        .accessibilityLabel("Export cURL request")
     }
 
     private var overviewSection: some View {

--- a/Sources/Scyther/Features/NetworkLogger/LoggerNetworkHelper.swift
+++ b/Sources/Scyther/Features/NetworkLogger/LoggerNetworkHelper.swift
@@ -23,7 +23,7 @@ import Foundation
 /// let type = HTTPModelShortType.JSON
 /// print(type.rawValue) // "JSON"
 /// ```
-public enum HTTPModelShortType: String, CaseIterable {
+public enum HTTPModelShortType: String, CaseIterable, Sendable {
     /// JSON response (application/json or variants like application/vnd.api+json).
     case JSON = "JSON"
 

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogAllFiltersSheet.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogAllFiltersSheet.swift
@@ -1,0 +1,111 @@
+//
+//  NetworkLogAllFiltersSheet.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import SwiftUI
+
+/// A full-height sheet listing every ``NetworkLogFilterDimension`` as a row that pushes its own page.
+///
+/// Presented from the leading icon-only chip in ``NetworkLogFilterBar``. Rows are sectioned by
+/// ``NetworkLogFilterGroup`` (Request, Response, Timing). Each row shows the dimension's icon,
+/// title, and a summary of its current selection. Tapping a row pushes
+/// ``NetworkLogFilterDimensionPage`` for that dimension. Selections apply immediately through the
+/// view model's change callback. A Reset button appears in the leading toolbar slot only while any
+/// dimension has a selection.
+struct NetworkLogAllFiltersSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @StateObject private var viewModel: NetworkLogAllFiltersSheetViewModel
+
+    /// Creates the all-filters sheet.
+    ///
+    /// - Parameter viewModel: The view model owning the sections and working filter.
+    init(viewModel: NetworkLogAllFiltersSheetViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(viewModel.groups) { grouped in
+                    Section(grouped.group.title) {
+                        ForEach(grouped.sections) { section in
+                            NavigationLink {
+                                NetworkLogFilterDimensionPage(viewModel: viewModel, section: section)
+                            } label: {
+                                LabeledContent {
+                                    Text(viewModel.summary(for: section.dimension))
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
+                                } label: {
+                                    Label(section.dimension.title, systemImage: section.dimension.systemImage)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Filters")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    if viewModel.canReset {
+                        Button("Reset") { viewModel.reset() }
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    NetworkLogFilterConfirmButton { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+    }
+}
+
+/// The pushed page for one dimension inside ``NetworkLogAllFiltersSheet``.
+///
+/// Shows the dimension's options as a checklist backed by the shared
+/// ``NetworkLogAllFiltersSheetViewModel``. A Reset button for this dimension alone appears in the
+/// trailing toolbar slot while it has a selection. The host page adds an Include / Exclude
+/// segmented control as its section header.
+struct NetworkLogFilterDimensionPage: View {
+    @ObservedObject var viewModel: NetworkLogAllFiltersSheetViewModel
+
+    /// The dimension and options this page edits.
+    let section: NetworkLogFilterSection
+
+    var body: some View {
+        List {
+            Section {
+                if section.options.isEmpty {
+                    NetworkLogFilterEmptyRow(dimensionName: section.dimension.title.lowercased())
+                } else {
+                    ForEach(section.options) { option in
+                        NetworkLogFilterOptionRow(
+                            title: option.title,
+                            isSelected: viewModel.isSelected(option, in: section.dimension),
+                            action: { viewModel.toggle(option, in: section.dimension) }
+                        )
+                    }
+                }
+            } header: {
+                if section.dimension == .host {
+                    NetworkLogHostModePicker(mode: viewModel.hostMode, onChange: viewModel.setHostMode)
+                }
+            }
+        }
+        .navigationTitle(section.dimension.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                if viewModel.canReset(section.dimension) {
+                    Button("Reset") { viewModel.reset(section.dimension) }
+                }
+            }
+        }
+    }
+}

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogAllFiltersSheetViewModel.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogAllFiltersSheetViewModel.swift
@@ -1,0 +1,171 @@
+//
+//  NetworkLogAllFiltersSheetViewModel.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import Foundation
+
+/// One section of ``NetworkLogAllFiltersSheet``: a dimension and its selectable options.
+struct NetworkLogFilterSection: Identifiable, Sendable {
+    /// The dimension this section edits.
+    let dimension: NetworkLogFilterDimension
+
+    /// The selectable rows for the dimension, in display order.
+    let options: [NetworkLogFilterOption]
+
+    var id: String { dimension.id }
+}
+
+/// A group of sections in ``NetworkLogAllFiltersSheet``.
+struct NetworkLogFilterGroupedSections: Identifiable, Sendable {
+    /// The group these sections belong to.
+    let group: NetworkLogFilterGroup
+
+    /// The sections in this group, in ``NetworkLogFilterGroup/dimensions`` order.
+    let sections: [NetworkLogFilterSection]
+
+    var id: String { group.id }
+}
+
+/// View model backing ``NetworkLogAllFiltersSheet`` and the dimension pages it pushes.
+///
+/// The view model holds a working copy of the ``NetworkLogFilter`` and reports the whole filter
+/// to its owner through `onChange` after every toggle or reset, so the list behind the sheet
+/// updates live.
+///
+/// ## Usage
+///
+/// ```swift
+/// let viewModel = NetworkLogAllFiltersSheetViewModel(
+///     filter: listViewModel.filter,
+///     options: listViewModel.options(for:)
+/// ) { listViewModel.filter = $0 }
+/// ```
+final class NetworkLogAllFiltersSheetViewModel: ViewModel {
+    /// The working filter reflected by the sheet.
+    @Published private(set) var filter: NetworkLogFilter
+
+    /// One section per dimension, in ``NetworkLogFilterDimension/allCases`` order.
+    let sections: [NetworkLogFilterSection]
+
+    /// The sections grouped for display, in ``NetworkLogFilterGroup/allCases`` order.
+    var groups: [NetworkLogFilterGroupedSections] {
+        NetworkLogFilterGroup.allCases.map { group in
+            NetworkLogFilterGroupedSections(
+                group: group,
+                sections: group.dimensions.compactMap { dimension in
+                    sections.first { $0.dimension == dimension }
+                }
+            )
+        }
+    }
+
+    /// Invoked with the full filter after every change.
+    private let onChange: (NetworkLogFilter) -> Void
+
+    /// Creates a view model for the all-filters sheet.
+    ///
+    /// - Parameters:
+    ///   - filter: The filter as it stands when the sheet opens.
+    ///   - options: Supplies the selectable options for each dimension.
+    ///   - onChange: Called with the full filter after every change.
+    init(
+        filter: NetworkLogFilter,
+        options: (NetworkLogFilterDimension) -> [NetworkLogFilterOption],
+        onChange: @escaping (NetworkLogFilter) -> Void
+    ) {
+        self.filter = filter
+        self.sections = NetworkLogFilterDimension.allCases.map {
+            NetworkLogFilterSection(dimension: $0, options: options($0))
+        }
+        self.onChange = onChange
+        super.init()
+    }
+
+    /// Whether any dimension has a selection that can be reset.
+    var canReset: Bool { filter.isActive }
+
+    /// Whether a single dimension has a selection that can be reset.
+    ///
+    /// - Parameter dimension: The dimension to check.
+    func canReset(_ dimension: NetworkLogFilterDimension) -> Bool {
+        filter.selectionCount(for: dimension) > 0
+    }
+
+    /// A one-line description of a dimension's selection for its row in the root list.
+    ///
+    /// Returns "Any" when nothing is selected, otherwise the selected option titles in
+    /// display order, comma separated.
+    ///
+    /// - Parameter dimension: The dimension to describe.
+    func summary(for dimension: NetworkLogFilterDimension) -> String {
+        let selected = filter.selection(for: dimension)
+        guard !selected.isEmpty else { return "Any" }
+        let options = sections.first { $0.dimension == dimension }?.options ?? []
+        let titles = options.filter { selected.contains($0.id) }.map(\.title)
+        let joined = titles.isEmpty ? selected.sorted().joined(separator: ", ") : titles.joined(separator: ", ")
+        if dimension == .host, filter.hostMode == .exclude {
+            return "Exclude: \(joined)"
+        }
+        return joined
+    }
+
+    /// The current host include/exclude mode.
+    var hostMode: HostFilterMode { filter.hostMode }
+
+    /// Updates the host include/exclude mode and notifies the owner.
+    ///
+    /// - Parameter mode: The new mode.
+    func setHostMode(_ mode: HostFilterMode) {
+        filter.hostMode = mode
+        onChange(filter)
+    }
+
+    /// Whether an option is selected within a dimension.
+    ///
+    /// - Parameters:
+    ///   - option: The option to check.
+    ///   - dimension: The dimension the option belongs to.
+    func isSelected(_ option: NetworkLogFilterOption, in dimension: NetworkLogFilterDimension) -> Bool {
+        filter.selection(for: dimension).contains(option.id)
+    }
+
+    /// Adds or removes an option from a dimension's selection.
+    ///
+    /// For a single-select dimension, selecting an option replaces any other selection.
+    ///
+    /// - Parameters:
+    ///   - option: The option to toggle.
+    ///   - dimension: The dimension the option belongs to.
+    func toggle(_ option: NetworkLogFilterOption, in dimension: NetworkLogFilterDimension) {
+        var selection = filter.selection(for: dimension)
+        if selection.contains(option.id) {
+            selection.remove(option.id)
+        } else if dimension.isSingleSelect {
+            selection = [option.id]
+        } else {
+            selection.insert(option.id)
+        }
+        filter.setSelection(selection, for: dimension)
+        onChange(filter)
+    }
+
+    /// Clears a single dimension.
+    ///
+    /// - Parameter dimension: The dimension to clear.
+    func reset(_ dimension: NetworkLogFilterDimension) {
+        filter.setSelection([], for: dimension)
+        if dimension == .host {
+            filter.hostMode = .include
+        }
+        onChange(filter)
+    }
+
+    /// Clears every dimension.
+    func reset() {
+        filter.clear()
+        onChange(filter)
+    }
+}

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogFilter.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogFilter.swift
@@ -1,0 +1,501 @@
+//
+//  NetworkLogFilter.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import Foundation
+
+/// A coarse grouping of HTTP response status codes used for filtering network logs.
+///
+/// Requests that have not yet received a response (or that failed without one) are
+/// grouped under ``pending``.
+enum HTTPStatusClass: String, CaseIterable, Hashable, Sendable {
+    /// 2xx responses.
+    case success
+    /// 3xx responses.
+    case redirect
+    /// 4xx responses.
+    case clientError
+    /// 5xx responses.
+    case serverError
+    /// No response received, or a response code outside the standard ranges.
+    case pending
+
+    /// A short label suitable for display in a chip or list row.
+    var displayName: String {
+        switch self {
+        case .success: return "2xx Success"
+        case .redirect: return "3xx Redirect"
+        case .clientError: return "4xx Client Error"
+        case .serverError: return "5xx Server Error"
+        case .pending: return "Pending / No Response"
+        }
+    }
+
+    /// Derives the status class for a captured request from its response code.
+    ///
+    /// - Parameter request: The request to classify.
+    init(request: HTTPRequest) {
+        switch request.responseCode ?? 0 {
+        case 200..<300: self = .success
+        case 300..<400: self = .redirect
+        case 400..<500: self = .clientError
+        case 500..<600: self = .serverError
+        default: self = .pending
+        }
+    }
+}
+
+/// Whether a request is plain REST or a GraphQL operation.
+enum APIKind: String, CaseIterable, Hashable, Sendable {
+    /// Not detected as GraphQL.
+    case rest
+    /// Detected as GraphQL.
+    case graphQL
+
+    /// A short label suitable for display in a list row.
+    var displayName: String {
+        switch self {
+        case .rest: return "REST"
+        case .graphQL: return "GraphQL"
+        }
+    }
+
+    /// Derives the kind for a captured request.
+    ///
+    /// - Parameter request: The request to classify.
+    init(request: HTTPRequest) {
+        self = request.isGraphQL ? .graphQL : .rest
+    }
+}
+
+/// The operation type of a GraphQL request.
+enum GraphQLOperationFilter: String, CaseIterable, Hashable, Sendable {
+    /// A GraphQL query.
+    case query
+    /// A GraphQL mutation.
+    case mutation
+    /// A GraphQL subscription.
+    case subscription
+    /// A GraphQL request with no single operation type, such as a batched payload.
+    case batch
+
+    /// A short label suitable for display in a list row.
+    var displayName: String {
+        switch self {
+        case .query: return "Query"
+        case .mutation: return "Mutation"
+        case .subscription: return "Subscription"
+        case .batch: return "Batch / Unknown"
+        }
+    }
+
+    /// Derives the operation for a captured GraphQL request, or `nil` for a non-GraphQL request.
+    ///
+    /// - Parameter request: The request to classify.
+    init?(request: HTTPRequest) {
+        guard request.isGraphQL else { return nil }
+        switch request.graphQLOperationType {
+        case .query: self = .query
+        case .mutation: self = .mutation
+        case .subscription: self = .subscription
+        case nil: self = .batch
+        }
+    }
+}
+
+/// A coarse bucket for how long a request took, from send to response.
+enum DurationBucket: String, CaseIterable, Hashable, Sendable {
+    case under100ms
+    case from100msTo500ms
+    case from500msTo1s
+    case from1sTo3s
+    case over3s
+
+    /// A short label suitable for display in a list row.
+    var displayName: String {
+        switch self {
+        case .under100ms: return "Under 100ms"
+        case .from100msTo500ms: return "100ms to 500ms"
+        case .from500msTo1s: return "500ms to 1s"
+        case .from1sTo3s: return "1s to 3s"
+        case .over3s: return "Over 3s"
+        }
+    }
+
+    /// Derives the bucket for a captured request, or `nil` if it has no duration yet.
+    ///
+    /// - Parameter request: The request to classify.
+    init?(request: HTTPRequest) {
+        guard let milliseconds = request.requestDuration else { return nil }
+        switch milliseconds {
+        case ..<100: self = .under100ms
+        case ..<500: self = .from100msTo500ms
+        case ..<1000: self = .from500msTo1s
+        case ..<3000: self = .from1sTo3s
+        default: self = .over3s
+        }
+    }
+}
+
+/// A trailing time window measured back from "now" in which a request must have been sent.
+enum RecencyWindow: String, CaseIterable, Hashable, Sendable {
+    case lastMinute
+    case lastFiveMinutes
+    case lastFifteenMinutes
+    case lastHour
+
+    /// A short label suitable for display in a list row.
+    var displayName: String {
+        switch self {
+        case .lastMinute: return "Last minute"
+        case .lastFiveMinutes: return "Last 5 minutes"
+        case .lastFifteenMinutes: return "Last 15 minutes"
+        case .lastHour: return "Last hour"
+        }
+    }
+
+    /// The window length in seconds.
+    var seconds: TimeInterval {
+        switch self {
+        case .lastMinute: return 60
+        case .lastFiveMinutes: return 300
+        case .lastFifteenMinutes: return 900
+        case .lastHour: return 3600
+        }
+    }
+
+    /// Whether `date` falls inside this window ending at `now`.
+    ///
+    /// - Parameters:
+    ///   - date: The request date to test.
+    ///   - now: The end of the window.
+    func contains(_ date: Date, now: Date) -> Bool {
+        now.timeIntervalSince(date) <= seconds
+    }
+}
+
+/// Whether the selected hosts in a ``NetworkLogFilter`` are the only ones shown or the ones hidden.
+enum HostFilterMode: String, CaseIterable, Hashable, Sendable {
+    /// Show only requests to the selected hosts.
+    case include
+    /// Hide requests to the selected hosts.
+    case exclude
+
+    /// The segment label for this mode.
+    var displayName: String {
+        switch self {
+        case .include: return "Include"
+        case .exclude: return "Exclude"
+        }
+    }
+}
+
+/// A logical grouping of ``NetworkLogFilterDimension`` values, used to section the all-filters sheet.
+enum NetworkLogFilterGroup: String, CaseIterable, Identifiable, Sendable {
+    /// Dimensions describing what was sent.
+    case request
+    /// Dimensions describing what came back.
+    case response
+    /// Dimensions describing when and how long.
+    case timing
+
+    var id: String { rawValue }
+
+    /// The section header for this group.
+    var title: String {
+        switch self {
+        case .request: return "Request"
+        case .response: return "Response"
+        case .timing: return "Timing"
+        }
+    }
+
+    /// The dimensions in this group, in display order.
+    var dimensions: [NetworkLogFilterDimension] {
+        switch self {
+        case .request: return [.method, .host, .api, .graphQL]
+        case .response: return [.status, .statusCode, .contentType]
+        case .timing: return [.duration, .recency]
+        }
+    }
+}
+
+/// The dimensions a ``NetworkLogFilter`` can constrain, one per chip in the filter bar.
+enum NetworkLogFilterDimension: String, CaseIterable, Identifiable, Sendable {
+    case method
+    case status
+    case host
+    case contentType
+    case api
+    case graphQL
+    case duration
+    case statusCode
+    case recency
+
+    var id: String { rawValue }
+
+    /// The group this dimension is sectioned under in the all-filters sheet.
+    var group: NetworkLogFilterGroup {
+        switch self {
+        case .method, .host, .api, .graphQL: return .request
+        case .status, .statusCode, .contentType: return .response
+        case .duration, .recency: return .timing
+        }
+    }
+
+    /// The chip and sheet title for this dimension.
+    var title: String {
+        switch self {
+        case .method: return "Method"
+        case .status: return "Status"
+        case .host: return "Host"
+        case .contentType: return "Type"
+        case .api: return "API"
+        case .graphQL: return "GraphQL"
+        case .duration: return "Duration"
+        case .statusCode: return "Code"
+        case .recency: return "Recency"
+        }
+    }
+
+    /// The SF Symbol shown on the chip for this dimension.
+    var systemImage: String {
+        switch self {
+        case .method: return "arrow.left.arrow.right"
+        case .status: return "checkmark.circle"
+        case .host: return "globe"
+        case .contentType: return "doc.text"
+        case .api: return "network"
+        case .graphQL: return "point.3.connected.trianglepath.dotted"
+        case .duration: return "timer"
+        case .statusCode: return "number"
+        case .recency: return "clock"
+        }
+    }
+
+    /// Whether only one option may be selected at a time. Selecting another option replaces it.
+    var isSingleSelect: Bool {
+        self == .recency
+    }
+
+    /// Whether this dimension's options are derived from the captured logs rather than a fixed list.
+    var isDerivedFromLogs: Bool {
+        switch self {
+        case .method, .host, .statusCode: return true
+        case .status, .contentType, .api, .graphQL, .duration, .recency: return false
+        }
+    }
+}
+
+/// A set of constraints applied to the network log list in addition to text search.
+///
+/// Each dimension holds a set of accepted values. An empty set means the dimension is
+/// not constrained. Dimensions combine with AND; values within a dimension combine with OR.
+///
+/// ## Usage
+///
+/// ```swift
+/// var filter = NetworkLogFilter()
+/// filter.methods = ["GET"]
+/// filter.statusClasses = [.clientError, .serverError]
+/// let failures = requests.filter(filter.matches)
+/// ```
+struct NetworkLogFilter: Equatable, Sendable {
+    /// Accepted HTTP methods, compared case-insensitively. Stored uppercased.
+    var methods: Set<String> = []
+
+    /// Accepted response status classes.
+    var statusClasses: Set<HTTPStatusClass> = []
+
+    /// Selected request hosts, compared case-insensitively. Stored lowercased.
+    ///
+    /// Whether these are included or excluded is governed by ``hostMode``.
+    var hosts: Set<String> = []
+
+    /// Whether ``hosts`` is an allow list or a deny list. Has no effect while ``hosts`` is empty.
+    var hostMode: HostFilterMode = .include
+
+    /// Accepted response content types.
+    var contentTypes: Set<HTTPModelShortType> = []
+
+    /// Accepted API kinds (REST or GraphQL).
+    var apiKinds: Set<APIKind> = []
+
+    /// Accepted GraphQL operation types. REST requests never match when this is non-empty.
+    var graphQLOperations: Set<GraphQLOperationFilter> = []
+
+    /// Accepted duration buckets. Requests with no duration never match when this is non-empty.
+    var durationBuckets: Set<DurationBucket> = []
+
+    /// Accepted exact response status codes.
+    var statusCodes: Set<Int> = []
+
+    /// The window in which a request must have been sent, or `nil` for no constraint.
+    var recencyWindow: RecencyWindow?
+
+    /// Creates an empty filter that matches every request.
+    init() {}
+
+    /// Whether any dimension is constrained.
+    var isActive: Bool {
+        totalSelectionCount > 0
+    }
+
+    /// The number of selected values across every dimension.
+    var totalSelectionCount: Int {
+        NetworkLogFilterDimension.allCases.reduce(0) { $0 + selectionCount(for: $1) }
+    }
+
+    /// Removes every constraint.
+    mutating func clear() {
+        self = NetworkLogFilter()
+    }
+
+    /// The number of selected values for a dimension.
+    ///
+    /// - Parameter dimension: The dimension to count.
+    func selectionCount(for dimension: NetworkLogFilterDimension) -> Int {
+        selection(for: dimension).count
+    }
+
+    /// The selected values for a dimension as raw strings.
+    ///
+    /// Methods and hosts are returned as stored; status classes and content types are
+    /// returned as their `rawValue`.
+    ///
+    /// - Parameter dimension: The dimension to read.
+    func selection(for dimension: NetworkLogFilterDimension) -> Set<String> {
+        switch dimension {
+        case .method: return methods
+        case .status: return Set(statusClasses.map(\.rawValue))
+        case .host: return hosts
+        case .contentType: return Set(contentTypes.map(\.rawValue))
+        case .api: return Set(apiKinds.map(\.rawValue))
+        case .graphQL: return Set(graphQLOperations.map(\.rawValue))
+        case .duration: return Set(durationBuckets.map(\.rawValue))
+        case .statusCode: return Set(statusCodes.map(String.init))
+        case .recency: return recencyWindow.map { [$0.rawValue] } ?? []
+        }
+    }
+
+    /// Replaces the selected values for a dimension using raw strings.
+    ///
+    /// Unknown raw values are ignored. For a single-select dimension such as recency, the widest
+    /// window among `values` is kept.
+    ///
+    /// - Parameters:
+    ///   - values: The raw values to select.
+    ///   - dimension: The dimension to write.
+    mutating func setSelection(_ values: Set<String>, for dimension: NetworkLogFilterDimension) {
+        switch dimension {
+        case .method: methods = Set(values.map { $0.uppercased() })
+        case .status: statusClasses = Set(values.compactMap(HTTPStatusClass.init(rawValue:)))
+        case .host: hosts = Set(values.map { $0.lowercased() })
+        case .contentType: contentTypes = Set(values.compactMap(HTTPModelShortType.init(rawValue:)))
+        case .api: apiKinds = Set(values.compactMap(APIKind.init(rawValue:)))
+        case .graphQL: graphQLOperations = Set(values.compactMap(GraphQLOperationFilter.init(rawValue:)))
+        case .duration: durationBuckets = Set(values.compactMap(DurationBucket.init(rawValue:)))
+        case .statusCode: statusCodes = Set(values.compactMap(Int.init))
+        case .recency: recencyWindow = values.compactMap(RecencyWindow.init(rawValue:)).max { $0.seconds < $1.seconds }
+        }
+    }
+
+    /// Whether a request satisfies every constrained dimension.
+    ///
+    /// - Parameters:
+    ///   - request: The request to test.
+    ///   - now: The reference time for recency windows. Defaults to the current time.
+    func matches(_ request: HTTPRequest, now: Date = Date()) -> Bool {
+        if !methods.isEmpty {
+            guard let method = request.requestMethod?.uppercased(), methods.contains(method) else {
+                return false
+            }
+        }
+        if !statusClasses.isEmpty, !statusClasses.contains(HTTPStatusClass(request: request)) {
+            return false
+        }
+        if !hosts.isEmpty {
+            let isListed = request.host.map(hosts.contains) ?? false
+            switch hostMode {
+            case .include where !isListed: return false
+            case .exclude where isListed: return false
+            default: break
+            }
+        }
+        if !contentTypes.isEmpty {
+            guard let type = HTTPModelShortType(rawValue: request.shortType),
+                  contentTypes.contains(type) else { return false }
+        }
+        if !apiKinds.isEmpty, !apiKinds.contains(APIKind(request: request)) {
+            return false
+        }
+        if !graphQLOperations.isEmpty {
+            guard let operation = GraphQLOperationFilter(request: request),
+                  graphQLOperations.contains(operation) else { return false }
+        }
+        if !durationBuckets.isEmpty {
+            guard let bucket = DurationBucket(request: request), durationBuckets.contains(bucket) else {
+                return false
+            }
+        }
+        if !statusCodes.isEmpty {
+            guard let code = request.responseCode, statusCodes.contains(code) else { return false }
+        }
+        if let recencyWindow {
+            guard let date = request.requestDate, recencyWindow.contains(date, now: now) else { return false }
+        }
+        return true
+    }
+}
+
+extension HTTPRequest {
+    /// The lowercased host of the request URL, or `nil` if the URL has no host.
+    var host: String? {
+        if let host = requestURLComponents?.host, !host.isEmpty {
+            return host.lowercased()
+        }
+        guard let urlString = requestURL,
+              let host = URLComponents(string: urlString)?.host,
+              !host.isEmpty else {
+            return nil
+        }
+        return host.lowercased()
+    }
+}
+
+/// A single selectable row in a ``NetworkLogFilterSheet`` or ``NetworkLogAllFiltersSheet``.
+struct NetworkLogFilterOption: Identifiable, Hashable, Sendable {
+    /// The raw value stored in the filter when selected.
+    let id: String
+
+    /// The label shown to the user.
+    let title: String
+
+    /// The fixed option list for a dimension whose values are not derived from the logs.
+    ///
+    /// Returns an empty array for ``NetworkLogFilterDimension/isDerivedFromLogs`` dimensions;
+    /// callers must build those from the captured requests.
+    ///
+    /// - Parameter dimension: The dimension to list.
+    static func staticOptions(for dimension: NetworkLogFilterDimension) -> [NetworkLogFilterOption] {
+        switch dimension {
+        case .status:
+            return HTTPStatusClass.allCases.map { NetworkLogFilterOption(id: $0.rawValue, title: $0.displayName) }
+        case .contentType:
+            return HTTPModelShortType.allCases.map { NetworkLogFilterOption(id: $0.rawValue, title: $0.rawValue) }
+        case .api:
+            return APIKind.allCases.map { NetworkLogFilterOption(id: $0.rawValue, title: $0.displayName) }
+        case .graphQL:
+            return GraphQLOperationFilter.allCases.map { NetworkLogFilterOption(id: $0.rawValue, title: $0.displayName) }
+        case .duration:
+            return DurationBucket.allCases.map { NetworkLogFilterOption(id: $0.rawValue, title: $0.displayName) }
+        case .recency:
+            return RecencyWindow.allCases.map { NetworkLogFilterOption(id: $0.rawValue, title: $0.displayName) }
+        case .method, .host, .statusCode:
+            return []
+        }
+    }
+}

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogFilterBar.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogFilterBar.swift
@@ -1,0 +1,194 @@
+//
+//  NetworkLogFilterBar.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import SwiftUI
+
+/// A horizontally scrolling row of filter chips pinned above the network log list.
+///
+/// The row starts with an icon-only chip that opens ``NetworkLogAllFiltersSheet``, followed by
+/// one chip per ``NetworkLogFilterDimension`` that opens ``NetworkLogFilterSheet`` for that
+/// dimension. Every chip is ``NetworkLogFilterChip/height`` points tall. Active chips are drawn
+/// with an accent-tinted capsule and white text, and show the selected value when there is exactly
+/// one or "Title · N" when there are several. When any dimension is constrained a red "Clear" chip
+/// appears at the end. Chips use Liquid Glass on iOS 26 and filled capsules on earlier releases.
+struct NetworkLogFilterBar: View {
+    /// The filter whose selections the chips reflect.
+    let filter: NetworkLogFilter
+
+    /// Supplies the text for each dimension chip. See ``NetworkLogsViewModel/chipTitle(for:)``.
+    let chipTitle: (NetworkLogFilterDimension) -> String
+
+    /// Called when the leading all-filters chip is tapped.
+    let onSelectAll: () -> Void
+
+    /// Called when a dimension chip is tapped.
+    let onSelect: (NetworkLogFilterDimension) -> Void
+
+    /// Called when the clear chip is tapped.
+    let onClear: () -> Void
+
+    @Namespace private var namespace
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            if #available(iOS 26.0, *) {
+                GlassEffectContainer(spacing: 8) {
+                    chips
+                }
+            } else {
+                chips
+            }
+        }
+    }
+
+    private var chips: some View {
+        HStack(spacing: 8) {
+            NetworkLogFilterChip(
+                title: nil,
+                systemImage: "slider.horizontal.3",
+                style: filter.isActive ? .active : .inactive,
+                accessibilityLabel: filter.isActive
+                    ? "All filters, \(filter.totalSelectionCount) selected"
+                    : "All filters",
+                namespace: namespace,
+                action: onSelectAll
+            )
+            ForEach(NetworkLogFilterDimension.allCases) { dimension in
+                let count = filter.selectionCount(for: dimension)
+                NetworkLogFilterChip(
+                    title: chipTitle(dimension),
+                    systemImage: dimension.systemImage,
+                    style: count > 0 ? .active : .inactive,
+                    accessibilityLabel: count > 0 ? "\(dimension.title), \(count) selected" : dimension.title,
+                    namespace: namespace,
+                    action: { onSelect(dimension) }
+                )
+            }
+            if filter.isActive {
+                NetworkLogFilterChip(
+                    title: "Clear",
+                    systemImage: "xmark",
+                    style: .destructive,
+                    accessibilityLabel: "Clear all filters",
+                    namespace: namespace,
+                    action: onClear
+                )
+                .transition(.scale.combined(with: .opacity))
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .animation(.snappy, value: filter.isActive)
+    }
+}
+
+/// The visual state of a ``NetworkLogFilterChip``.
+enum NetworkLogFilterChipStyle: Sendable {
+    /// Plain glass with primary text; nothing selected.
+    case inactive
+    /// Accent-tinted capsule with white text; something selected.
+    case active
+    /// Red-tinted capsule with white text; the Clear action.
+    case destructive
+
+    /// The capsule tint, or `nil` for untinted glass.
+    var tint: Color? {
+        switch self {
+        case .inactive: return nil
+        case .active: return Color.accentColor
+        case .destructive: return Color.red
+        }
+    }
+}
+
+/// A single capsule chip in ``NetworkLogFilterBar``.
+///
+/// Every chip is exactly ``height`` points tall. The chip's ``NetworkLogFilterChipStyle`` decides
+/// whether the capsule is untinted glass, accent-tinted, or red, with white content on any tinted
+/// capsule. A `nil` title renders an icon-only chip. The capsule is drawn as interactive Liquid
+/// Glass on iOS 26 and a filled capsule on earlier releases.
+struct NetworkLogFilterChip: View {
+    /// The fixed height of every chip, in points.
+    static let height: CGFloat = 40
+
+    /// The chip text, or `nil` for an icon-only chip.
+    let title: String?
+
+    /// The SF Symbol shown before the title.
+    let systemImage: String
+
+    /// The visual state of the chip.
+    let style: NetworkLogFilterChipStyle
+
+    /// The label read by assistive technologies.
+    let accessibilityLabel: String
+
+    /// The glass namespace shared by every chip in the bar.
+    let namespace: Namespace.ID
+
+    /// Called when the chip is tapped.
+    let action: () -> Void
+
+    private var isTinted: Bool { style.tint != nil }
+
+    private var glassID: String { title ?? systemImage }
+
+    var body: some View {
+        capsule(
+            Button(action: action) {
+                label
+                    .padding(.horizontal, title == nil ? 20 : 16)
+                    .frame(height: Self.height)
+            }
+            .buttonStyle(.plain)
+        )
+    }
+
+    /// Wraps the button in the capsule background appropriate for the platform.
+    @ViewBuilder
+    private func capsule<Content: View>(_ content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .glassEffect(
+                    style.tint.map { Glass.regular.tint($0).interactive() } ?? .regular.interactive(),
+                    in: .capsule
+                )
+                .glassEffectID(glassID, in: namespace)
+        } else {
+            content
+                .background(
+                    Capsule().fill(style.tint ?? Color(uiColor: .secondarySystemFill))
+                )
+        }
+    }
+
+    private var label: some View {
+        HStack(spacing: 4) {
+            Image(systemName: systemImage)
+            if let title {
+                Text(title)
+            }
+        }
+        .font(.subheadline.weight(isTinted ? .semibold : .regular))
+        .foregroundStyle(isTinted ? Color.white : Color.primary)
+        .lineLimit(1)
+        .fixedSize()
+        .accessibilityLabel(accessibilityLabel)
+    }
+}
+
+#Preview {
+    var filter = NetworkLogFilter()
+    filter.methods = ["GET", "POST"]
+    return NetworkLogFilterBar(
+        filter: filter,
+        chipTitle: { $0.title },
+        onSelectAll: {},
+        onSelect: { _ in },
+        onClear: {}
+    )
+}

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogFilterSheet.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogFilterSheet.swift
@@ -1,0 +1,65 @@
+//
+//  NetworkLogFilterSheet.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import SwiftUI
+
+/// A modal checklist for choosing the accepted values of one ``NetworkLogFilterDimension``.
+///
+/// Presented from a chip in ``NetworkLogFilterBar``. Selections apply immediately through the
+/// view model's change callback, so the list behind the sheet updates as rows are toggled.
+/// A Reset button appears in the leading toolbar slot only while something is selected. The host
+/// sheet adds an Include / Exclude segmented control as its section header.
+struct NetworkLogFilterSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @StateObject private var viewModel: NetworkLogFilterSheetViewModel
+
+    /// Creates a filter sheet for one dimension.
+    ///
+    /// - Parameter viewModel: The view model owning the options and working selection.
+    init(viewModel: NetworkLogFilterSheetViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    if viewModel.options.isEmpty {
+                        NetworkLogFilterEmptyRow(dimensionName: viewModel.title.lowercased())
+                    } else {
+                        ForEach(viewModel.options) { option in
+                            NetworkLogFilterOptionRow(
+                                title: option.title,
+                                isSelected: viewModel.isSelected(option),
+                                action: { viewModel.toggle(option) }
+                            )
+                        }
+                    }
+                } header: {
+                    if viewModel.supportsHostMode {
+                        NetworkLogHostModePicker(mode: viewModel.hostMode, onChange: viewModel.setHostMode)
+                    }
+                }
+            }
+            .navigationTitle(viewModel.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    if viewModel.canReset {
+                        Button("Reset") { viewModel.reset() }
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    NetworkLogFilterConfirmButton { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+}

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogFilterSheetComponents.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogFilterSheetComponents.swift
@@ -1,0 +1,92 @@
+//
+//  NetworkLogFilterSheetComponents.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import SwiftUI
+
+/// A checklist row shared by ``NetworkLogFilterSheet`` and ``NetworkLogAllFiltersSheet``.
+///
+/// Renders the option title as a `LabeledContent` label with a tinted checkmark as its content
+/// when selected.
+struct NetworkLogFilterOptionRow: View {
+    /// The text shown for the option.
+    let title: String
+
+    /// Whether the option is currently selected.
+    let isSelected: Bool
+
+    /// Called when the row is tapped.
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            LabeledContent(title) {
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.tint)
+                }
+            }
+            .foregroundStyle(Color.primary)
+        }
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+/// The placeholder shown when a log-derived dimension has no values yet.
+struct NetworkLogFilterEmptyRow: View {
+    /// The lowercased dimension name, e.g. "host".
+    let dimensionName: String
+
+    var body: some View {
+        Text("No \(dimensionName) values captured yet")
+            .fontWeight(.bold)
+            .foregroundStyle(.gray)
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
+}
+
+/// The tinted confirmation button that dismisses a filter sheet.
+///
+/// Uses the system confirm role with its system-provided checkmark label on iOS 26, which
+/// renders as prominent tinted glass, and a checkmark in a bordered prominent capsule on
+/// earlier releases.
+struct NetworkLogFilterConfirmButton: View {
+    /// Called when the button is tapped.
+    let action: () -> Void
+
+    var body: some View {
+        if #available(iOS 26.0, *) {
+            Button(role: .confirm, action: action)
+        } else {
+            Button(action: action) {
+                Image(systemName: "checkmark")
+            }
+            .buttonStyle(.borderedProminent)
+            .buttonBorderShape(.capsule)
+            .accessibilityLabel("Done")
+        }
+    }
+}
+
+/// A segmented Include / Exclude control shown as the section header of the host checklist.
+struct NetworkLogHostModePicker: View {
+    /// The current mode.
+    let mode: HostFilterMode
+
+    /// Called when a segment is chosen.
+    let onChange: (HostFilterMode) -> Void
+
+    var body: some View {
+        Picker("Host mode", selection: Binding(get: { mode }, set: onChange)) {
+            ForEach(HostFilterMode.allCases, id: \.self) { mode in
+                Text(mode.displayName).tag(mode)
+            }
+        }
+        .pickerStyle(.segmented)
+        .textCase(nil)
+        .padding(.bottom, 8)
+    }
+}

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogFilterSheetViewModel.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogFilterSheetViewModel.swift
@@ -1,0 +1,117 @@
+//
+//  NetworkLogFilterSheetViewModel.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import Foundation
+
+/// View model backing ``NetworkLogFilterSheet``, the per-dimension checklist presented from a filter chip.
+///
+/// The view model owns the working selection for a single ``NetworkLogFilterDimension`` and
+/// reports every change to its owner through `onChange`, so the list behind the sheet updates live.
+///
+/// ## Usage
+///
+/// ```swift
+/// let viewModel = NetworkLogFilterSheetViewModel(
+///     dimension: .method,
+///     options: listViewModel.options(for: .method),
+///     selected: listViewModel.filter.selection(for: .method)
+/// ) { listViewModel.filter.setSelection($0, for: .method) }
+/// ```
+final class NetworkLogFilterSheetViewModel: ViewModel {
+    /// The dimension being edited.
+    let dimension: NetworkLogFilterDimension
+
+    /// The selectable rows, in display order.
+    let options: [NetworkLogFilterOption]
+
+    /// The ids of the currently selected options.
+    @Published private(set) var selected: Set<String>
+
+    /// Whether the selected hosts are included or excluded. Only meaningful for the host dimension.
+    @Published private(set) var hostMode: HostFilterMode
+
+    /// Invoked with the full selection after every change.
+    private let onChange: (Set<String>) -> Void
+
+    /// Invoked with the new host mode after it changes.
+    private let onHostModeChange: (HostFilterMode) -> Void
+
+    /// Creates a sheet view model for one filter dimension.
+    ///
+    /// - Parameters:
+    ///   - dimension: The dimension being edited.
+    ///   - options: The selectable rows.
+    ///   - selected: The ids selected when the sheet opens.
+    ///   - hostMode: The host include/exclude mode when the sheet opens. Ignored for other dimensions.
+    ///   - onChange: Called with the full selection after every change.
+    ///   - onHostModeChange: Called with the new mode after ``setHostMode(_:)``.
+    init(
+        dimension: NetworkLogFilterDimension,
+        options: [NetworkLogFilterOption],
+        selected: Set<String>,
+        hostMode: HostFilterMode = .include,
+        onChange: @escaping (Set<String>) -> Void,
+        onHostModeChange: @escaping (HostFilterMode) -> Void = { _ in }
+    ) {
+        self.dimension = dimension
+        self.options = options
+        self.selected = selected
+        self.hostMode = hostMode
+        self.onChange = onChange
+        self.onHostModeChange = onHostModeChange
+        super.init()
+    }
+
+    /// Whether this sheet shows the include/exclude control. True only for the host dimension.
+    var supportsHostMode: Bool { dimension == .host }
+
+    /// Updates the host include/exclude mode and notifies the owner.
+    ///
+    /// - Parameter mode: The new mode.
+    func setHostMode(_ mode: HostFilterMode) {
+        hostMode = mode
+        onHostModeChange(mode)
+    }
+
+    /// The navigation title for the sheet.
+    var title: String { dimension.title }
+
+    /// The number of selected options.
+    var selectedCount: Int { selected.count }
+
+    /// Whether the sheet has a selection that can be reset.
+    var canReset: Bool { !selected.isEmpty }
+
+    /// Whether an option is currently selected.
+    ///
+    /// - Parameter option: The option to check.
+    func isSelected(_ option: NetworkLogFilterOption) -> Bool {
+        selected.contains(option.id)
+    }
+
+    /// Adds or removes an option from the selection.
+    ///
+    /// For a single-select dimension, selecting an option replaces any other selection.
+    ///
+    /// - Parameter option: The option to toggle.
+    func toggle(_ option: NetworkLogFilterOption) {
+        if selected.contains(option.id) {
+            selected.remove(option.id)
+        } else if dimension.isSingleSelect {
+            selected = [option.id]
+        } else {
+            selected.insert(option.id)
+        }
+        onChange(selected)
+    }
+
+    /// Clears the selection, which removes this dimension's constraint.
+    func reset() {
+        selected = []
+        onChange(selected)
+    }
+}

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogsView.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogsView.swift
@@ -16,6 +16,9 @@ import SwiftUI
 /// ## Features
 /// - Real-time updates as new requests are captured
 /// - Search functionality across URLs, status codes, and HTTP methods
+/// - Filter chips for method, status class, host, content type, GraphQL kind, duration, exact status
+///   code, and recency, each opening a selection sheet, plus an all-filters chip that edits every
+///   dimension on one screen
 /// - Color-coded status indicators
 /// - Navigation to detailed request view
 ///
@@ -28,6 +31,12 @@ import SwiftUI
 struct NetworkLogsView: View {
     /// Current search text for filtering network requests.
     @State private var searchText: String = ""
+
+    /// The filter dimension whose sheet is currently presented, if any.
+    @State private var editingDimension: NetworkLogFilterDimension?
+
+    /// Whether the all-filters sheet is presented.
+    @State private var showingAllFilters: Bool = false
 
     /// View model managing the network logs state and filtering.
     @StateObject private var viewModel: NetworkLogsViewModel = .init()
@@ -51,6 +60,36 @@ struct NetworkLogsView: View {
             }
         }
         .listStyle(.plain)
+        .safeAreaInset(edge: .top, spacing: 0) {
+            NetworkLogFilterBar(
+                filter: viewModel.filter,
+                chipTitle: viewModel.chipTitle(for:),
+                onSelectAll: { showingAllFilters = true },
+                onSelect: { editingDimension = $0 },
+                onClear: { viewModel.clearFilter() }
+            )
+        }
+        .sheet(isPresented: $showingAllFilters) {
+            NetworkLogAllFiltersSheet(
+                viewModel: NetworkLogAllFiltersSheetViewModel(
+                    filter: viewModel.filter,
+                    options: viewModel.options(for:),
+                    onChange: { viewModel.filter = $0 }
+                )
+            )
+        }
+        .sheet(item: $editingDimension) { dimension in
+            NetworkLogFilterSheet(
+                viewModel: NetworkLogFilterSheetViewModel(
+                    dimension: dimension,
+                    options: viewModel.options(for: dimension),
+                    selected: viewModel.filter.selection(for: dimension),
+                    hostMode: viewModel.filter.hostMode,
+                    onChange: { viewModel.filter.setSelection($0, for: dimension) },
+                    onHostModeChange: { viewModel.filter.hostMode = $0 }
+                )
+            )
+        }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button("Delete", systemImage: "trash", role: .destructive) {

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogsViewModel.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogsViewModel.swift
@@ -17,6 +17,8 @@ import Combine
 /// ## Features
 /// - Real-time updates from `NetworkLogger`
 /// - Debounced search (300ms delay)
+/// - Chip-driven filtering by method, status class, host, content type, API kind, GraphQL operation, duration,
+///   exact status code, and recency via ``NetworkLogFilter``
 /// - Background filtering for better performance
 /// - Automatic cleanup on deinitialization
 ///
@@ -33,6 +35,25 @@ class NetworkLogsViewModel: ViewModel {
 
     /// Current search term used for filtering requests.
     private var searchTerm: String = ""
+
+    /// The chip-driven filter applied alongside the search term.
+    ///
+    /// Changing this value re-runs filtering immediately (no debounce).
+    @Published var filter: NetworkLogFilter = NetworkLogFilter() {
+        didSet {
+            guard filter != oldValue else { return }
+            scheduleFilter()
+        }
+    }
+
+    /// The distinct HTTP methods present in the captured logs, uppercased and sorted.
+    @Published private(set) var availableMethods: [String] = []
+
+    /// The distinct request hosts present in the captured logs, lowercased and sorted.
+    @Published private(set) var availableHosts: [String] = []
+
+    /// The distinct response status codes present in the captured logs, sorted ascending.
+    @Published private(set) var availableStatusCodes: [Int] = []
 
     /// Subject for debouncing search input.
     private var searchSubject = PassthroughSubject<String, Never>()
@@ -52,6 +73,9 @@ class NetworkLogsViewModel: ViewModel {
     /// Internal array of all network requests before filtering.
     private var items: [HTTPRequest] = [] {
         didSet {
+            availableMethods = Self.availableMethods(in: items)
+            availableHosts = Self.availableHosts(in: items)
+            availableStatusCodes = Self.availableStatusCodes(in: items)
             scheduleFilter()
         }
     }
@@ -113,21 +137,100 @@ class NetworkLogsViewModel: ViewModel {
         }
     }
 
-    /// Filters requests by matching the search term against URL, operation name, status code, or method.
+    /// Filters requests by matching the search term against URL, operation name, status code, or method,
+    /// and by the chip-driven ``NetworkLogFilter``.
     ///
     /// - Parameters:
     ///   - items: The requests to filter.
     ///   - searchTerm: The raw search term (case-insensitive; whitespace is trimmed).
-    /// - Returns: All items when the term is empty, otherwise the matching subset.
-    nonisolated static func filter(items: [HTTPRequest], searchTerm: String) -> [HTTPRequest] {
+    ///   - filter: The dimension constraints to apply. Defaults to an empty filter.
+    /// - Returns: All items when the term is empty and the filter is inactive, otherwise the matching subset.
+    nonisolated static func filter(
+        items: [HTTPRequest],
+        searchTerm: String,
+        filter: NetworkLogFilter = NetworkLogFilter()
+    ) -> [HTTPRequest] {
         let predicate = searchTerm.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !predicate.isEmpty else { return items }
+        guard !predicate.isEmpty || filter.isActive else { return items }
         return items.filter { item in
-            item.responseCode?.description.lowercased().contains(predicate) == true ||
-            item.requestURL?.lowercased().contains(predicate) == true ||
-            item.requestMethod?.lowercased().contains(predicate) == true ||
-            item.graphQLOperationName?.lowercased().contains(predicate) == true
+            guard filter.matches(item) else { return false }
+            guard !predicate.isEmpty else { return true }
+            return item.responseCode?.description.lowercased().contains(predicate) == true ||
+                item.requestURL?.lowercased().contains(predicate) == true ||
+                item.requestMethod?.lowercased().contains(predicate) == true ||
+                item.graphQLOperationName?.lowercased().contains(predicate) == true
         }
+    }
+
+    /// The distinct HTTP methods present in `items`, uppercased and sorted.
+    ///
+    /// - Parameter items: The requests to inspect.
+    nonisolated static func availableMethods(in items: [HTTPRequest]) -> [String] {
+        Set(items.compactMap { $0.requestMethod?.uppercased() }).sorted()
+    }
+
+    /// The distinct request hosts present in `items`, lowercased and sorted.
+    ///
+    /// - Parameter items: The requests to inspect.
+    nonisolated static func availableHosts(in items: [HTTPRequest]) -> [String] {
+        Set(items.compactMap(\.host)).sorted()
+    }
+
+    /// The distinct response status codes present in `items`, sorted ascending.
+    ///
+    /// Requests with no response (a `nil` or zero code) are excluded.
+    ///
+    /// - Parameter items: The requests to inspect.
+    nonisolated static func availableStatusCodes(in items: [HTTPRequest]) -> [Int] {
+        Set(items.compactMap { $0.responseCode }.filter { $0 > 0 }).sorted()
+    }
+
+    /// The selectable options for a filter dimension.
+    ///
+    /// Method, host, and exact status code options are derived from the captured logs; every
+    /// other dimension uses its fixed list from ``NetworkLogFilterOption/staticOptions(for:)``.
+    ///
+    /// - Parameter dimension: The dimension being edited.
+    func options(for dimension: NetworkLogFilterDimension) -> [NetworkLogFilterOption] {
+        switch dimension {
+        case .method:
+            return availableMethods.map { NetworkLogFilterOption(id: $0, title: $0) }
+        case .host:
+            return availableHosts.map { NetworkLogFilterOption(id: $0, title: $0) }
+        case .statusCode:
+            return availableStatusCodes.map { NetworkLogFilterOption(id: String($0), title: String($0)) }
+        case .status, .contentType, .api, .graphQL, .duration, .recency:
+            return NetworkLogFilterOption.staticOptions(for: dimension)
+        }
+    }
+
+    /// The text shown on a dimension's chip.
+    ///
+    /// Returns the dimension title when nothing is selected, the selected option's title when
+    /// exactly one value is selected (prefixed with "Not " for a single excluded host), and
+    /// "Title · N" when several are selected.
+    ///
+    /// - Parameter dimension: The dimension whose chip is being drawn.
+    func chipTitle(for dimension: NetworkLogFilterDimension) -> String {
+        let selected = filter.selection(for: dimension)
+        switch selected.count {
+        case 0:
+            return dimension.title
+        case 1:
+            let id = selected.first ?? ""
+            let title = options(for: dimension).first { $0.id == id }?.title ?? id
+            if dimension == .host, filter.hostMode == .exclude {
+                return "Not \(title)"
+            }
+            return title
+        default:
+            return "\(dimension.title) · \(selected.count)"
+        }
+    }
+
+    /// Removes every chip constraint.
+    func clearFilter() {
+        filter.clear()
     }
 
     /// Filters the network requests based on the current search term.
@@ -139,13 +242,14 @@ class NetworkLogsViewModel: ViewModel {
     private func updateData() async {
         let currentItems = items
         let currentSearchTerm = searchTerm.trimmingCharacters(in: .whitespacesAndNewlines)
+        let currentFilter = filter
 
-        if currentSearchTerm.isEmpty {
+        if currentSearchTerm.isEmpty && !currentFilter.isActive {
             requests = currentItems
         } else {
             // Filter on background thread
             let filtered = await Task.detached(priority: .userInitiated) {
-                Self.filter(items: currentItems, searchTerm: currentSearchTerm)
+                Self.filter(items: currentItems, searchTerm: currentSearchTerm, filter: currentFilter)
             }.value
 
             // Check if task was cancelled before updating

--- a/Sources/Scyther/Scyther.docc/NetworkDebugging.md
+++ b/Sources/Scyther/Scyther.docc/NetworkDebugging.md
@@ -60,14 +60,42 @@ for await request in NetworkLogger.shared.requests {
 
 ## Filtering Requests
 
-In the Network Logs UI, you can filter requests by:
-- HTTP method (GET, POST, PUT, DELETE, etc.)
-- Status code (success, client error, server error)
-- URL pattern
+The Network Logs screen offers two ways to narrow the list, and they combine.
+
+**Search** matches the URL, GraphQL operation name, status code, or HTTP method.
+
+**Filter chips** sit above the list. Tap a chip to open a sheet with a multi-select checklist:
+
+- **Method**: the HTTP methods present in the captured requests
+- **Status**: 2xx success, 3xx redirect, 4xx client error, 5xx server error, or pending / no response
+- **Host**: the request hosts present in the captured requests. An Include / Exclude segmented
+  control in the list header decides whether the selected hosts are the only ones shown or the
+  ones hidden
+- **Type**: JSON, XML, HTML, Image, or Other, based on the detected response content type
+- **API**: REST or GraphQL
+- **GraphQL**: Query, Mutation, Subscription, or Batch / Unknown for GraphQL requests with no
+  single operation type. REST requests never match a GraphQL selection
+- **Duration**: under 100ms, 100ms to 500ms, 500ms to 1s, 1s to 3s, or over 3s. Requests still
+  awaiting a response have no duration and never match a duration selection
+- **Code**: the exact response status codes present in the captured requests
+- **Recency**: last minute, 5 minutes, 15 minutes, or hour, measured from when the filter runs.
+  Single-select, since each window contains the shorter ones
+
+The icon-only chip at the start of the row opens a full-height Filters sheet that lists every
+dimension, grouped into Request, Response, and Timing, with a summary of its selection. Tapping a row pushes that dimension's checklist, with
+a Reset for that dimension alone; the root Filters screen offers Reset for everything.
+
+Selections apply immediately behind the sheet. Chips combine with AND, values within a chip with
+OR (Recency allows one value). Active chips are fully tinted and show the selected value when exactly one is chosen, or the
+dimension name with a count when several are. A Reset button appears in each
+sheet while it has a selection, and a red Clear chip appears in the bar whenever any filter is active.
+Filters are held in memory for the current session only.
 
 ## Exporting cURL Commands
 
-Every request can be exported as a cURL command. This is useful for:
+Every request can be exported as a cURL command from the request details page. Tap the
+share button in the top-trailing corner of the navigation bar, or the "Export cURL request"
+row in the Developer Info section; both present the same system share sheet. This is useful for:
 - Sharing with backend developers
 - Testing in terminal
 - Creating API documentation

--- a/Tests/ScytherTests/Features/LogDetailsViewModelTests.swift
+++ b/Tests/ScytherTests/Features/LogDetailsViewModelTests.swift
@@ -23,6 +23,23 @@ final class LogDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.graphQLOperationType, "Mutation")
     }
 
+    func testCurlRequestPopulatedOnFirstAppear() async {
+        let request = HTTPRequest()
+        request.requestCurl = "curl -X GET 'https://api.example.com/users'"
+
+        let viewModel = LogDetailsViewModel(httpRequest: request)
+        await viewModel.onFirstAppear()
+
+        XCTAssertEqual(viewModel.curlRequest, "curl -X GET 'https://api.example.com/users'")
+    }
+
+    func testCurlRequestDefaultsToEmptyWhenMissing() async {
+        let request = HTTPRequest()
+        let viewModel = LogDetailsViewModel(httpRequest: request)
+        await viewModel.onFirstAppear()
+        XCTAssertEqual(viewModel.curlRequest, "")
+    }
+
     func testNonGraphQLHasNoGraphQLSection() async {
         let request = HTTPRequest()
         let viewModel = LogDetailsViewModel(httpRequest: request)

--- a/Tests/ScytherTests/Features/NetworkLogAllFiltersSheetViewModelTests.swift
+++ b/Tests/ScytherTests/Features/NetworkLogAllFiltersSheetViewModelTests.swift
@@ -1,0 +1,127 @@
+//
+//  NetworkLogAllFiltersSheetViewModelTests.swift
+//  ScytherTests
+//
+
+@testable import Scyther
+import XCTest
+
+@MainActor
+final class NetworkLogAllFiltersSheetViewModelTests: XCTestCase {
+
+    private func makeViewModel(
+        filter: NetworkLogFilter = NetworkLogFilter(),
+        onChange: @escaping (NetworkLogFilter) -> Void = { _ in }
+    ) -> NetworkLogAllFiltersSheetViewModel {
+        NetworkLogAllFiltersSheetViewModel(
+            filter: filter,
+            options: { dimension in
+                switch dimension {
+                case .method: return [NetworkLogFilterOption(id: "GET", title: "GET")]
+                case .host: return [NetworkLogFilterOption(id: "a.com", title: "a.com")]
+                case .statusCode: return [NetworkLogFilterOption(id: "200", title: "200")]
+                default: return NetworkLogFilterOption.staticOptions(for: dimension)
+                }
+            },
+            onChange: onChange
+        )
+    }
+
+    func testSectionsCoverEveryDimensionInOrder() {
+        let viewModel = makeViewModel()
+        XCTAssertEqual(viewModel.sections.map(\.dimension), NetworkLogFilterDimension.allCases)
+        XCTAssertEqual(viewModel.sections.first?.options.map(\.id), ["GET"])
+    }
+
+    func testGroupedSectionsFollowGroupOrder() {
+        let viewModel = makeViewModel()
+        XCTAssertEqual(viewModel.groups.map(\.group), NetworkLogFilterGroup.allCases)
+        XCTAssertEqual(viewModel.groups.first?.sections.map(\.dimension), [.method, .host, .api, .graphQL])
+    }
+
+    func testToggleUpdatesFilterAndNotifies() {
+        var received: NetworkLogFilter?
+        let viewModel = makeViewModel { received = $0 }
+        let option = NetworkLogFilterOption(id: HTTPStatusClass.success.rawValue, title: "2xx")
+
+        viewModel.toggle(option, in: .status)
+        XCTAssertTrue(viewModel.isSelected(option, in: .status))
+        XCTAssertEqual(received?.statusClasses, [.success])
+        XCTAssertTrue(viewModel.canReset)
+
+        viewModel.toggle(option, in: .status)
+        XCTAssertFalse(viewModel.isSelected(option, in: .status))
+        XCTAssertEqual(received?.statusClasses, [])
+        XCTAssertFalse(viewModel.canReset)
+    }
+
+    func testSummaryIsAnyWhenUnselectedAndJoinsTitlesInOptionOrder() {
+        var initial = NetworkLogFilter()
+        initial.statusClasses = [.serverError, .success]
+        let viewModel = makeViewModel(filter: initial)
+
+        XCTAssertEqual(viewModel.summary(for: .method), "Any")
+        XCTAssertEqual(viewModel.summary(for: .status), "2xx Success, 5xx Server Error")
+    }
+
+    func testHostModeChangesNotifyAndAffectSummary() {
+        var initial = NetworkLogFilter()
+        initial.hosts = ["a.com"]
+        var received: NetworkLogFilter?
+        let viewModel = makeViewModel(filter: initial) { received = $0 }
+
+        XCTAssertEqual(viewModel.summary(for: .host), "a.com")
+        viewModel.setHostMode(.exclude)
+        XCTAssertEqual(received?.hostMode, .exclude)
+        XCTAssertEqual(viewModel.summary(for: .host), "Exclude: a.com")
+
+        viewModel.reset(.host)
+        XCTAssertEqual(received?.hostMode, .include)
+        XCTAssertEqual(viewModel.summary(for: .host), "Any")
+    }
+
+    func testResetForSingleDimensionLeavesOthersIntact() {
+        var initial = NetworkLogFilter()
+        initial.methods = ["GET"]
+        initial.hosts = ["a.com"]
+        var received: NetworkLogFilter?
+        let viewModel = makeViewModel(filter: initial) { received = $0 }
+
+        XCTAssertTrue(viewModel.canReset(.method))
+        XCTAssertFalse(viewModel.canReset(.status))
+
+        viewModel.reset(.method)
+        XCTAssertFalse(viewModel.canReset(.method))
+        XCTAssertEqual(received?.methods, [])
+        XCTAssertEqual(received?.hosts, ["a.com"])
+    }
+
+    func testSingleSelectDimensionReplacesSelectionOnToggle() {
+        var received: NetworkLogFilter?
+        let viewModel = makeViewModel { received = $0 }
+        let minute = NetworkLogFilterOption(id: RecencyWindow.lastMinute.rawValue, title: "Last minute")
+        let hour = NetworkLogFilterOption(id: RecencyWindow.lastHour.rawValue, title: "Last hour")
+
+        viewModel.toggle(minute, in: .recency)
+        viewModel.toggle(hour, in: .recency)
+        XCTAssertFalse(viewModel.isSelected(minute, in: .recency))
+        XCTAssertTrue(viewModel.isSelected(hour, in: .recency))
+        XCTAssertEqual(received?.recencyWindow, .lastHour)
+
+        viewModel.toggle(hour, in: .recency)
+        XCTAssertNil(received?.recencyWindow)
+    }
+
+    func testResetClearsEveryDimensionAndNotifies() {
+        var initial = NetworkLogFilter()
+        initial.methods = ["GET"]
+        initial.recencyWindow = .lastHour
+        var received: NetworkLogFilter?
+        let viewModel = makeViewModel(filter: initial) { received = $0 }
+        XCTAssertTrue(viewModel.canReset)
+
+        viewModel.reset()
+        XCTAssertFalse(viewModel.canReset)
+        XCTAssertEqual(received, NetworkLogFilter())
+    }
+}

--- a/Tests/ScytherTests/Features/NetworkLogFilterSheetViewModelTests.swift
+++ b/Tests/ScytherTests/Features/NetworkLogFilterSheetViewModelTests.swift
@@ -1,0 +1,109 @@
+//
+//  NetworkLogFilterSheetViewModelTests.swift
+//  ScytherTests
+//
+
+@testable import Scyther
+import XCTest
+
+@MainActor
+final class NetworkLogFilterSheetViewModelTests: XCTestCase {
+
+    private let options = [
+        NetworkLogFilterOption(id: "GET", title: "GET"),
+        NetworkLogFilterOption(id: "POST", title: "POST"),
+        NetworkLogFilterOption(id: "DELETE", title: "DELETE"),
+    ]
+
+    private func makeViewModel(
+        selected: Set<String> = [],
+        onChange: @escaping (Set<String>) -> Void = { _ in }
+    ) -> NetworkLogFilterSheetViewModel {
+        NetworkLogFilterSheetViewModel(
+            dimension: .method,
+            options: options,
+            selected: selected,
+            onChange: onChange
+        )
+    }
+
+    func testToggleAddsAndRemovesSelectionAndNotifies() {
+        var received: [Set<String>] = []
+        let viewModel = makeViewModel { received.append($0) }
+
+        viewModel.toggle(options[0])
+        XCTAssertTrue(viewModel.isSelected(options[0]))
+        XCTAssertEqual(received.last, ["GET"])
+
+        viewModel.toggle(options[0])
+        XCTAssertFalse(viewModel.isSelected(options[0]))
+        XCTAssertEqual(received.last, [])
+    }
+
+    func testResetClearsSelectionAndNotifies() {
+        var received: Set<String>?
+        let viewModel = makeViewModel(selected: ["GET", "POST"]) { received = $0 }
+        XCTAssertTrue(viewModel.canReset)
+        viewModel.reset()
+        XCTAssertFalse(viewModel.canReset)
+        XCTAssertEqual(viewModel.selectedCount, 0)
+        XCTAssertEqual(received, [])
+    }
+
+    func testCanResetTracksSelection() {
+        let viewModel = makeViewModel()
+        XCTAssertFalse(viewModel.canReset)
+        viewModel.toggle(options[2])
+        XCTAssertTrue(viewModel.canReset)
+        viewModel.toggle(options[2])
+        XCTAssertFalse(viewModel.canReset)
+    }
+
+    func testHostSheetSupportsModeAndNotifiesChanges() {
+        var received: HostFilterMode?
+        let viewModel = NetworkLogFilterSheetViewModel(
+            dimension: .host,
+            options: [NetworkLogFilterOption(id: "a.com", title: "a.com")],
+            selected: [],
+            hostMode: .include,
+            onChange: { _ in },
+            onHostModeChange: { received = $0 }
+        )
+        XCTAssertTrue(viewModel.supportsHostMode)
+        viewModel.setHostMode(.exclude)
+        XCTAssertEqual(viewModel.hostMode, .exclude)
+        XCTAssertEqual(received, .exclude)
+    }
+
+    func testNonHostSheetDoesNotSupportMode() {
+        XCTAssertFalse(makeViewModel().supportsHostMode)
+    }
+
+    func testSingleSelectSheetReplacesSelectionOnToggle() {
+        var received: Set<String>?
+        let minute = NetworkLogFilterOption(id: RecencyWindow.lastMinute.rawValue, title: "Last minute")
+        let hour = NetworkLogFilterOption(id: RecencyWindow.lastHour.rawValue, title: "Last hour")
+        let viewModel = NetworkLogFilterSheetViewModel(
+            dimension: .recency,
+            options: [minute, hour],
+            selected: [],
+            onChange: { received = $0 }
+        )
+
+        viewModel.toggle(minute)
+        viewModel.toggle(hour)
+        XCTAssertEqual(received, [hour.id])
+        XCTAssertFalse(viewModel.isSelected(minute))
+
+        viewModel.toggle(hour)
+        XCTAssertEqual(received, [])
+    }
+
+    func testInitialSelectionIsHonoured() {
+        let viewModel = makeViewModel(selected: ["POST"])
+        XCTAssertTrue(viewModel.isSelected(options[1]))
+        XCTAssertFalse(viewModel.isSelected(options[0]))
+        XCTAssertEqual(viewModel.selectedCount, 1)
+        XCTAssertEqual(viewModel.title, "Method")
+    }
+}

--- a/Tests/ScytherTests/Features/NetworkLogFilterTests.swift
+++ b/Tests/ScytherTests/Features/NetworkLogFilterTests.swift
@@ -1,0 +1,344 @@
+//
+//  NetworkLogFilterTests.swift
+//  ScytherTests
+//
+
+@testable import Scyther
+import XCTest
+
+final class NetworkLogFilterTests: XCTestCase {
+
+    private func makeRequest(
+        method: String? = "GET",
+        url: String? = "https://api.example.com/users",
+        code: Int? = 200,
+        shortType: HTTPModelShortType = .JSON
+    ) -> HTTPRequest {
+        let request = HTTPRequest()
+        request.requestMethod = method
+        request.requestURL = url
+        request.responseCode = code
+        request.noResponse = code == nil
+        request.shortType = shortType.rawValue
+        return request
+    }
+
+    // MARK: - Empty filter
+
+    func testEmptyFilterIsInactiveAndMatchesEverything() {
+        let filter = NetworkLogFilter()
+        XCTAssertFalse(filter.isActive)
+        XCTAssertTrue(filter.matches(makeRequest()))
+        XCTAssertTrue(filter.matches(makeRequest(method: nil, url: nil, code: nil, shortType: .OTHER)))
+    }
+
+    // MARK: - Method
+
+    func testMethodFilterMatchesCaseInsensitively() {
+        var filter = NetworkLogFilter()
+        filter.methods = ["POST"]
+        XCTAssertTrue(filter.isActive)
+        XCTAssertTrue(filter.matches(makeRequest(method: "post")))
+        XCTAssertFalse(filter.matches(makeRequest(method: "GET")))
+        XCTAssertFalse(filter.matches(makeRequest(method: nil)))
+    }
+
+    func testMethodFilterAllowsMultipleValues() {
+        var filter = NetworkLogFilter()
+        filter.methods = ["GET", "DELETE"]
+        XCTAssertTrue(filter.matches(makeRequest(method: "GET")))
+        XCTAssertTrue(filter.matches(makeRequest(method: "DELETE")))
+        XCTAssertFalse(filter.matches(makeRequest(method: "PUT")))
+    }
+
+    // MARK: - Status
+
+    func testStatusClassIsDerivedFromResponseCode() {
+        XCTAssertEqual(HTTPStatusClass(request: makeRequest(code: 200)), .success)
+        XCTAssertEqual(HTTPStatusClass(request: makeRequest(code: 204)), .success)
+        XCTAssertEqual(HTTPStatusClass(request: makeRequest(code: 301)), .redirect)
+        XCTAssertEqual(HTTPStatusClass(request: makeRequest(code: 404)), .clientError)
+        XCTAssertEqual(HTTPStatusClass(request: makeRequest(code: 503)), .serverError)
+        XCTAssertEqual(HTTPStatusClass(request: makeRequest(code: nil)), .pending)
+        XCTAssertEqual(HTTPStatusClass(request: makeRequest(code: 0)), .pending)
+    }
+
+    func testStatusFilterMatchesByClass() {
+        var filter = NetworkLogFilter()
+        filter.statusClasses = [.clientError, .pending]
+        XCTAssertTrue(filter.matches(makeRequest(code: 401)))
+        XCTAssertTrue(filter.matches(makeRequest(code: nil)))
+        XCTAssertFalse(filter.matches(makeRequest(code: 200)))
+        XCTAssertFalse(filter.matches(makeRequest(code: 500)))
+    }
+
+    // MARK: - Host
+
+    func testHostIsDerivedFromRequestURL() {
+        XCTAssertEqual(makeRequest(url: "https://API.Example.com/users?id=1").host, "api.example.com")
+        XCTAssertNil(makeRequest(url: nil).host)
+        XCTAssertNil(makeRequest(url: "not a url").host)
+    }
+
+    func testHostFilterMatchesCaseInsensitively() {
+        var filter = NetworkLogFilter()
+        filter.hosts = ["api.example.com"]
+        XCTAssertTrue(filter.matches(makeRequest(url: "https://API.example.com/a")))
+        XCTAssertFalse(filter.matches(makeRequest(url: "https://cdn.example.com/a")))
+        XCTAssertFalse(filter.matches(makeRequest(url: nil)))
+    }
+
+    func testHostExcludeModeInvertsMatching() {
+        var filter = NetworkLogFilter()
+        filter.hosts = ["api.example.com"]
+        filter.hostMode = .exclude
+        XCTAssertTrue(filter.isActive)
+        XCTAssertFalse(filter.matches(makeRequest(url: "https://api.example.com/a")))
+        XCTAssertTrue(filter.matches(makeRequest(url: "https://cdn.example.com/a")))
+        XCTAssertTrue(filter.matches(makeRequest(url: nil)))
+    }
+
+    func testHostModeAloneDoesNotActivateFilterAndClearResetsIt() {
+        var filter = NetworkLogFilter()
+        filter.hostMode = .exclude
+        XCTAssertFalse(filter.isActive)
+        XCTAssertTrue(filter.matches(makeRequest()))
+        filter.hosts = ["a.com"]
+        filter.clear()
+        XCTAssertEqual(filter.hostMode, .include)
+    }
+
+    // MARK: - Content type
+
+    func testContentTypeFilterMatchesShortType() {
+        var filter = NetworkLogFilter()
+        filter.contentTypes = [.IMAGE, .HTML]
+        XCTAssertTrue(filter.matches(makeRequest(shortType: .IMAGE)))
+        XCTAssertTrue(filter.matches(makeRequest(shortType: .HTML)))
+        XCTAssertFalse(filter.matches(makeRequest(shortType: .JSON)))
+    }
+
+    // MARK: - Combination
+
+    func testDimensionsCombineWithAnd() {
+        var filter = NetworkLogFilter()
+        filter.methods = ["GET"]
+        filter.statusClasses = [.success]
+        filter.hosts = ["api.example.com"]
+        filter.contentTypes = [.JSON]
+
+        XCTAssertTrue(filter.matches(makeRequest()))
+        XCTAssertFalse(filter.matches(makeRequest(method: "POST")))
+        XCTAssertFalse(filter.matches(makeRequest(code: 500)))
+        XCTAssertFalse(filter.matches(makeRequest(url: "https://other.com/x")))
+        XCTAssertFalse(filter.matches(makeRequest(shortType: .XML)))
+    }
+
+    func testSelectionCountPerDimension() {
+        var filter = NetworkLogFilter()
+        filter.methods = ["GET", "POST"]
+        filter.hosts = ["a.com"]
+        XCTAssertEqual(filter.selectionCount(for: .method), 2)
+        XCTAssertEqual(filter.selectionCount(for: .status), 0)
+        XCTAssertEqual(filter.selectionCount(for: .host), 1)
+        XCTAssertEqual(filter.selectionCount(for: .contentType), 0)
+    }
+
+    func testClearRemovesAllSelections() {
+        var filter = NetworkLogFilter()
+        filter.methods = ["GET"]
+        filter.statusClasses = [.success]
+        filter.hosts = ["a.com"]
+        filter.contentTypes = [.JSON]
+        filter.clear()
+        XCTAssertFalse(filter.isActive)
+        XCTAssertEqual(filter, NetworkLogFilter())
+    }
+
+    func testSelectionsAreReadAndWrittenByDimension() {
+        var filter = NetworkLogFilter()
+        filter.setSelection(["GET"], for: .method)
+        filter.setSelection([HTTPStatusClass.success.rawValue], for: .status)
+        filter.setSelection(["a.com"], for: .host)
+        filter.setSelection([HTTPModelShortType.XML.rawValue], for: .contentType)
+
+        XCTAssertEqual(filter.methods, ["GET"])
+        XCTAssertEqual(filter.statusClasses, [.success])
+        XCTAssertEqual(filter.hosts, ["a.com"])
+        XCTAssertEqual(filter.contentTypes, [.XML])
+
+        XCTAssertEqual(filter.selection(for: .method), ["GET"])
+        XCTAssertEqual(filter.selection(for: .status), [HTTPStatusClass.success.rawValue])
+        XCTAssertEqual(filter.selection(for: .host), ["a.com"])
+        XCTAssertEqual(filter.selection(for: .contentType), [HTTPModelShortType.XML.rawValue])
+    }
+}
+
+// MARK: - Extended dimensions
+
+final class NetworkLogFilterExtendedTests: XCTestCase {
+
+    private func makeRequest(
+        isGraphQL: Bool = false,
+        operationType: GraphQLOperationType? = nil,
+        durationMs: Float? = 50,
+        code: Int? = 200,
+        date: Date? = Date()
+    ) -> HTTPRequest {
+        let request = HTTPRequest()
+        request.requestMethod = "GET"
+        request.requestURL = "https://api.example.com/x"
+        request.isGraphQL = isGraphQL
+        request.graphQLOperationType = operationType
+        request.requestDuration = durationMs
+        request.responseCode = code
+        request.noResponse = code == nil
+        request.requestDate = date
+        return request
+    }
+
+    // MARK: API kind
+
+    func testAPIKindIsDerivedFromRequest() {
+        XCTAssertEqual(APIKind(request: makeRequest()), .rest)
+        XCTAssertEqual(APIKind(request: makeRequest(isGraphQL: true, operationType: .query)), .graphQL)
+        XCTAssertEqual(APIKind(request: makeRequest(isGraphQL: true, operationType: nil)), .graphQL)
+    }
+
+    func testAPIFilterMatchesByKind() {
+        var filter = NetworkLogFilter()
+        filter.apiKinds = [.graphQL]
+        XCTAssertTrue(filter.matches(makeRequest(isGraphQL: true, operationType: .query)))
+        XCTAssertFalse(filter.matches(makeRequest()))
+        filter.apiKinds = [.rest]
+        XCTAssertTrue(filter.matches(makeRequest()))
+        XCTAssertFalse(filter.matches(makeRequest(isGraphQL: true, operationType: nil)))
+    }
+
+    // MARK: GraphQL operation
+
+    func testGraphQLOperationIsDerivedFromRequest() {
+        XCTAssertNil(GraphQLOperationFilter(request: makeRequest()))
+        XCTAssertEqual(GraphQLOperationFilter(request: makeRequest(isGraphQL: true, operationType: .query)), .query)
+        XCTAssertEqual(GraphQLOperationFilter(request: makeRequest(isGraphQL: true, operationType: .mutation)), .mutation)
+        XCTAssertEqual(GraphQLOperationFilter(request: makeRequest(isGraphQL: true, operationType: .subscription)), .subscription)
+        XCTAssertEqual(GraphQLOperationFilter(request: makeRequest(isGraphQL: true, operationType: nil)), .batch)
+    }
+
+    func testGraphQLFilterMatchesOperationAndExcludesREST() {
+        var filter = NetworkLogFilter()
+        filter.graphQLOperations = [.mutation, .batch]
+        XCTAssertTrue(filter.matches(makeRequest(isGraphQL: true, operationType: .mutation)))
+        XCTAssertTrue(filter.matches(makeRequest(isGraphQL: true, operationType: nil)))
+        XCTAssertFalse(filter.matches(makeRequest(isGraphQL: true, operationType: .query)))
+        XCTAssertFalse(filter.matches(makeRequest()))
+    }
+
+    // MARK: Duration
+
+    func testDurationBucketIsDerivedFromMilliseconds() {
+        XCTAssertEqual(DurationBucket(request: makeRequest(durationMs: 0)), .under100ms)
+        XCTAssertEqual(DurationBucket(request: makeRequest(durationMs: 99.9)), .under100ms)
+        XCTAssertEqual(DurationBucket(request: makeRequest(durationMs: 100)), .from100msTo500ms)
+        XCTAssertEqual(DurationBucket(request: makeRequest(durationMs: 500)), .from500msTo1s)
+        XCTAssertEqual(DurationBucket(request: makeRequest(durationMs: 1000)), .from1sTo3s)
+        XCTAssertEqual(DurationBucket(request: makeRequest(durationMs: 3000)), .over3s)
+        XCTAssertNil(DurationBucket(request: makeRequest(durationMs: nil)))
+    }
+
+    func testDurationFilterMatchesBucketAndExcludesPending() {
+        var filter = NetworkLogFilter()
+        filter.durationBuckets = [.over3s, .from1sTo3s]
+        XCTAssertTrue(filter.matches(makeRequest(durationMs: 4500)))
+        XCTAssertTrue(filter.matches(makeRequest(durationMs: 1500)))
+        XCTAssertFalse(filter.matches(makeRequest(durationMs: 20)))
+        XCTAssertFalse(filter.matches(makeRequest(durationMs: nil, code: nil)))
+    }
+
+    // MARK: Exact status code
+
+    func testStatusCodeFilterMatchesExactCode() {
+        var filter = NetworkLogFilter()
+        filter.statusCodes = [404, 201]
+        XCTAssertTrue(filter.matches(makeRequest(code: 404)))
+        XCTAssertTrue(filter.matches(makeRequest(code: 201)))
+        XCTAssertFalse(filter.matches(makeRequest(code: 200)))
+        XCTAssertFalse(filter.matches(makeRequest(code: nil)))
+    }
+
+    // MARK: Recency
+
+    func testRecencyWindowMatchesAgainstInjectedNow() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        var filter = NetworkLogFilter()
+        filter.recencyWindow = .lastFiveMinutes
+
+        XCTAssertTrue(filter.matches(makeRequest(date: now.addingTimeInterval(-299)), now: now))
+        XCTAssertFalse(filter.matches(makeRequest(date: now.addingTimeInterval(-301)), now: now))
+        XCTAssertFalse(filter.matches(makeRequest(date: nil), now: now))
+    }
+
+    func testRecencyIsSingleSelectAndSetSelectionKeepsWidestWindow() {
+        XCTAssertTrue(NetworkLogFilterDimension.recency.isSingleSelect)
+        XCTAssertFalse(NetworkLogFilterDimension.method.isSingleSelect)
+
+        var filter = NetworkLogFilter()
+        filter.setSelection([RecencyWindow.lastMinute.rawValue, RecencyWindow.lastHour.rawValue], for: .recency)
+        XCTAssertEqual(filter.recencyWindow, .lastHour)
+        XCTAssertEqual(filter.selectionCount(for: .recency), 1)
+    }
+
+    // MARK: Dimension plumbing
+
+    func testNewDimensionsRoundTripThroughSelectionAPI() {
+        var filter = NetworkLogFilter()
+        filter.setSelection([APIKind.graphQL.rawValue], for: .api)
+        filter.setSelection([GraphQLOperationFilter.query.rawValue], for: .graphQL)
+        filter.setSelection([DurationBucket.over3s.rawValue], for: .duration)
+        filter.setSelection(["404", "500", "not-a-code"], for: .statusCode)
+        filter.setSelection([RecencyWindow.lastMinute.rawValue], for: .recency)
+
+        XCTAssertEqual(filter.apiKinds, [.graphQL])
+        XCTAssertEqual(filter.graphQLOperations, [.query])
+        XCTAssertEqual(filter.durationBuckets, [.over3s])
+        XCTAssertEqual(filter.statusCodes, [404, 500])
+        XCTAssertEqual(filter.recencyWindow, .lastMinute)
+
+        XCTAssertEqual(filter.selection(for: .api), ["graphQL"])
+        XCTAssertEqual(filter.selection(for: .graphQL), ["query"])
+        XCTAssertEqual(filter.selection(for: .duration), [DurationBucket.over3s.rawValue])
+        XCTAssertEqual(filter.selection(for: .statusCode), ["404", "500"])
+        XCTAssertEqual(filter.selection(for: .recency), [RecencyWindow.lastMinute.rawValue])
+        XCTAssertEqual(filter.totalSelectionCount, 6)
+        XCTAssertTrue(filter.isActive)
+
+        filter.clear()
+        XCTAssertEqual(filter.totalSelectionCount, 0)
+    }
+
+    func testGroupsPartitionEveryDimensionExactlyOnce() {
+        let grouped = NetworkLogFilterGroup.allCases.flatMap(\.dimensions)
+        XCTAssertEqual(Set(grouped), Set(NetworkLogFilterDimension.allCases))
+        XCTAssertEqual(grouped.count, NetworkLogFilterDimension.allCases.count)
+        for dimension in NetworkLogFilterDimension.allCases {
+            XCTAssertTrue(dimension.group.dimensions.contains(dimension))
+        }
+    }
+
+    func testGroupMembership() {
+        XCTAssertEqual(NetworkLogFilterGroup.request.dimensions, [.method, .host, .api, .graphQL])
+        XCTAssertEqual(NetworkLogFilterGroup.response.dimensions, [.status, .statusCode, .contentType])
+        XCTAssertEqual(NetworkLogFilterGroup.timing.dimensions, [.duration, .recency])
+    }
+
+    func testChipHeightIsFixedAt40Points() {
+        XCTAssertEqual(NetworkLogFilterChip.height, 40)
+    }
+
+    func testDimensionOrderStartsWithOriginalFour() {
+        XCTAssertEqual(
+            NetworkLogFilterDimension.allCases,
+            [.method, .status, .host, .contentType, .api, .graphQL, .duration, .statusCode, .recency]
+        )
+    }
+}

--- a/Tests/ScytherTests/Features/NetworkLogsViewModelTests.swift
+++ b/Tests/ScytherTests/Features/NetworkLogsViewModelTests.swift
@@ -34,3 +34,125 @@ final class NetworkLogsViewModelTests: XCTestCase {
         XCTAssertEqual(NetworkLogsViewModel.filter(items: [a, b], searchTerm: "").count, 2)
     }
 }
+
+// MARK: - Filter integration
+
+@MainActor
+final class NetworkLogsViewModelFilterTests: XCTestCase {
+
+    private func makeRequest(method: String, url: String, code: Int?) -> HTTPRequest {
+        let request = HTTPRequest()
+        request.requestMethod = method
+        request.requestURL = url
+        request.responseCode = code
+        request.noResponse = code == nil
+        return request
+    }
+
+    func testFilterAndSearchCompose() {
+        let a = makeRequest(method: "GET", url: "https://api.example.com/users", code: 200)
+        let b = makeRequest(method: "POST", url: "https://api.example.com/users", code: 201)
+        let c = makeRequest(method: "GET", url: "https://api.example.com/orders", code: 200)
+
+        var filter = NetworkLogFilter()
+        filter.methods = ["GET"]
+
+        let result = NetworkLogsViewModel.filter(items: [a, b, c], searchTerm: "users", filter: filter)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertTrue(result.first === a)
+    }
+
+    func testFilterWithEmptySearchOnlyAppliesChips() {
+        let a = makeRequest(method: "GET", url: "https://api.example.com/users", code: 200)
+        let b = makeRequest(method: "POST", url: "https://api.example.com/users", code: 500)
+
+        var filter = NetworkLogFilter()
+        filter.statusClasses = [.serverError]
+
+        let result = NetworkLogsViewModel.filter(items: [a, b], searchTerm: "", filter: filter)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertTrue(result.first === b)
+    }
+
+    func testAvailableMethodsAreDistinctUppercasedAndSorted() {
+        let items = [
+            makeRequest(method: "post", url: "https://a.com", code: 200),
+            makeRequest(method: "GET", url: "https://a.com", code: 200),
+            makeRequest(method: "POST", url: "https://a.com", code: 200),
+        ]
+        XCTAssertEqual(NetworkLogsViewModel.availableMethods(in: items), ["GET", "POST"])
+    }
+
+    func testAvailableHostsAreDistinctLowercasedAndSorted() {
+        let items = [
+            makeRequest(method: "GET", url: "https://Zeta.com/x", code: 200),
+            makeRequest(method: "GET", url: "https://alpha.com/y", code: 200),
+            makeRequest(method: "GET", url: "https://zeta.com/z", code: 200),
+            makeRequest(method: "GET", url: "-", code: nil),
+        ]
+        XCTAssertEqual(NetworkLogsViewModel.availableHosts(in: items), ["alpha.com", "zeta.com"])
+    }
+
+    func testOptionsForDimensionUseStaticListsForStatusAndContentType() {
+        let viewModel = NetworkLogsViewModel()
+        let status = viewModel.options(for: .status)
+        XCTAssertEqual(status.map(\.id), HTTPStatusClass.allCases.map(\.rawValue))
+        let types = viewModel.options(for: .contentType)
+        XCTAssertEqual(types.map(\.id), HTTPModelShortType.allCases.map(\.rawValue))
+    }
+}
+
+// MARK: - Extended options
+
+@MainActor
+final class NetworkLogsViewModelExtendedOptionsTests: XCTestCase {
+
+    private func makeRequest(code: Int?) -> HTTPRequest {
+        let request = HTTPRequest()
+        request.requestMethod = "GET"
+        request.requestURL = "https://a.com"
+        request.responseCode = code
+        request.noResponse = code == nil
+        return request
+    }
+
+    func testAvailableStatusCodesAreDistinctSortedAndExcludePending() {
+        let items = [makeRequest(code: 500), makeRequest(code: 200), makeRequest(code: 500), makeRequest(code: nil), makeRequest(code: 0)]
+        XCTAssertEqual(NetworkLogsViewModel.availableStatusCodes(in: items), [200, 500])
+    }
+
+    func testChipTitleShowsValueForSingleSelectionAndCountForMultiple() {
+        let viewModel = NetworkLogsViewModel()
+        XCTAssertEqual(viewModel.chipTitle(for: .recency), "Recency")
+
+        viewModel.filter.recencyWindow = .lastHour
+        XCTAssertEqual(viewModel.chipTitle(for: .recency), "Last hour")
+
+        viewModel.filter.statusClasses = [.success]
+        XCTAssertEqual(viewModel.chipTitle(for: .status), "2xx Success")
+
+        viewModel.filter.statusClasses = [.success, .serverError]
+        XCTAssertEqual(viewModel.chipTitle(for: .status), "Status · 2")
+
+        viewModel.filter.methods = ["GET"]
+        XCTAssertEqual(viewModel.chipTitle(for: .method), "GET")
+    }
+
+    func testChipTitleMarksSingleExcludedHost() {
+        let viewModel = NetworkLogsViewModel()
+        viewModel.filter.hosts = ["a.com"]
+        viewModel.filter.hostMode = .exclude
+        XCTAssertEqual(viewModel.chipTitle(for: .host), "Not a.com")
+        viewModel.filter.hostMode = .include
+        XCTAssertEqual(viewModel.chipTitle(for: .host), "a.com")
+    }
+
+    func testStaticOptionsForNewDimensions() {
+        let viewModel = NetworkLogsViewModel()
+        XCTAssertEqual(viewModel.options(for: .api).map(\.id), APIKind.allCases.map(\.rawValue))
+        XCTAssertEqual(viewModel.options(for: .graphQL).map(\.id), GraphQLOperationFilter.allCases.map(\.rawValue))
+        XCTAssertEqual(viewModel.options(for: .duration).map(\.id), DurationBucket.allCases.map(\.rawValue))
+        XCTAssertEqual(viewModel.options(for: .recency).map(\.id), RecencyWindow.allCases.map(\.rawValue))
+        XCTAssertEqual(viewModel.options(for: .statusCode), [])
+    }
+}


### PR DESCRIPTION
## Summary

**Request Details** gains a top-trailing export button that opens the same system share sheet as the existing "Export cURL request" row.

**Network Logs** gains chip-driven filtering that composes with the search field:

- **Nine dimensions**: Method, Status (2xx/3xx/4xx/5xx/pending), Host, Type, API (REST or GraphQL), GraphQL operation, Duration buckets, exact status Code, and Recency. Method, Host, and Code options are built from the captured requests. Dimensions combine with AND, values within a dimension with OR; Recency is single-select since each window contains the shorter ones.
- **Chip bar** pinned above the list via a top safe-area inset. 40pt glass capsules on iOS 26 with a filled-capsule fallback. An active chip is accent-tinted with white text and shows the selected value (e.g. `Last hour`, `Not a.com`) or `Status · 2` for several. A red Clear chip appears while any filter is active.
- **Per-dimension sheet** from each chip: `LabeledContent` checklist, conditional Reset, system confirm button. The Host list has an Include / Exclude segmented header so the selection acts as an allow list or a deny list.
- **Filters sheet** from the leading `slider.horizontal.3` chip: rows grouped into Request, Response, and Timing, each showing its selection summary and pushing that dimension's checklist with its own Reset.

**Architecture**: `NetworkLogFilter` (pure value type with the dimension, group, and bucket enums), `NetworkLogsViewModel` owns the published filter and derived option lists, and each sheet has its own view model file. Shared row, empty state, confirm button, and host-mode picker live in one components file. `HTTPModelShortType` is now `Sendable`.

## Testing

- New unit tests for every dimension's matching, the derived option lists, chip titles, both sheet view models (toggle, single-select, reset, host mode, summaries), and the group partitioning. All written before the implementation.
- Full suite on the iPhone 17 Pro simulator: Executed 500 tests, with 0 failures.
- Verified visually in the example app on iOS 26.2.