### PR TITLE
Add zip export of the network log with best-effort redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A comprehensive iOS debugging toolkit that helps you cut through bugs in your iO
 - **Network Logging**: Automatically intercept and log all HTTP requests/responses
 - **Request Details**: View headers, body, timing, and response codes
 - **cURL Export**: Generate cURL commands for any captured request
+- **Log Export**: Share the captured requests as a zip containing a HAR 1.2 file, raw bodies, and a cURL command per request, with best-effort redaction and a sensitivity warning
 - **Filter Chips**: Narrow the network log by method, status class, host, content type, API kind, GraphQL operation, duration, exact status code, or recency from glass chips pinned above the list, or edit every filter at once from the all-filters sheet
 - **Server Configuration**: Switch between development, staging, and production environments
 - **IP Address**: Display the device's public IP address
@@ -412,6 +413,15 @@ captured requests, so you only ever choose from values that exist. The Host list
 Exclude control in its header, so the selected hosts can act as an allow list or a deny list. An icon-only chip at the start
 of the row opens a Filters sheet listing every dimension, grouped into Request, Response, and Timing, with
 its current selection; each row pushes that dimension's checklist. A Clear chip appears whenever a filter is active.
+
+The export button in the navigation bar shares the requests currently shown (so search and
+filters narrow the archive) as `<App-Name>-Network-Log-<timestamp>.zip`, named after the host app. The zip holds a HAR 1.2
+file that opens in Charles, Proxyman, or Chrome DevTools, plus a folder per request with the raw
+request body, raw response body, and a cURL command. The export sheet shows progress while the
+zip is built, and a Redaction toggle (on by default) replaces common tokens, cookies, passwords,
+and API keys in headers, URLs, bodies, and cURL commands with `REDACTED`, as a best-effort attempt
+rather than a guarantee. Because the archive can include full headers, cookies, tokens, and
+bodies, tapping Export shows a sensitivity alert before the system share sheet opens.
 
 #### GraphQL Support
 

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogExportSheet.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogExportSheet.swift
@@ -1,0 +1,166 @@
+//
+//  NetworkLogExportSheet.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import SwiftUI
+
+/// A full-height sheet that builds the network log archive and shares it after a warning.
+///
+/// Opened from the export button on ``NetworkLogsView``. Shows a progress indicator while
+/// ``NetworkLogExportViewModel`` writes the zip, then the archive name, request count, contents,
+/// a redaction toggle that rebuilds the archive in place (the previous rows stay put with an
+/// inline spinner in the File row), and a red Export button. Export shows the
+/// sensitivity alert; confirming it opens the system share sheet. A close button sits in the
+/// leading toolbar slot, matching the root menu. The archive is deleted when the sheet is dismissed.
+struct NetworkLogExportSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @StateObject private var viewModel: NetworkLogExportViewModel
+
+    /// Whether the sensitivity alert is presented.
+    @State private var showingWarning: Bool = false
+
+    /// Whether the system share sheet is presented.
+    @State private var showingShareSheet: Bool = false
+
+    /// Creates the export sheet.
+    ///
+    /// - Parameter viewModel: The view model that builds and owns the archive.
+    init(viewModel: NetworkLogExportViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                archiveSection
+                contentsSection
+                redactionSection
+                exportSection
+            }
+            .navigationTitle("Export Network Log")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityLabel("Close")
+                }
+            }
+            .alert("Export Sensitive Data?", isPresented: $showingWarning) {
+                Button("Cancel", role: .cancel) {}
+                Button("Export", role: .destructive) {
+                    showingShareSheet = true
+                }
+            } message: {
+                Text(warningMessage)
+            }
+            .sheet(isPresented: $showingShareSheet) {
+                if let url = viewModel.archiveURL {
+                    ActivityShareSheet(items: [url])
+                        .presentationDetents([.medium, .large])
+                }
+            }
+        }
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+        .onFirstAppear {
+            await viewModel.onFirstAppear()
+        }
+        .onDisappear {
+            viewModel.cleanup()
+        }
+    }
+
+    private var warningMessage: String {
+        let base = "The archive contains the full headers, cookies, authentication tokens, and request and response bodies of the \(viewModel.requestCount) requests currently shown. This data may be extremely sensitive. Handle and share it with extreme care."
+        return viewModel.redactSensitiveValues
+            ? base + " Redaction is on, but it is best effort and not a guarantee of privacy."
+            : base
+    }
+
+    @ViewBuilder
+    private var archiveSection: some View {
+        switch viewModel.state {
+        case .preparing:
+            Section("Archive") {
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text("Preparing archive of \(viewModel.requestCount) requests…")
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 8)
+            }
+        case .ready(let url):
+            Section("Archive") {
+                // The spinner stays mounted as a trailing accessory and only changes
+                // opacity, so the row never re-lays out when a rebuild starts or ends.
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("File")
+                        Text(url.lastPathComponent)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    ProgressView()
+                        .opacity(viewModel.isRebuilding ? 1 : 0)
+                }
+                LabeledContent("Requests", value: "\(viewModel.requestCount)")
+            }
+        case .failed(let message):
+            Section("Archive") {
+                Label(message, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var contentsSection: some View {
+        Section("Contents") {
+            Label("network-log.har (HAR 1.2)", systemImage: "doc.text")
+            Label("Raw request and response bodies", systemImage: "folder")
+            Label("cURL command per request", systemImage: "terminal")
+        }
+    }
+
+    private var redactionSection: some View {
+        Section {
+            Toggle(
+                "Redact sensitive values",
+                isOn: Binding(
+                    get: { viewModel.redactSensitiveValues },
+                    set: { viewModel.setRedaction($0) }
+                )
+            )
+        } header: {
+            Text("Redaction")
+        } footer: {
+            Text("Replaces common tokens, cookies, passwords, and API keys in headers, URLs, bodies, and cURL commands with REDACTED. This is an attempt, not a guarantee of privacy.")
+        }
+    }
+
+    private var exportSection: some View {
+        Section {
+            Button(role: .destructive) {
+                showingWarning = true
+            } label: {
+                Text("Export")
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .tint(.red)
+            .disabled(viewModel.archiveURL == nil || viewModel.isRebuilding)
+            .listRowBackground(Color.clear)
+            .listRowInsets(.init())
+        }
+    }
+}

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogExportViewModel.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogExportViewModel.swift
@@ -1,0 +1,144 @@
+//
+//  NetworkLogExportViewModel.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import Foundation
+
+/// View model backing ``NetworkLogExportSheet``.
+///
+/// On first appearance it builds the zip archive for the supplied requests off the main actor,
+/// publishing ``state`` transitions so the sheet can show progress, the finished archive, or an
+/// error. Toggling ``redactSensitiveValues`` through ``setRedaction(_:)`` rebuilds the archive.
+/// ``cleanup()`` deletes the archive when the sheet closes.
+///
+/// ## Usage
+///
+/// ```swift
+/// let viewModel = NetworkLogExportViewModel(requests: listViewModel.requests)
+/// ```
+final class NetworkLogExportViewModel: ViewModel {
+    /// The stages of an export.
+    enum State: Equatable, Sendable {
+        /// The archive is being written.
+        case preparing
+        /// The archive is ready at the given URL.
+        case ready(URL)
+        /// The export failed with a user-facing message.
+        case failed(String)
+    }
+
+    /// The requests being exported.
+    let requests: [HTTPRequest]
+
+    /// The current stage of the export.
+    @Published private(set) var state: State = .preparing
+
+    /// Whether the archive is passed through ``NetworkLogRedactor``. Defaults to on.
+    @Published private(set) var redactSensitiveValues: Bool = true
+
+    /// Whether a replacement archive is being built after a setting change.
+    ///
+    /// While true, ``state`` still holds the previous archive so the sheet can keep its rows in
+    /// place and show an inline spinner rather than tearing the section down.
+    @Published private(set) var isRebuilding: Bool = false
+
+    /// Produces the archive for the requests and redaction flag. Injected so tests can avoid real zipping.
+    private let exporter: @Sendable ([HTTPRequest], Bool) throws -> URL
+
+    /// The shortest time a rebuild is allowed to take, so the inline spinner is seen rather than flickering.
+    static let defaultMinimumRebuildDuration: Duration = .milliseconds(750)
+
+    /// The minimum wall-clock time for a rebuild triggered by ``setRedaction(_:)``.
+    private let minimumRebuildDuration: Duration
+
+    /// Creates an export view model.
+    ///
+    /// - Parameters:
+    ///   - requests: The requests to export.
+    ///   - minimumRebuildDuration: Floor on how long a rebuild appears to take. Defaults to
+    ///     ``defaultMinimumRebuildDuration``; pass `.zero` in tests.
+    ///   - exporter: Builds the archive. Defaults to ``NetworkLogExporter/export(_:in:now:redact:)``.
+    init(
+        requests: [HTTPRequest],
+        minimumRebuildDuration: Duration = defaultMinimumRebuildDuration,
+        exporter: @escaping @Sendable ([HTTPRequest], Bool) throws -> URL = { requests, redact in
+            try NetworkLogExporter.export(requests, redact: redact)
+        }
+    ) {
+        self.requests = requests
+        self.minimumRebuildDuration = minimumRebuildDuration
+        self.exporter = exporter
+        super.init()
+    }
+
+    /// The number of requests in the archive.
+    var requestCount: Int { requests.count }
+
+    /// The finished archive, once ``state`` is ``State/ready(_:)``.
+    var archiveURL: URL? {
+        if case .ready(let url) = state { return url }
+        return nil
+    }
+
+    /// The finished archive's filename, for display.
+    var archiveFilename: String? { archiveURL?.lastPathComponent }
+
+    /// Builds the archive off the main actor and publishes the outcome.
+    override func onFirstAppear() async {
+        await super.onFirstAppear()
+        await build()
+    }
+
+    /// Changes the redaction setting and rebuilds the archive.
+    ///
+    /// The setting and ``isRebuilding`` flip synchronously so a bound `Toggle` never bounces. The
+    /// previous archive stays in ``state`` until the replacement is ready, after which the old
+    /// file is deleted. The rebuild is padded to at least the minimum duration so the spinner is
+    /// visible rather than a flicker.
+    ///
+    /// - Parameter enabled: Whether to redact.
+    /// - Returns: The rebuild task, or `nil` when the value did not change. Await it in tests.
+    @discardableResult
+    func setRedaction(_ enabled: Bool) -> Task<Void, Never>? {
+        guard enabled != redactSensitiveValues else { return nil }
+        redactSensitiveValues = enabled
+        isRebuilding = true
+        let previous = archiveURL
+        let minimum = minimumRebuildDuration
+        return Task { @MainActor in
+            let started = ContinuousClock.now
+            await build()
+            let remaining = minimum - (ContinuousClock.now - started)
+            if remaining > .zero {
+                try? await Task.sleep(for: remaining)
+            }
+            isRebuilding = false
+            if let previous, previous != archiveURL {
+                try? FileManager.default.removeItem(at: previous)
+            }
+        }
+    }
+
+    private func build() async {
+        let requests = self.requests
+        let redact = self.redactSensitiveValues
+        let exporter = self.exporter
+        do {
+            let url = try await Task.detached(priority: .userInitiated) {
+                try exporter(requests, redact)
+            }.value
+            state = .ready(url)
+        } catch {
+            state = .failed(error.localizedDescription)
+        }
+    }
+
+    /// Deletes the archive file, if one was produced.
+    func cleanup() {
+        guard let archiveURL else { return }
+        try? FileManager.default.removeItem(at: archiveURL)
+    }
+}

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogExporter.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogExporter.swift
@@ -1,0 +1,201 @@
+//
+//  NetworkLogExporter.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import Foundation
+
+/// Packages captured ``HTTPRequest`` values into a shareable zip archive.
+///
+/// The archive is laid out as:
+///
+/// ```
+/// <App-Name>-Network-Log-<timestamp>/
+/// ├── network-log.har                 HAR 1.2 document (see ``NetworkLogHARBuilder``)
+/// └── requests/
+///     └── 001-GET-api.example.com/
+///         ├── request.curl            cURL command to replay the request
+///         ├── request-body.json       raw request body, when one was sent
+///         └── response-body.json      raw response body, when one was received
+/// ```
+///
+/// Zipping uses `NSFileCoordinator`'s `forUploading` option, which produces a zip of a directory
+/// without any third-party dependency.
+///
+/// ## Usage
+///
+/// ```swift
+/// let zipURL = try NetworkLogExporter.export(requests)
+/// ```
+enum NetworkLogExporter {
+    /// Failures raised by ``export(_:in:now:)``.
+    enum ExportError: Error, Equatable {
+        /// No requests were supplied.
+        case nothingToExport
+        /// The file coordinator could not produce a zip.
+        case zipFailed(String)
+    }
+
+    /// Builds the zip archive for `requests`.
+    ///
+    /// - Parameters:
+    ///   - requests: The requests to include. Must not be empty.
+    ///   - parent: The directory to write into. Defaults to the temporary directory.
+    ///   - now: The timestamp used in the archive name.
+    ///   - redact: Whether to pass every file through ``NetworkLogRedactor`` first.
+    /// - Returns: The URL of the finished `.zip` file. The staging directory is removed.
+    static func export(
+        _ requests: [HTTPRequest],
+        in parent: URL = FileManager.default.temporaryDirectory,
+        now: Date = Date(),
+        redact: Bool = false
+    ) throws -> URL {
+        guard !requests.isEmpty else { throw ExportError.nothingToExport }
+        let name = archiveName(now: now)
+        let staging = try writeArchiveDirectory(for: requests, in: parent, name: name, redact: redact)
+        defer { try? FileManager.default.removeItem(at: staging) }
+        return try zip(directory: staging)
+    }
+
+    /// The host app's display name, falling back to its bundle name, then `App`.
+    static var hostAppName: String {
+        let bundle = Bundle.main
+        return (bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
+            ?? (bundle.object(forInfoDictionaryKey: "CFBundleName") as? String)
+            ?? "App"
+    }
+
+    /// The archive base name for a timestamp, e.g. `My-App-Network-Log-2026-09-04-091500`.
+    ///
+    /// Whitespace in the app name becomes `-`; any other character outside letters, digits,
+    /// `.`, `-`, and `_` becomes `_`. An empty name falls back to `App`.
+    ///
+    /// - Parameters:
+    ///   - now: The timestamp.
+    ///   - timeZone: The zone used to format it. Defaults to the current zone.
+    ///   - appName: The name to prefix. Defaults to ``hostAppName``.
+    static func archiveName(now: Date, timeZone: TimeZone = .current, appName: String = hostAppName) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        let trimmed = appName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefix = trimmed.isEmpty ? "App" : sanitised(trimmed.replacingOccurrences(of: " ", with: "-"))
+        return "\(prefix)-Network-Log-\(formatter.string(from: now))"
+    }
+
+    /// The per-request folder name, e.g. `003-DELETE-api.example.com`.
+    ///
+    /// - Parameters:
+    ///   - index: The 1-based position of the request in the export.
+    ///   - request: The request.
+    static func folderName(index: Int, request: HTTPRequest) -> String {
+        let method = sanitised(request.requestMethod?.uppercased() ?? "UNKNOWN")
+        let host = sanitised(request.host ?? "unknown-host")
+        return String(format: "%03d-%@-%@", index, method, host)
+    }
+
+    /// Writes the un-zipped archive layout for `requests`.
+    ///
+    /// - Parameters:
+    ///   - requests: The requests to include.
+    ///   - parent: The directory to create the archive folder in.
+    ///   - name: The archive folder name.
+    ///   - redact: Whether to pass the HAR, bodies, and cURL commands through ``NetworkLogRedactor``.
+    /// - Returns: The URL of the created folder.
+    static func writeArchiveDirectory(
+        for requests: [HTTPRequest],
+        in parent: URL,
+        name: String,
+        redact: Bool = false
+    ) throws -> URL {
+        let fileManager = FileManager.default
+        let root = parent.appendingPathComponent(name, isDirectory: true)
+        try? fileManager.removeItem(at: root)
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+
+        var har = NetworkLogHARBuilder.build(from: requests)
+        if redact { har = NetworkLogRedactor.redact(har) }
+        try NetworkLogHARBuilder.encode(har).write(to: root.appendingPathComponent("network-log.har"))
+
+        let ordered = requests.sorted { ($0.requestDate ?? .distantPast) < ($1.requestDate ?? .distantPast) }
+        for (offset, request) in ordered.enumerated() {
+            let folder = root
+                .appendingPathComponent("requests", isDirectory: true)
+                .appendingPathComponent(folderName(index: offset + 1, request: request), isDirectory: true)
+            try fileManager.createDirectory(at: folder, withIntermediateDirectories: true)
+
+            var curl = request.requestCurl ?? ""
+            if redact { curl = NetworkLogRedactor.redactCurl(curl) }
+            try Data(curl.utf8).write(to: folder.appendingPathComponent("request.curl"))
+
+            if let body = request.readRawData(request.getRequestBodyFilepath()), !body.isEmpty {
+                let filename = "request-body.\(fileExtension(for: request.requestType, shortType: nil))"
+                try scrubbed(body, redact: redact, isBase64: false).write(to: folder.appendingPathComponent(filename))
+            }
+            if let body = request.readRawData(request.getResponseBodyFilepath()), !body.isEmpty {
+                let isImage = request.shortType == HTTPModelShortType.IMAGE.rawValue
+                let filename = "response-body.\(fileExtension(for: request.responseType, shortType: request.shortType))"
+                try scrubbed(body, redact: redact, isBase64: isImage).write(to: folder.appendingPathComponent(filename))
+            }
+        }
+        return root
+    }
+
+    /// Zips a directory into a sibling `.zip` file using the file coordinator.
+    ///
+    /// - Parameter directory: The directory to zip.
+    /// - Returns: The URL of the zip file, named after the directory.
+    static func zip(directory: URL) throws -> URL {
+        let destination = directory.deletingPathExtension().appendingPathExtension("zip")
+        try? FileManager.default.removeItem(at: destination)
+
+        var coordinationError: NSError?
+        var copyError: Error?
+        NSFileCoordinator().coordinate(
+            readingItemAt: directory,
+            options: .forUploading,
+            error: &coordinationError
+        ) { zippedURL in
+            do {
+                try FileManager.default.copyItem(at: zippedURL, to: destination)
+            } catch {
+                copyError = error
+            }
+        }
+        if let coordinationError {
+            throw ExportError.zipFailed(coordinationError.localizedDescription)
+        }
+        if let copyError {
+            throw ExportError.zipFailed(copyError.localizedDescription)
+        }
+        return destination
+    }
+
+    // MARK: - Helpers
+
+    /// Passes a stored body through the redactor when requested. Base64 bodies are never altered.
+    private static func scrubbed(_ body: Data, redact: Bool, isBase64: Bool) -> Data {
+        guard redact, !isBase64 else { return body }
+        return Data(NetworkLogRedactor.redactText(String(decoding: body, as: UTF8.self)).utf8)
+    }
+
+    private static func sanitised(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: ".-_"))
+        return String(value.unicodeScalars.map { allowed.contains($0) ? Character($0) : "_" })
+    }
+
+    private static func fileExtension(for contentType: String?, shortType: String?) -> String {
+        if shortType == HTTPModelShortType.IMAGE.rawValue {
+            return "base64.txt"
+        }
+        let type = (contentType ?? "").lowercased()
+        if type.contains("json") { return "json" }
+        if type.contains("xml") { return "xml" }
+        if type.contains("html") { return "html" }
+        if type.hasPrefix("text/") { return "txt" }
+        return "txt"
+    }
+}

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogHARBuilder.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogHARBuilder.swift
@@ -1,0 +1,220 @@
+//
+//  NetworkLogHARBuilder.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import Foundation
+
+/// The root of an HTTP Archive (HAR) 1.2 document.
+struct HARLog: Codable, Sendable {
+    let log: HARLogBody
+}
+
+/// The `log` object of a HAR document.
+struct HARLogBody: Codable, Sendable {
+    let version: String
+    let creator: HARCreator
+    /// Free text about the log, e.g. a redaction notice. Omitted from JSON when `nil`.
+    let comment: String?
+    let entries: [HAREntry]
+}
+
+/// The tool that produced a HAR document.
+struct HARCreator: Codable, Sendable {
+    let name: String
+    let version: String
+}
+
+/// One captured request/response pair in a HAR document.
+struct HAREntry: Codable, Sendable {
+    let startedDateTime: String
+    let time: Double
+    let request: HARRequest
+    let response: HARResponse
+    let cache: HARCache
+    let timings: HARTimings
+}
+
+/// The request half of a ``HAREntry``.
+struct HARRequest: Codable, Sendable {
+    let method: String
+    let url: String
+    let httpVersion: String
+    let cookies: [HARCookie]
+    let headers: [HARNameValue]
+    let queryString: [HARNameValue]
+    let postData: HARPostData?
+    let headersSize: Int
+    let bodySize: Int
+}
+
+/// The response half of a ``HAREntry``.
+struct HARResponse: Codable, Sendable {
+    let status: Int
+    let statusText: String
+    let httpVersion: String
+    let cookies: [HARCookie]
+    let headers: [HARNameValue]
+    let content: HARContent
+    let redirectURL: String
+    let headersSize: Int
+    let bodySize: Int
+}
+
+/// A header or query string pair.
+struct HARNameValue: Codable, Sendable {
+    let name: String
+    let value: String
+}
+
+/// A cookie entry. Scyther does not capture cookies separately, so this is always empty.
+struct HARCookie: Codable, Sendable {
+    let name: String
+    let value: String
+}
+
+/// A request body.
+struct HARPostData: Codable, Sendable {
+    let mimeType: String
+    let text: String
+}
+
+/// A response body. `encoding` is `"base64"` when `text` is base64 rather than literal text.
+struct HARContent: Codable, Sendable {
+    let size: Int
+    let mimeType: String
+    let text: String?
+    let encoding: String?
+}
+
+/// Cache information. Always empty; Scyther does not inspect the URL cache.
+struct HARCache: Codable, Sendable {}
+
+/// Phase timings in milliseconds. Scyther only measures total duration, reported as `wait`.
+struct HARTimings: Codable, Sendable {
+    let send: Double
+    let wait: Double
+    let receive: Double
+}
+
+/// Builds HAR 1.2 documents from captured ``HTTPRequest`` values.
+///
+/// HAR is the interchange format read by Charles, Proxyman, Chrome DevTools, and most HTTP
+/// tooling. Bodies are embedded as text; image bodies are embedded as base64 and flagged with
+/// `encoding: "base64"`.
+///
+/// ## Usage
+///
+/// ```swift
+/// let har = NetworkLogHARBuilder.build(from: requests)
+/// let data = try NetworkLogHARBuilder.encode(har)
+/// ```
+enum NetworkLogHARBuilder {
+    /// The version reported for the creator when none is supplied: the host app's marketing
+    /// version, since the toolkit does not embed its own.
+    static var defaultCreatorVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+    }
+
+    /// Builds a HAR document from captured requests, ordered oldest first.
+    ///
+    /// - Parameters:
+    ///   - requests: The requests to include.
+    ///   - creatorVersion: The version recorded in the `creator` object.
+    /// - Returns: The HAR document.
+    static func build(from requests: [HTTPRequest], creatorVersion: String = defaultCreatorVersion) -> HARLog {
+        let ordered = requests.sorted { ($0.requestDate ?? .distantPast) < ($1.requestDate ?? .distantPast) }
+        return HARLog(log: HARLogBody(
+            version: "1.2",
+            creator: HARCreator(name: "Scyther", version: creatorVersion),
+            comment: nil,
+            entries: ordered.map(entry(for:))
+        ))
+    }
+
+    /// Encodes a HAR document as pretty-printed JSON with stable key order.
+    ///
+    /// - Parameter log: The document to encode.
+    static func encode(_ log: HARLog) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(log)
+    }
+
+    // MARK: - Mapping
+
+    private static func iso8601(_ date: Date) -> String {
+        date.formatted(.iso8601.year().month().day().dateTimeSeparator(.standard).time(includingFractionalSeconds: true).timeZone(separator: .omitted))
+    }
+
+    private static func entry(for request: HTTPRequest) -> HAREntry {
+        let duration = Double(request.requestDuration ?? 0)
+        return HAREntry(
+            startedDateTime: iso8601(request.requestDate ?? .distantPast),
+            time: duration,
+            request: harRequest(for: request),
+            response: harResponse(for: request),
+            cache: HARCache(),
+            timings: HARTimings(send: 0, wait: duration, receive: 0)
+        )
+    }
+
+    private static func harRequest(for request: HTTPRequest) -> HARRequest {
+        let bodyData = request.readRawData(request.getRequestBodyFilepath())
+        let postData: HARPostData? = bodyData.flatMap { data in
+            guard !data.isEmpty else { return nil }
+            return HARPostData(
+                mimeType: request.requestType ?? "",
+                text: String(decoding: data, as: UTF8.self)
+            )
+        }
+        return HARRequest(
+            method: request.requestMethod ?? "GET",
+            url: request.requestURL ?? "",
+            httpVersion: "HTTP/1.1",
+            cookies: [],
+            headers: nameValues(from: request.requestHeaders),
+            queryString: (request.requestURLQueryItems ?? []).map {
+                HARNameValue(name: $0.name, value: $0.value ?? "")
+            },
+            postData: postData,
+            headersSize: -1,
+            bodySize: bodyData?.count ?? 0
+        )
+    }
+
+    private static func harResponse(for request: HTTPRequest) -> HARResponse {
+        let status = request.responseCode ?? 0
+        let bodyData = request.readRawData(request.getResponseBodyFilepath())
+        let isImage = request.shortType == HTTPModelShortType.IMAGE.rawValue
+        let text = bodyData.map { String(decoding: $0, as: UTF8.self) }
+        let size = request.responseBodyLength ?? bodyData?.count ?? 0
+        return HARResponse(
+            status: status,
+            statusText: status > 0 ? HTTPURLResponse.localizedString(forStatusCode: status) : "",
+            httpVersion: "HTTP/1.1",
+            cookies: [],
+            headers: nameValues(from: request.responseHeaders),
+            content: HARContent(
+                size: size,
+                mimeType: request.responseType ?? "",
+                text: text,
+                encoding: (isImage && text != nil) ? "base64" : nil
+            ),
+            redirectURL: "",
+            headersSize: -1,
+            bodySize: size
+        )
+    }
+
+    private static func nameValues(from headers: [AnyHashable: Any]?) -> [HARNameValue] {
+        (headers ?? [:])
+            .compactMap { key, value -> HARNameValue? in
+                guard let name = key as? String else { return nil }
+                return HARNameValue(name: name, value: "\(value)")
+            }
+            .sorted { $0.name < $1.name }
+    }
+}

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogRedactor.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogRedactor.swift
@@ -1,0 +1,229 @@
+//
+//  NetworkLogRedactor.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import Foundation
+
+/// Best-effort scrubbing of secrets from an exported network log.
+///
+/// Replaces values with `REDACTED` when their header name, query parameter, JSON key, or form
+/// field looks sensitive (authorization, tokens, cookies, passwords, API keys, sessions), and
+/// replaces `Bearer` credentials and JWT-shaped strings wherever they appear in text.
+///
+/// This is an attempt, not a guarantee: secrets under unusual names, inside binary bodies, or in
+/// formats the patterns do not cover will pass through untouched.
+///
+/// ## Usage
+///
+/// ```swift
+/// let safeHAR = NetworkLogRedactor.redact(har)
+/// let safeCurl = NetworkLogRedactor.redactCurl(curl)
+/// ```
+enum NetworkLogRedactor {
+    /// The replacement written in place of a redacted value.
+    static let placeholder = "REDACTED"
+
+    /// The `log.comment` written into a redacted HAR document.
+    static let harComment = "Sensitive values replaced with REDACTED by Scyther. Best effort only, not a guarantee of privacy."
+
+    /// Whole words that mark a name as sensitive, matched after splitting on separators and camel case.
+    private static let sensitiveWords: Set<String> = [
+        "authorization", "auth", "token", "secret", "password", "passwd", "pwd", "cookie", "session",
+        "signature", "credential", "credentials", "bearer", "jwt", "otp", "csrf", "xsrf", "apikey",
+    ]
+
+    /// Substrings that mark a name as sensitive after separators are removed, e.g. `x-api-key`.
+    private static let sensitiveFragments = ["apikey", "token", "secret", "password", "cookie", "session"]
+
+    // MARK: - Names
+
+    /// Whether a header, query, JSON, or form name should have its value redacted.
+    ///
+    /// - Parameter name: The name to test, in any casing or separator style.
+    static func isSensitiveName(_ name: String) -> Bool {
+        let words = Set(splitWords(name))
+        if !words.isDisjoint(with: sensitiveWords) { return true }
+        let compact = name.lowercased().filter(\.isLetter)
+        return sensitiveFragments.contains { compact.contains($0) }
+    }
+
+    private static func splitWords(_ name: String) -> [String] {
+        var words: [String] = []
+        var current = ""
+        var previousWasLower = false
+        for character in name {
+            if character.isLetter || character.isNumber {
+                if character.isUppercase, previousWasLower, !current.isEmpty {
+                    words.append(current)
+                    current = ""
+                }
+                current.append(character.lowercased())
+                previousWasLower = character.isLowercase
+            } else {
+                if !current.isEmpty { words.append(current) }
+                current = ""
+                previousWasLower = false
+            }
+        }
+        if !current.isEmpty { words.append(current) }
+        return words
+    }
+
+    // MARK: - Structured values
+
+    /// Redacts the values of any sensitively named pairs.
+    ///
+    /// - Parameter pairs: Header or query pairs.
+    static func redact(_ pairs: [HARNameValue]) -> [HARNameValue] {
+        pairs.map { isSensitiveName($0.name) ? HARNameValue(name: $0.name, value: placeholder) : $0 }
+    }
+
+    /// Redacts sensitively named query parameters in a URL string.
+    ///
+    /// - Parameter url: The URL to scrub. Returned unchanged if it cannot be parsed.
+    static func redactURL(_ url: String) -> String {
+        guard var components = URLComponents(string: url),
+              let items = components.queryItems, !items.isEmpty else { return url }
+        components.queryItems = items.map {
+            isSensitiveName($0.name) ? URLQueryItem(name: $0.name, value: placeholder) : $0
+        }
+        return components.string ?? url
+    }
+
+    /// Redacts response content unless it is base64 encoded binary.
+    ///
+    /// - Parameter content: The content to scrub.
+    static func redact(_ content: HARContent) -> HARContent {
+        guard content.encoding == nil, let text = content.text else { return content }
+        return HARContent(size: content.size, mimeType: content.mimeType, text: redactText(text), encoding: nil)
+    }
+
+    /// Redacts every field of a HAR document and stamps ``harComment`` on the log.
+    ///
+    /// - Parameter log: The document to scrub.
+    static func redact(_ log: HARLog) -> HARLog {
+        HARLog(log: HARLogBody(
+            version: log.log.version,
+            creator: log.log.creator,
+            comment: harComment,
+            entries: log.log.entries.map(redact(_:))
+        ))
+    }
+
+    private static func redact(_ entry: HAREntry) -> HAREntry {
+        let request = HARRequest(
+            method: entry.request.method,
+            url: redactURL(entry.request.url),
+            httpVersion: entry.request.httpVersion,
+            cookies: entry.request.cookies.map { HARCookie(name: $0.name, value: placeholder) },
+            headers: redact(entry.request.headers),
+            queryString: redact(entry.request.queryString),
+            postData: entry.request.postData.map { HARPostData(mimeType: $0.mimeType, text: redactText($0.text)) },
+            headersSize: entry.request.headersSize,
+            bodySize: entry.request.bodySize
+        )
+        let response = HARResponse(
+            status: entry.response.status,
+            statusText: entry.response.statusText,
+            httpVersion: entry.response.httpVersion,
+            cookies: entry.response.cookies.map { HARCookie(name: $0.name, value: placeholder) },
+            headers: redact(entry.response.headers),
+            content: redact(entry.response.content),
+            redirectURL: redactURL(entry.response.redirectURL),
+            headersSize: entry.response.headersSize,
+            bodySize: entry.response.bodySize
+        )
+        return HAREntry(
+            startedDateTime: entry.startedDateTime,
+            time: entry.time,
+            request: request,
+            response: response,
+            cache: entry.cache,
+            timings: entry.timings
+        )
+    }
+
+    // MARK: - Free text
+
+    private static let jsonPairPattern = try! NSRegularExpression(
+        pattern: #""((?:[^"\\]|\\.)+)"(\s*:\s*)("(?:[^"\\]|\\.)*"|[^,}\]\s"{\[]+)"#
+    )
+    private static let formPairPattern = try! NSRegularExpression(
+        pattern: #"(?<![A-Za-z0-9_\-\.\[\]])([A-Za-z0-9_\-\.\[\]]+)=([^&\s'"]+)"#
+    )
+    private static let bearerPattern = try! NSRegularExpression(
+        pattern: #"(?i)\bBearer\s+[A-Za-z0-9\-._~+/]+=*"#
+    )
+    private static let jwtPattern = try! NSRegularExpression(
+        pattern: #"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"#
+    )
+
+    /// Redacts sensitively keyed JSON and form values, `Bearer` credentials, and JWTs in text.
+    ///
+    /// - Parameter text: A body, log line, or command to scrub.
+    static func redactText(_ text: String) -> String {
+        var output = replace(jsonPairPattern, in: text) { match, source in
+            let key = source.substring(match.range(at: 1))
+            guard isSensitiveName(key) else { return nil }
+            return "\"\(key)\"\(source.substring(match.range(at: 2)))\"\(placeholder)\""
+        }
+        output = replace(formPairPattern, in: output) { match, source in
+            let key = source.substring(match.range(at: 1))
+            guard isSensitiveName(key) else { return nil }
+            return "\(key)=\(placeholder)"
+        }
+        output = replace(bearerPattern, in: output) { _, _ in "Bearer \(placeholder)" }
+        output = replace(jwtPattern, in: output) { _, _ in placeholder }
+        return output
+    }
+
+    private static let curlSingleQuotedHeader = try! NSRegularExpression(pattern: #"-H '([^:']+):\s*([^']*)'"#)
+    private static let curlDoubleQuotedHeader = try! NSRegularExpression(pattern: #"-H "([^:"]+):\s*([^"]*)""#)
+    private static let quotedURLPattern = try! NSRegularExpression(pattern: #"(['"])(https?://[^'"]+)\1"#)
+
+    /// Redacts sensitive headers, query parameters, and body values in a cURL command.
+    ///
+    /// - Parameter curl: The command to scrub.
+    static func redactCurl(_ curl: String) -> String {
+        var output = replace(curlSingleQuotedHeader, in: curl) { match, source in
+            let name = source.substring(match.range(at: 1))
+            guard isSensitiveName(name) else { return nil }
+            return "-H '\(name): \(placeholder)'"
+        }
+        output = replace(curlDoubleQuotedHeader, in: output) { match, source in
+            let name = source.substring(match.range(at: 1))
+            guard isSensitiveName(name) else { return nil }
+            return "-H \"\(name): \(placeholder)\""
+        }
+        output = replace(quotedURLPattern, in: output) { match, source in
+            let quote = source.substring(match.range(at: 1))
+            return quote + redactURL(source.substring(match.range(at: 2))) + quote
+        }
+        return redactText(output)
+    }
+
+    /// Applies `replacement` to each match, right to left so ranges stay valid. A `nil` result leaves the match as is.
+    private static func replace(
+        _ regex: NSRegularExpression,
+        in text: String,
+        with replacement: (NSTextCheckingResult, NSString) -> String?
+    ) -> String {
+        let source = text as NSString
+        var output = text
+        for match in regex.matches(in: text, range: NSRange(location: 0, length: source.length)).reversed() {
+            guard let value = replacement(match, source),
+                  let range = Range(match.range, in: output) else { continue }
+            output.replaceSubrange(range, with: value)
+        }
+        return output
+    }
+}
+
+private extension NSString {
+    func substring(_ range: NSRange) -> String {
+        range.location == NSNotFound ? "" : substring(with: range)
+    }
+}

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogsView.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogsView.swift
@@ -16,9 +16,11 @@ import SwiftUI
 /// ## Features
 /// - Real-time updates as new requests are captured
 /// - Search functionality across URLs, status codes, and HTTP methods
-/// - Filter chips for method, status class, host, content type, GraphQL kind, duration, exact status
-///   code, and recency, each opening a selection sheet, plus an all-filters chip that edits every
-///   dimension on one screen
+/// - Filter chips for method, status class, host, content type, API kind, GraphQL operation,
+///   duration, exact status code, and recency, each opening a selection sheet, plus an all-filters
+///   chip that edits every dimension from one Filters sheet
+/// - Export of the requests currently shown as a zip archive (HAR plus raw bodies), with optional
+///   redaction and a sensitivity alert before sharing
 /// - Color-coded status indicators
 /// - Navigation to detailed request view
 ///
@@ -37,6 +39,9 @@ struct NetworkLogsView: View {
 
     /// Whether the all-filters sheet is presented.
     @State private var showingAllFilters: Bool = false
+
+    /// The requests snapshotted for export when the export button was tapped, if any.
+    @State private var exportRequests: [HTTPRequest]?
 
     /// View model managing the network logs state and filtering.
     @StateObject private var viewModel: NetworkLogsViewModel = .init()
@@ -92,12 +97,24 @@ struct NetworkLogsView: View {
         }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
+                Button("Export", systemImage: "square.and.arrow.up") {
+                    exportRequests = viewModel.requests
+                }
+                .disabled(viewModel.requests.isEmpty)
+            }
+            ToolbarItem(placement: .topBarTrailing) {
                 Button("Delete", systemImage: "trash", role: .destructive) {
                     Task {
                         await viewModel.didPressDeleteButton()
                     }
                 }
             }
+        }
+        .sheet(item: Binding(
+            get: { exportRequests.map(NetworkLogExportBatch.init) },
+            set: { exportRequests = $0?.requests }
+        )) { batch in
+            NetworkLogExportSheet(viewModel: NetworkLogExportViewModel(requests: batch.requests))
         }
         .searchable(
             text: $searchText,
@@ -108,4 +125,10 @@ struct NetworkLogsView: View {
             viewModel.setSearchTerm(to: $0)
         }
     }
+}
+
+/// An identifiable wrapper for the requests snapshotted at export time, used to drive the export sheet.
+struct NetworkLogExportBatch: Identifiable {
+    let id = UUID()
+    let requests: [HTTPRequest]
 }

--- a/Sources/Scyther/Scyther.docc/NetworkDebugging.md
+++ b/Sources/Scyther/Scyther.docc/NetworkDebugging.md
@@ -91,6 +91,29 @@ dimension name with a count when several are. A Reset button appears in each
 sheet while it has a selection, and a red Clear chip appears in the bar whenever any filter is active.
 Filters are held in memory for the current session only.
 
+## Exporting the Whole Log
+
+The export button in the Network Logs navigation bar packages the requests currently shown into
+`<App-Name>-Network-Log-<timestamp>.zip`, named after the host app. Search and filter chips narrow what is included.
+
+The archive contains:
+
+- `network-log.har`, a HAR 1.2 document readable by Charles, Proxyman, Chrome DevTools, and most
+  HTTP tooling. Image bodies are embedded as base64.
+- `requests/<index>-<METHOD>-<host>/` per request, holding `request.curl` and the raw request
+  and response bodies when they exist.
+
+The export sheet shows progress while the zip is built. A **Redaction** toggle, on by default,
+replaces values whose header name, query parameter, JSON key, or form field looks sensitive
+(authorization, tokens, cookies, passwords, API keys, sessions) with `REDACTED`, and scrubs
+`Bearer` credentials and JWT-shaped strings wherever they appear. Redacted HAR files carry a
+`log.comment` saying so. This is an attempt, not a guarantee: secrets under unusual names or in
+formats the patterns do not cover pass through untouched.
+
+Because the archive can include full headers, cookies, authentication tokens, and bodies, tapping
+**Export** shows a sensitivity alert first; confirming opens the system share sheet. The file is
+deleted when the sheet closes.
+
 ## Exporting cURL Commands
 
 Every request can be exported as a cURL command from the request details page. Tap the

--- a/Sources/Scyther/Shared/Components/ActivityShareSheet.swift
+++ b/Sources/Scyther/Shared/Components/ActivityShareSheet.swift
@@ -1,0 +1,24 @@
+//
+//  ActivityShareSheet.swift
+//  Scyther
+//
+//  Created by Brandon Stillitano on 4/9/2026.
+//
+
+import SwiftUI
+import UIKit
+
+/// The system share sheet, for the one case `ShareLink` cannot cover: opening it from an alert action.
+///
+/// Present it with `.sheet(isPresented:)`. Prefer `ShareLink` wherever the share is triggered
+/// directly by a tap on a view.
+struct ActivityShareSheet: UIViewControllerRepresentable {
+    /// The items to share, typically file URLs.
+    let items: [URL]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/Tests/ScytherTests/Features/NetworkLogExportViewModelTests.swift
+++ b/Tests/ScytherTests/Features/NetworkLogExportViewModelTests.swift
@@ -1,0 +1,136 @@
+//
+//  NetworkLogExportViewModelTests.swift
+//  ScytherTests
+//
+
+@testable import Scyther
+import XCTest
+
+@MainActor
+final class NetworkLogExportViewModelTests: XCTestCase {
+
+    private func makeTempFile() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("export-\(UUID().uuidString).zip")
+        try Data("PK".utf8).write(to: url)
+        return url
+    }
+
+    func testStartsPreparingThenBecomesReadyWithArchive() async throws {
+        let file = try makeTempFile()
+        let requests = [HTTPRequest(), HTTPRequest()]
+        let viewModel = NetworkLogExportViewModel(requests: requests, minimumRebuildDuration: .zero) { _, _ in file }
+
+        XCTAssertEqual(viewModel.state, .preparing)
+        XCTAssertEqual(viewModel.requestCount, 2)
+
+        await viewModel.onFirstAppear()
+
+        XCTAssertEqual(viewModel.state, .ready(file))
+        XCTAssertEqual(viewModel.archiveURL, file)
+        XCTAssertEqual(viewModel.archiveFilename, file.lastPathComponent)
+    }
+
+    func testFailureIsReported() async {
+        struct Boom: Error {}
+        let viewModel = NetworkLogExportViewModel(requests: [HTTPRequest()], minimumRebuildDuration: .zero) { _, _ in throw Boom() }
+        await viewModel.onFirstAppear()
+        guard case .failed = viewModel.state else {
+            return XCTFail("expected failed state, got \(viewModel.state)")
+        }
+        XCTAssertNil(viewModel.archiveURL)
+    }
+
+    func testCleanupRemovesArchive() async throws {
+        let file = try makeTempFile()
+        let viewModel = NetworkLogExportViewModel(requests: [HTTPRequest()], minimumRebuildDuration: .zero) { _, _ in file }
+        await viewModel.onFirstAppear()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: file.path))
+        viewModel.cleanup()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: file.path))
+    }
+
+    func testRedactionDefaultsOnAndTogglingRebuildsWithFlag() async throws {
+        final class Box: @unchecked Sendable { var flags: [Bool] = [] }
+        let first = try makeTempFile()
+        let second = try makeTempFile()
+        let box = Box()
+        let viewModel = NetworkLogExportViewModel(requests: [HTTPRequest()], minimumRebuildDuration: .zero) { _, redact in
+            box.flags.append(redact)
+            return redact ? first : second
+        }
+        XCTAssertTrue(viewModel.redactSensitiveValues)
+        await viewModel.onFirstAppear()
+        XCTAssertEqual(viewModel.archiveURL, first)
+
+        let task = viewModel.setRedaction(false)
+        XCTAssertFalse(viewModel.redactSensitiveValues, "flag flips synchronously so the toggle never bounces")
+        XCTAssertTrue(viewModel.isRebuilding)
+        await task?.value
+        XCTAssertEqual(box.flags, [true, false])
+        XCTAssertEqual(viewModel.archiveURL, second)
+        XCTAssertFalse(viewModel.isRebuilding)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: first.path), "previous archive should be removed")
+    }
+
+    func testRebuildKeepsPreviousArchiveVisibleUntilReplaced() async throws {
+        final class Gate: @unchecked Sendable {
+            let semaphore = DispatchSemaphore(value: 0)
+            var calls = 0
+        }
+        let first = try makeTempFile()
+        let second = try makeTempFile()
+        let gate = Gate()
+        let viewModel = NetworkLogExportViewModel(requests: [HTTPRequest()], minimumRebuildDuration: .zero) { _, redact in
+            gate.calls += 1
+            if !redact { gate.semaphore.wait() }
+            return redact ? first : second
+        }
+        await viewModel.onFirstAppear()
+
+        let rebuild = viewModel.setRedaction(false)
+        while gate.calls < 2 { await Task.yield() }
+
+        XCTAssertTrue(viewModel.isRebuilding)
+        XCTAssertEqual(viewModel.state, .ready(first), "previous archive stays in the ready state while rebuilding")
+        XCTAssertFalse(viewModel.redactSensitiveValues, "toggle reflects the new value immediately")
+
+        gate.semaphore.signal()
+        await rebuild?.value
+        XCTAssertFalse(viewModel.isRebuilding)
+        XCTAssertEqual(viewModel.state, .ready(second))
+    }
+
+    func testRebuildHonoursMinimumDuration() async throws {
+        let file = try makeTempFile()
+        let viewModel = NetworkLogExportViewModel(requests: [HTTPRequest()], minimumRebuildDuration: .milliseconds(300)) { _, _ in file }
+        await viewModel.onFirstAppear()
+
+        let start = ContinuousClock.now
+        await viewModel.setRedaction(false)?.value
+        let elapsed = ContinuousClock.now - start
+        XCTAssertGreaterThanOrEqual(elapsed, .milliseconds(300))
+        XCTAssertFalse(viewModel.isRebuilding)
+    }
+
+    func testDefaultMinimumRebuildDurationIs750Milliseconds() {
+        XCTAssertEqual(NetworkLogExportViewModel.defaultMinimumRebuildDuration, .milliseconds(750))
+    }
+
+    func testSettingSameRedactionValueIsNoOp() async throws {
+        let file = try makeTempFile()
+        let viewModel = NetworkLogExportViewModel(requests: [HTTPRequest()], minimumRebuildDuration: .zero) { _, _ in file }
+        await viewModel.onFirstAppear()
+        XCTAssertNil(viewModel.setRedaction(true))
+        XCTAssertFalse(viewModel.isRebuilding)
+    }
+
+    func testExporterReceivesTheGivenRequests() async throws {
+        final class Box: @unchecked Sendable { var received: [HTTPRequest] = [] }
+        let file = try makeTempFile()
+        let a = HTTPRequest(), b = HTTPRequest()
+        let box = Box()
+        let viewModel = NetworkLogExportViewModel(requests: [a, b], minimumRebuildDuration: .zero) { requests, _ in box.received = requests; return file }
+        await viewModel.onFirstAppear()
+        XCTAssertTrue(box.received[0] === a && box.received[1] === b)
+    }
+}

--- a/Tests/ScytherTests/Features/NetworkLogExporterTests.swift
+++ b/Tests/ScytherTests/Features/NetworkLogExporterTests.swift
@@ -1,0 +1,149 @@
+//
+//  NetworkLogExporterTests.swift
+//  ScytherTests
+//
+
+@testable import Scyther
+import XCTest
+
+final class NetworkLogExporterTests: XCTestCase {
+
+    private var scratch: URL!
+
+    override func setUpWithError() throws {
+        scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("NetworkLogExporterTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: scratch)
+    }
+
+    private func makeRequest(url: String, method: String = "GET", body: String? = nil) -> HTTPRequest {
+        let mutable = NSMutableURLRequest(url: URL(string: url)!)
+        mutable.httpMethod = method
+        if let body {
+            mutable.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            URLProtocol.setProperty(Data(body.utf8), forKey: "ScytherBodyData", in: mutable)
+        }
+        let urlRequest = mutable as URLRequest
+        let request = HTTPRequest()
+        request.saveRequest(urlRequest)
+        request.saveRequestBody(urlRequest)
+        let response = HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        request.saveResponse(response, data: Data("{\"ok\":true}".utf8))
+        return request
+    }
+
+    func testArchiveNameUsesHostAppNameAndTimestamp() {
+        let now = Date(timeIntervalSince1970: 0)
+        let utc = TimeZone(identifier: "UTC")!
+        XCTAssertEqual(
+            NetworkLogExporter.archiveName(now: now, timeZone: utc, appName: "Scyther Example"),
+            "Scyther-Example-Network-Log-1970-01-01-000000"
+        )
+        XCTAssertEqual(
+            NetworkLogExporter.archiveName(now: now, timeZone: utc, appName: "My/App: v2"),
+            "My_App_-v2-Network-Log-1970-01-01-000000"
+        )
+        XCTAssertEqual(
+            NetworkLogExporter.archiveName(now: now, timeZone: utc, appName: "   "),
+            "App-Network-Log-1970-01-01-000000"
+        )
+    }
+
+    func testDefaultAppNameComesFromHostBundle() {
+        let expected = (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
+            ?? (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String)
+            ?? "App"
+        XCTAssertEqual(NetworkLogExporter.hostAppName, expected)
+    }
+
+    func testFolderNameIsIndexedAndFilesystemSafe() {
+        let request = makeRequest(url: "https://api.example.com/users/1?x=y", method: "DELETE")
+        XCTAssertEqual(NetworkLogExporter.folderName(index: 3, request: request), "003-DELETE-api.example.com")
+    }
+
+    func testWriteArchiveDirectoryLaysOutHARAndPerRequestFolders() throws {
+        let requests = [
+            makeRequest(url: "https://api.example.com/a", method: "POST", body: "{\"k\":1}"),
+            makeRequest(url: "https://cdn.example.com/b"),
+        ]
+        let root = try NetworkLogExporter.writeArchiveDirectory(for: requests, in: scratch, name: "archive")
+        let fm = FileManager.default
+
+        XCTAssertTrue(fm.fileExists(atPath: root.appendingPathComponent("network-log.har").path))
+        let first = root.appendingPathComponent("requests/001-POST-api.example.com")
+        XCTAssertTrue(fm.fileExists(atPath: first.appendingPathComponent("request.curl").path))
+        XCTAssertTrue(fm.fileExists(atPath: first.appendingPathComponent("request-body.json").path))
+        XCTAssertTrue(fm.fileExists(atPath: first.appendingPathComponent("response-body.json").path))
+        XCTAssertEqual(
+            try String(contentsOf: first.appendingPathComponent("request-body.json"), encoding: .utf8),
+            "{\"k\":1}"
+        )
+
+        let second = root.appendingPathComponent("requests/002-GET-cdn.example.com")
+        XCTAssertTrue(fm.fileExists(atPath: second.appendingPathComponent("request.curl").path))
+        XCTAssertFalse(fm.fileExists(atPath: second.appendingPathComponent("request-body.json").path))
+    }
+
+    func testExportProducesZipFile() throws {
+        let zip = try NetworkLogExporter.export([makeRequest(url: "https://api.example.com/a")], in: scratch)
+        XCTAssertEqual(zip.pathExtension, "zip")
+        XCTAssertTrue(zip.lastPathComponent.contains("-Network-Log-"))
+        let data = try Data(contentsOf: zip)
+        XCTAssertGreaterThan(data.count, 100)
+        XCTAssertEqual(data.prefix(2), Data([0x50, 0x4B]), "expected zip magic bytes")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: zip.deletingPathExtension().path),
+            "staging directory should be removed after zipping"
+        )
+    }
+
+    func testRedactedExportScrubsHARBodiesAndCurl() throws {
+        let mutable = NSMutableURLRequest(url: URL(string: "https://api.example.com/login?token=abc")!)
+        mutable.httpMethod = "POST"
+        mutable.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        mutable.setValue("Bearer secret-token", forHTTPHeaderField: "Authorization")
+        URLProtocol.setProperty(Data(#"{"password":"hunter2"}"#.utf8), forKey: "ScytherBodyData", in: mutable)
+        let urlRequest = mutable as URLRequest
+        let request = HTTPRequest()
+        request.saveRequest(urlRequest)
+        request.saveRequestBody(urlRequest)
+        let response = HTTPURLResponse(url: urlRequest.url!, statusCode: 200, httpVersion: nil, headerFields: ["Content-Type": "application/json"])!
+        request.saveResponse(response, data: Data(#"{"access_token":"tok"}"#.utf8))
+
+        let root = try NetworkLogExporter.writeArchiveDirectory(for: [request], in: scratch, name: "redacted", redact: true)
+        let har = try String(contentsOf: root.appendingPathComponent("network-log.har"), encoding: .utf8)
+        XCTAssertFalse(har.contains("secret-token"))
+        XCTAssertFalse(har.contains("hunter2"))
+        XCTAssertFalse(har.contains("\"tok\""))
+        XCTAssertFalse(har.contains("token=abc"))
+        XCTAssertTrue(har.contains(NetworkLogRedactor.harComment))
+
+        let folder = root.appendingPathComponent("requests/001-POST-api.example.com")
+        let curl = try String(contentsOf: folder.appendingPathComponent("request.curl"), encoding: .utf8)
+        XCTAssertFalse(curl.contains("secret-token"))
+        XCTAssertFalse(curl.contains("token=abc"))
+        let requestBody = try String(contentsOf: folder.appendingPathComponent("request-body.json"), encoding: .utf8)
+        XCTAssertEqual(requestBody, #"{"password":"REDACTED"}"#)
+        let responseBody = try String(contentsOf: folder.appendingPathComponent("response-body.json"), encoding: .utf8)
+        XCTAssertEqual(responseBody, #"{"access_token":"REDACTED"}"#)
+
+        let raw = try NetworkLogExporter.writeArchiveDirectory(for: [request], in: scratch, name: "raw", redact: false)
+        let rawHar = try String(contentsOf: raw.appendingPathComponent("network-log.har"), encoding: .utf8)
+        XCTAssertTrue(rawHar.contains("secret-token"))
+    }
+
+    func testExportRefusesEmptyList() {
+        XCTAssertThrowsError(try NetworkLogExporter.export([], in: scratch)) { error in
+            XCTAssertEqual(error as? NetworkLogExporter.ExportError, .nothingToExport)
+        }
+    }
+}

--- a/Tests/ScytherTests/Features/NetworkLogHARBuilderTests.swift
+++ b/Tests/ScytherTests/Features/NetworkLogHARBuilderTests.swift
@@ -1,0 +1,127 @@
+//
+//  NetworkLogHARBuilderTests.swift
+//  ScytherTests
+//
+
+@testable import Scyther
+import XCTest
+
+final class NetworkLogHARBuilderTests: XCTestCase {
+
+    private func makeRequest(
+        url: String = "https://api.example.com/users?page=2&sort=name",
+        method: String = "POST",
+        requestBody: String? = "{\"name\":\"Ada\"}",
+        responseBody: Data = Data("{\"ok\":true}".utf8),
+        status: Int = 201,
+        contentType: String = "application/json"
+    ) -> HTTPRequest {
+        let mutable = NSMutableURLRequest(url: URL(string: url)!)
+        mutable.httpMethod = method
+        mutable.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        mutable.setValue("Bearer secret", forHTTPHeaderField: "Authorization")
+        if let requestBody {
+            // Same mechanism the interceptor uses to hand the body to the logger.
+            URLProtocol.setProperty(Data(requestBody.utf8), forKey: "ScytherBodyData", in: mutable)
+        }
+        let urlRequest = mutable as URLRequest
+
+        let request = HTTPRequest()
+        request.saveRequest(urlRequest)
+        request.saveRequestBody(urlRequest)
+
+        let response = HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": contentType, "X-Trace": "abc"]
+        )!
+        request.saveResponse(response, data: responseBody)
+        return request
+    }
+
+    func testLogHeaderAndCreator() {
+        let log = NetworkLogHARBuilder.build(from: [makeRequest()], creatorVersion: "9.9.9")
+        XCTAssertEqual(log.log.version, "1.2")
+        XCTAssertEqual(log.log.creator.name, "Scyther")
+        XCTAssertEqual(log.log.creator.version, "9.9.9")
+        XCTAssertEqual(log.log.entries.count, 1)
+    }
+
+    func testEntryMapsRequestFields() throws {
+        let entry = try XCTUnwrap(NetworkLogHARBuilder.build(from: [makeRequest()]).log.entries.first)
+        XCTAssertEqual(entry.request.method, "POST")
+        XCTAssertEqual(entry.request.url, "https://api.example.com/users?page=2&sort=name")
+        XCTAssertEqual(entry.request.httpVersion, "HTTP/1.1")
+        XCTAssertEqual(entry.request.queryString.map(\.name), ["page", "sort"])
+        XCTAssertEqual(entry.request.queryString.map(\.value), ["2", "name"])
+        XCTAssertTrue(entry.request.headers.contains { $0.name == "Authorization" && $0.value == "Bearer secret" })
+        XCTAssertEqual(entry.request.postData?.mimeType, "application/json")
+        XCTAssertEqual(entry.request.postData?.text, "{\"name\":\"Ada\"}")
+        XCTAssertEqual(entry.request.bodySize, "{\"name\":\"Ada\"}".utf8.count)
+        XCTAssertEqual(entry.request.headersSize, -1)
+    }
+
+    func testEntryMapsResponseFieldsAndTimings() throws {
+        let entry = try XCTUnwrap(NetworkLogHARBuilder.build(from: [makeRequest()]).log.entries.first)
+        XCTAssertEqual(entry.response.status, 201)
+        XCTAssertEqual(entry.response.statusText, "created")
+        XCTAssertTrue(entry.response.headers.contains { $0.name == "X-Trace" && $0.value == "abc" })
+        XCTAssertEqual(entry.response.content.mimeType, "application/json")
+        XCTAssertEqual(entry.response.content.text, "{\"ok\":true}")
+        XCTAssertNil(entry.response.content.encoding)
+        XCTAssertEqual(entry.response.content.size, "{\"ok\":true}".utf8.count)
+        XCTAssertEqual(entry.response.redirectURL, "")
+        XCTAssertGreaterThanOrEqual(entry.time, 0)
+        XCTAssertEqual(entry.timings.wait, entry.time)
+        XCTAssertEqual(entry.timings.send, 0)
+        XCTAssertEqual(entry.timings.receive, 0)
+        XCTAssertTrue(entry.startedDateTime.hasSuffix("Z"), "expected ISO 8601 UTC, got \(entry.startedDateTime)")
+    }
+
+    func testImageResponseIsMarkedBase64() throws {
+        let png = Data([0x89, 0x50, 0x4E, 0x47, 0x00, 0xFF])
+        let request = makeRequest(responseBody: png, contentType: "image/png")
+        let entry = try XCTUnwrap(NetworkLogHARBuilder.build(from: [request]).log.entries.first)
+        XCTAssertEqual(entry.response.content.encoding, "base64")
+        XCTAssertEqual(
+            entry.response.content.text?.replacingOccurrences(of: "\n", with: ""),
+            png.base64EncodedString()
+        )
+    }
+
+    func testRequestWithoutBodyHasNoPostData() throws {
+        let request = makeRequest(method: "GET", requestBody: nil)
+        let entry = try XCTUnwrap(NetworkLogHARBuilder.build(from: [request]).log.entries.first)
+        XCTAssertNil(entry.request.postData)
+        XCTAssertEqual(entry.request.bodySize, 0)
+    }
+
+    func testPendingRequestHasZeroStatusAndNoContent() throws {
+        var urlRequest = URLRequest(url: URL(string: "https://api.example.com/slow")!)
+        urlRequest.httpMethod = "GET"
+        let request = HTTPRequest()
+        request.saveRequest(urlRequest)
+        let entry = try XCTUnwrap(NetworkLogHARBuilder.build(from: [request]).log.entries.first)
+        XCTAssertEqual(entry.response.status, 0)
+        XCTAssertNil(entry.response.content.text)
+        XCTAssertEqual(entry.time, 0)
+    }
+
+    func testEntriesAreOrderedOldestFirst() {
+        let newer = makeRequest(url: "https://api.example.com/newer")
+        let older = makeRequest(url: "https://api.example.com/older")
+        older.requestDate = Date(timeIntervalSince1970: 1_000)
+        newer.requestDate = Date(timeIntervalSince1970: 2_000)
+        let log = NetworkLogHARBuilder.build(from: [newer, older])
+        XCTAssertEqual(log.log.entries.map(\.request.url), ["https://api.example.com/older", "https://api.example.com/newer"])
+    }
+
+    func testEncodedOutputIsValidJSONWithLogRoot() throws {
+        let data = try NetworkLogHARBuilder.encode(NetworkLogHARBuilder.build(from: [makeRequest()]))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let log = try XCTUnwrap(object["log"] as? [String: Any])
+        XCTAssertEqual(log["version"] as? String, "1.2")
+        XCTAssertEqual((log["entries"] as? [Any])?.count, 1)
+    }
+}

--- a/Tests/ScytherTests/Features/NetworkLogRedactorTests.swift
+++ b/Tests/ScytherTests/Features/NetworkLogRedactorTests.swift
@@ -1,0 +1,125 @@
+//
+//  NetworkLogRedactorTests.swift
+//  ScytherTests
+//
+
+@testable import Scyther
+import XCTest
+
+final class NetworkLogRedactorTests: XCTestCase {
+
+    // MARK: Names
+
+    func testSensitiveNamesAreDetectedCaseInsensitively() {
+        for name in ["Authorization", "authorization", "Cookie", "Set-Cookie", "X-API-Key", "x-auth-token",
+                     "access_token", "refreshToken", "password", "client_secret", "sessionId", "apikey"] {
+            XCTAssertTrue(NetworkLogRedactor.isSensitiveName(name), name)
+        }
+        for name in ["Content-Type", "Accept", "page", "sort", "user_id", "name"] {
+            XCTAssertFalse(NetworkLogRedactor.isSensitiveName(name), name)
+        }
+    }
+
+    // MARK: Headers and query
+
+    func testHeadersWithSensitiveNamesAreRedacted() {
+        let headers = [
+            HARNameValue(name: "Authorization", value: "Bearer abc"),
+            HARNameValue(name: "Content-Type", value: "application/json"),
+        ]
+        let redacted = NetworkLogRedactor.redact(headers)
+        XCTAssertEqual(redacted.map(\.value), ["REDACTED", "application/json"])
+    }
+
+    func testURLQueryValuesWithSensitiveNamesAreRedacted() {
+        let url = "https://api.example.com/users?page=2&access_token=abc123&sort=name"
+        XCTAssertEqual(
+            NetworkLogRedactor.redactURL(url),
+            "https://api.example.com/users?page=2&access_token=REDACTED&sort=name"
+        )
+        XCTAssertEqual(NetworkLogRedactor.redactURL("https://api.example.com/users"), "https://api.example.com/users")
+    }
+
+    // MARK: Body text
+
+    func testJSONKeysWithSensitiveNamesAreRedacted() {
+        let body = #"{"user":"ada","password":"hunter2","token": "t-1","nested":{"apiKey":"k","id":7}}"#
+        let redacted = NetworkLogRedactor.redactText(body)
+        XCTAssertEqual(
+            redacted,
+            #"{"user":"ada","password":"REDACTED","token": "REDACTED","nested":{"apiKey":"REDACTED","id":7}}"#
+        )
+    }
+
+    func testBearerAndJWTValuesAreRedactedAnywhereInText() {
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        let text = "Authorization: Bearer \(jwt)\nplain \(jwt) end\nBearer short"
+        let redacted = NetworkLogRedactor.redactText(text)
+        XCTAssertFalse(redacted.contains(jwt))
+        XCTAssertEqual(redacted, "Authorization: Bearer REDACTED\nplain REDACTED end\nBearer REDACTED")
+    }
+
+    func testNonSensitiveTextIsUntouched() {
+        let text = #"{"items":[{"id":1,"name":"Ada"}],"page":2}"#
+        XCTAssertEqual(NetworkLogRedactor.redactText(text), text)
+    }
+
+    // MARK: cURL
+
+    func testCurlHeadersWithSensitiveNamesAreRedacted() {
+        let curl = "curl 'https://api.example.com/a?api_key=k1' -X GET -H 'Authorization: Bearer abc' -H 'Accept: */*' -H \"Cookie: session=1\""
+        XCTAssertEqual(
+            NetworkLogRedactor.redactCurl(curl),
+            "curl 'https://api.example.com/a?api_key=REDACTED' -X GET -H 'Authorization: REDACTED' -H 'Accept: */*' -H \"Cookie: REDACTED\""
+        )
+    }
+
+    // MARK: HAR
+
+    func testHARRedactionTouchesEveryFieldAndAddsComment() {
+        let entry = HAREntry(
+            startedDateTime: "2026-09-04T00:00:00.000Z",
+            time: 1,
+            request: HARRequest(
+                method: "POST",
+                url: "https://api.example.com/login?token=abc",
+                httpVersion: "HTTP/1.1",
+                cookies: [],
+                headers: [HARNameValue(name: "Cookie", value: "s=1")],
+                queryString: [HARNameValue(name: "token", value: "abc")],
+                postData: HARPostData(mimeType: "application/json", text: #"{"password":"x"}"#),
+                headersSize: -1,
+                bodySize: 14
+            ),
+            response: HARResponse(
+                status: 200,
+                statusText: "no error",
+                httpVersion: "HTTP/1.1",
+                cookies: [],
+                headers: [HARNameValue(name: "Set-Cookie", value: "s=2")],
+                content: HARContent(size: 10, mimeType: "application/json", text: #"{"refresh_token":"r"}"#, encoding: nil),
+                redirectURL: "",
+                headersSize: -1,
+                bodySize: 10
+            ),
+            cache: HARCache(),
+            timings: HARTimings(send: 0, wait: 1, receive: 0)
+        )
+        let log = HARLog(log: HARLogBody(version: "1.2", creator: HARCreator(name: "Scyther", version: "1"), comment: nil, entries: [entry]))
+
+        let redacted = NetworkLogRedactor.redact(log)
+        let out = redacted.log.entries[0]
+        XCTAssertEqual(out.request.url, "https://api.example.com/login?token=REDACTED")
+        XCTAssertEqual(out.request.headers[0].value, "REDACTED")
+        XCTAssertEqual(out.request.queryString[0].value, "REDACTED")
+        XCTAssertEqual(out.request.postData?.text, #"{"password":"REDACTED"}"#)
+        XCTAssertEqual(out.response.headers[0].value, "REDACTED")
+        XCTAssertEqual(out.response.content.text, #"{"refresh_token":"REDACTED"}"#)
+        XCTAssertEqual(redacted.log.comment, NetworkLogRedactor.harComment)
+    }
+
+    func testBase64ContentIsLeftAlone() {
+        let content = HARContent(size: 4, mimeType: "image/png", text: "iVBORw0KGgo=", encoding: "base64")
+        XCTAssertEqual(NetworkLogRedactor.redact(content).text, "iVBORw0KGgo=")
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **export button** to Network Logs that packages the requests currently shown (search and filter chips narrow it) into `<App-Name>-Network-Log-<timestamp>.zip`, named after the host app.

**Archive contents**
- `network-log.har`: a HAR 1.2 document readable by Charles, Proxyman, Chrome DevTools, and most HTTP tooling. Image bodies are embedded as base64.
- `requests/<index>-<METHOD>-<host>/`: `request.curl` plus the raw request and response bodies where they exist.
- Zipped with `NSFileCoordinator`'s `forUploading` option, so no dependency is added.

**Export sheet** (full height, root-style X to close)
- Builds the archive on open with a progress row, then shows the file, request count, and contents.
- **Redaction** toggle, on by default. Replaces values whose header name, query parameter, JSON key, or form field looks sensitive (authorization, tokens, cookies, passwords, API keys, sessions) with `REDACTED`, and scrubs `Bearer` credentials and JWT-shaped strings anywhere in text, across the HAR, raw bodies, and cURL commands. Base64 bodies are left alone. Redacted HAR files carry a `log.comment`. The footer states it is an attempt, not a guarantee.
- Toggling rebuilds in place: the previous archive stays on screen, a trailing spinner shows in the File row, the toggle flips synchronously, and a 750ms floor keeps the spinner from flickering. The old zip is deleted once the new one exists.
- A red **Export** button shows a destructive "Export Sensitive Data?" alert; confirming opens the system share sheet. Because an alert action cannot trigger `ShareLink`, this one path uses a minimal `UIActivityViewController` wrapper.
- The archive is deleted when the sheet closes.

**Architecture**: `NetworkLogHARBuilder` (pure Codable HAR model + mapping), `NetworkLogRedactor` (pure text and HAR scrubbing), `NetworkLogExporter` (layout + zip), `NetworkLogExportViewModel` (state machine, redaction, rebuild), and `NetworkLogExportSheet`. `HARLogBody` gains an optional `comment`.

## Testing

- New unit tests for HAR field mapping, ordering, base64 flagging, pending requests, archive naming and layout, zip magic bytes, the empty-list error, redacted-versus-raw output, the redactor's name detection and each text pattern, and the export view model (state machine, cleanup, synchronous toggle, in-place rebuild, minimum duration, no-op). All written before the implementation.
- Full suite on the iPhone 17 Pro simulator: Executed 533 tests, with 0 failures.
- Verified in the example app on iOS 26.2: export flow, redaction toggle without flashing, share sheet, and app-named zip.