### PR TITLE
Fix the held requests screen, and break on requests from the log

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,6 +968,20 @@ There are four ways out, and doing nothing is one of them:
 A log entry that was held carries an indigo `HELD` badge, beside `MOCKED` and `REPLAY`, and the
 log records what the app actually sent and received — the edit, not the original.
 
+#### Breaking on a Captured Request
+
+The request details page carries a **Break on requests like this** button, beside **Save as mock**
+and **Replay this request**. It opens the breakpoint editor pre-filled from the capture: the same
+matcher a mock built from that page uses — its method, host and path exactly, with the query left
+unconstrained — holding the request stage, for the default minute.
+
+Unlike a mock, it arrives **enabled**: a breakpoint announces itself by stopping the request and
+putting a screen in front of you, so there is nothing to switch on afterwards and nothing hidden
+if you forget to. Nothing is written until the editor is confirmed either way.
+
+It is offered wherever the entry has a URL, including one an override answered — seeing what the
+app *sent* to a stubbed endpoint is one of the things a breakpoint is for.
+
 #### What it does not do
 
 - **Nothing blocks.** A held request does not occupy the thread it was intercepted on. The pause

--- a/Scripts/localization/strings/Breakpoints.json
+++ b/Scripts/localization/strings/Breakpoints.json
@@ -448,5 +448,20 @@
     "ko": "보류된 요청이 모두 처리되었습니다. 앱은 더 이상 기다리지 않습니다.",
     "ru": "Все удержанные запросы обработаны. Приложение больше не ждёт.",
     "ar": "تمت معالجة كل طلب محتجز. لم يعد التطبيق ينتظر."
+  },
+  "Break on requests like this": {
+    "comment": "Button on a network log entry that creates a breakpoint matching requests like it",
+    "fr": "Interrompre les requêtes similaires",
+    "de": "Bei ähnlichen Anfragen anhalten",
+    "es": "Interrumpir solicitudes similares",
+    "it": "Interrompi richieste simili",
+    "pt-BR": "Interromper solicitações semelhantes",
+    "nl": "Onderbreek vergelijkbare verzoeken",
+    "ja": "同様のリクエストで停止",
+    "zh-Hans": "在类似请求处中断",
+    "zh-Hant": "在類似請求處中斷",
+    "ko": "유사한 요청에서 중단",
+    "ru": "Останавливать похожие запросы",
+    "ar": "إيقاف الطلبات المشابهة"
   }
 }

--- a/Scripts/localization/strings/Breakpoints.json
+++ b/Scripts/localization/strings/Breakpoints.json
@@ -418,5 +418,35 @@
     "ru": "Какую ошибку должно получить приложение?",
     "zh-Hans": "应用应看到哪个错误？",
     "zh-Hant": "App 應該看到哪個錯誤？"
+  },
+  "Nothing Held": {
+    "comment": "Title of the empty state on the held requests screen, shown when every hold has been decided",
+    "fr": "Rien en attente",
+    "de": "Nichts angehalten",
+    "es": "Nada retenido",
+    "it": "Nulla in attesa",
+    "pt-BR": "Nada retido",
+    "nl": "Niets vastgehouden",
+    "ja": "保留なし",
+    "zh-Hans": "无暂停请求",
+    "zh-Hant": "無暫停請求",
+    "ko": "보류 없음",
+    "ru": "Ничего не удерживается",
+    "ar": "لا شيء محتجز"
+  },
+  "Every held request has been decided. The app is no longer waiting.": {
+    "comment": "Description of the empty state on the held requests screen",
+    "fr": "Chaque requête retenue a été traitée. L’application n’attend plus.",
+    "de": "Jede angehaltene Anfrage wurde entschieden. Die App wartet nicht mehr.",
+    "es": "Se ha resuelto cada solicitud retenida. La app ya no está esperando.",
+    "it": "Ogni richiesta in attesa è stata decisa. L’app non sta più aspettando.",
+    "pt-BR": "Todas as requisições retidas foram decididas. O app não está mais esperando.",
+    "nl": "Elk vastgehouden verzoek is afgehandeld. De app wacht niet meer.",
+    "ja": "保留中のリクエストはすべて処理されました。アプリはもう待機していません。",
+    "zh-Hans": "所有暂停的请求都已处理，应用不再等待。",
+    "zh-Hant": "所有暫停的請求都已處理，應用程式不再等待。",
+    "ko": "보류된 요청이 모두 처리되었습니다. 앱은 더 이상 기다리지 않습니다.",
+    "ru": "Все удержанные запросы обработаны. Приложение больше не ждёт.",
+    "ar": "تمت معالجة كل طلب محتجز. لم يعد التطبيق ينتظر."
   }
 }

--- a/Scripts/localization/strings/NetworkLogger.json
+++ b/Scripts/localization/strings/NetworkLogger.json
@@ -674,21 +674,6 @@
     "ru": "Экспорт сетевого журнала",
     "ar": "تصدير سجل الشبكة"
   },
-  "Close": {
-    "comment": "Accessibility label of the button that dismisses the export sheet",
-    "fr": "Fermer",
-    "de": "Schließen",
-    "es": "Cerrar",
-    "it": "Chiudi",
-    "pt-BR": "Fechar",
-    "nl": "Sluiten",
-    "ja": "閉じる",
-    "zh-Hans": "关闭",
-    "zh-Hant": "關閉",
-    "ko": "닫기",
-    "ru": "Закрыть",
-    "ar": "إغلاق"
-  },
   "Export Sensitive Data?": {
     "comment": "Title of the alert shown before sharing the archive",
     "fr": "Exporter des données sensibles ?",

--- a/Scripts/localization/strings/Shared.json
+++ b/Scripts/localization/strings/Shared.json
@@ -88,5 +88,20 @@
     "ko": "%lld번째 / 전체 %lld개",
     "ru": "%lld из %lld",
     "ar": "%lld من %lld"
+  },
+  "Close": {
+    "comment": "Accessibility label of the button that closes a screen without deciding anything",
+    "fr": "Fermer",
+    "de": "Schließen",
+    "es": "Cerrar",
+    "it": "Chiudi",
+    "pt-BR": "Fechar",
+    "nl": "Sluiten",
+    "ja": "閉じる",
+    "zh-Hans": "关闭",
+    "zh-Hant": "關閉",
+    "ko": "닫기",
+    "ru": "Закрыть",
+    "ar": "إغلاق"
   }
 }

--- a/Scyther.podspec
+++ b/Scyther.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Scyther'
-  s.version          = '4.1.0'
+  s.version          = '4.1.1'
   s.summary          = 'Just like scyther, this menu helps you cut through bugs in your iOS app.'
 
   s.homepage         = 'https://github.com/bstillitano/Scyther'

--- a/Sources/Scyther/Features/NetworkBreakpoints/BreakpointEditorView.swift
+++ b/Sources/Scyther/Features/NetworkBreakpoints/BreakpointEditorView.swift
@@ -40,6 +40,20 @@ struct BreakpointEditorView: View {
         self.showsCancel = showsCancel
     }
 
+    /// Creates the editor on a breakpoint that does not exist yet but is already filled in — the
+    /// one **Break on requests like this** builds from a log entry.
+    ///
+    /// Saving *adds* it, unlike ``init(breakpoint:store:showsCancel:)``, which updates a
+    /// breakpoint the store already holds.
+    ///
+    /// - Parameters:
+    ///   - breakpoint: The pre-filled breakpoint. Nothing is written until it is confirmed.
+    ///   - store: Where the breakpoint is written on save. Defaults to the shared store.
+    init(prefilled breakpoint: NetworkBreakpoint, store: BreakpointStore = .shared) {
+        _viewModel = StateObject(wrappedValue: BreakpointEditorViewModel(prefilled: breakpoint, store: store))
+        self.showsCancel = true
+    }
+
     var body: some View {
         List {
             Section {

--- a/Sources/Scyther/Features/NetworkBreakpoints/BreakpointEditorViewModel.swift
+++ b/Sources/Scyther/Features/NetworkBreakpoints/BreakpointEditorViewModel.swift
@@ -24,6 +24,7 @@ import Foundation
 ///
 /// ### Creating an Editor
 /// - ``init(breakpoint:store:)``
+/// - ``init(prefilled:store:)``
 ///
 /// ### The Breakpoint Being Edited
 /// - ``draft``
@@ -75,12 +76,38 @@ final class BreakpointEditorViewModel: ViewModel {
     /// - Parameters:
     ///   - breakpoint: The breakpoint to edit, or `nil` to create one.
     ///   - store: Where the breakpoint is written on save. Defaults to the shared store.
-    init(breakpoint: NetworkBreakpoint?, store: BreakpointStore = .shared) {
+    convenience init(breakpoint: NetworkBreakpoint?, store: BreakpointStore = .shared) {
+        self.init(draft: breakpoint ?? NetworkBreakpoint(name: "", match: NetworkRuleMatch()),
+                  isCreating: breakpoint == nil,
+                  store: store)
+    }
+
+    /// Creates an editor for a breakpoint that does not exist yet but is already filled in.
+    ///
+    /// Breaking on a captured request builds the whole breakpoint up front — name, methods, host
+    /// and path — and then opens the editor on it. That breakpoint carries an identifier the store
+    /// has never seen, so it must be *added* on ``save()``; routing it through
+    /// ``init(breakpoint:store:)`` would treat it as an edit and update nothing at all.
+    ///
+    /// - Parameters:
+    ///   - breakpoint: The pre-filled breakpoint. Nothing is written until ``save()`` is called.
+    ///   - store: Where the breakpoint is written on save. Defaults to the shared store.
+    convenience init(prefilled breakpoint: NetworkBreakpoint, store: BreakpointStore = .shared) {
+        self.init(draft: breakpoint, isCreating: true, store: store)
+    }
+
+    /// The designated initialiser both entry points funnel through.
+    ///
+    /// - Parameters:
+    ///   - draft: The breakpoint the form edits.
+    ///   - isCreating: Whether ``save()`` adds the breakpoint or updates one already in the store.
+    ///   - store: Where the breakpoint is written on save.
+    private init(draft: NetworkBreakpoint, isCreating: Bool, store: BreakpointStore) {
         self.store = store
-        self.isCreating = breakpoint == nil
-        self.draft = breakpoint ?? NetworkBreakpoint(name: "", match: NetworkRuleMatch())
-        if let host = breakpoint?.match.host { rememberedHostKind = host.kind }
-        if let path = breakpoint?.match.path { rememberedPathKind = path.kind }
+        self.isCreating = isCreating
+        self.draft = draft
+        if let host = draft.match.host { rememberedHostKind = host.kind }
+        if let path = draft.match.path { rememberedPathKind = path.kind }
         super.init()
     }
 

--- a/Sources/Scyther/Features/NetworkBreakpoints/BreakpointPresenter.swift
+++ b/Sources/Scyther/Features/NetworkBreakpoints/BreakpointPresenter.swift
@@ -48,6 +48,7 @@ import UIKit
 /// - ``applicationState``
 /// - ``presentEditor``
 /// - ``dismissEditor``
+/// - ``scheduleRetry``
 @MainActor
 internal final class BreakpointPresenter: ObservableObject {
     /// The presenter `Scyther.start()` wires up.
@@ -86,6 +87,17 @@ internal final class BreakpointPresenter: ObservableObject {
         $0.dismissFromKeyWindow(whenGone: $1)
     }
 
+    /// How a refused presentation is tried again. Replaced by a test.
+    ///
+    /// The app is paused while a presentation cannot be made, so a refusal cannot be the end of
+    /// it: the anchor is busy for a moment — a sheet dismissing, a screen still appearing — and
+    /// waiting for the *next* hold means this one sits invisible for the whole of its timeout.
+    var scheduleRetry: @MainActor (@escaping @MainActor () -> Void) -> Void = { work in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            MainActor.assumeIsolated { work() }
+        }
+    }
+
     /// The controller currently presented, or `nil` when nothing is on screen.
     ///
     /// Held strongly, and cleared only where this presenter knows the screen has gone:
@@ -101,6 +113,10 @@ internal final class BreakpointPresenter: ObservableObject {
 
     /// Whether a dismissal arrived while the editor was still appearing, and is owed.
     private var wantsDismissal: Bool = false
+
+    /// Whether a retry of a refused presentation is already booked, so a burst of holds books one
+    /// rather than one apiece.
+    private var isRetryScheduled: Bool = false
 
     /// Whether the dismissal animation is still running.
     ///
@@ -215,9 +231,26 @@ internal final class BreakpointPresenter: ObservableObject {
 
         isAppearing = true
         isPresenting = presentEditor(self) { [weak self] in self?.editorDidAppear() }
-        if !isPresenting {
-            isAppearing = false
-            wantsDismissal = false
+        guard !isPresenting else { return }
+
+        isAppearing = false
+        wantsDismissal = false
+        scheduleRetryIfNeeded()
+    }
+
+    /// Books another attempt at presenting, because something is held and nothing is showing it.
+    ///
+    /// A refusal is nearly always momentary — the anchor is a sheet on its way out, or a screen
+    /// on its way in — and the exchange behind it is an app sitting still. Retrying stops of its
+    /// own accord: the hold's timeout releases it, and an empty list books nothing.
+    private func scheduleRetryIfNeeded() {
+        guard !isRetryScheduled, !pending.isEmpty else { return }
+
+        isRetryScheduled = true
+        scheduleRetry { [weak self] in
+            guard let self else { return }
+            self.isRetryScheduled = false
+            self.presentIfNeeded()
         }
     }
 
@@ -342,12 +375,12 @@ internal final class BreakpointPresenter: ObservableObject {
     /// - Returns: Whether the editor is now on screen.
     private func presentOverKeyWindow(whenAppeared: @escaping @MainActor () -> Void) -> Bool {
         guard let presenter = Scyther.topViewController else {
-            logMessage("Breakpoint editor could not be presented: no key window to anchor to. It will be offered again the next time an exchange is held.")
+            logMessage("Breakpoint editor could not be presented: no key window to anchor to. It will be tried again while the exchange is held.")
             return false
         }
 
         guard !presenter.isBeingDismissed, presenter.viewIfLoaded?.window != nil else {
-            logMessage("Breakpoint editor could not be presented: the anchor is on its way off screen. It will be offered again the next time an exchange is held.")
+            logMessage("Breakpoint editor could not be presented: the anchor is on its way off screen. It will be tried again while the exchange is held.")
             return false
         }
 
@@ -360,7 +393,7 @@ internal final class BreakpointPresenter: ObservableObject {
         }
 
         guard controller.presentingViewController != nil else {
-            logMessage("Breakpoint editor could not be presented: the anchor is already presenting something. It will be offered again the next time an exchange is held.")
+            logMessage("Breakpoint editor could not be presented: the anchor is already presenting something. It will be tried again while the exchange is held.")
             return false
         }
 

--- a/Sources/Scyther/Features/NetworkBreakpoints/BreakpointPresenter.swift
+++ b/Sources/Scyther/Features/NetworkBreakpoints/BreakpointPresenter.swift
@@ -125,9 +125,15 @@ internal final class BreakpointPresenter: ObservableObject {
         revalidatePresentation()
 
         guard !items.isEmpty else {
+            // Anything that suggests a screen is up is enough to ask for it to come down. The
+            // flag alone was not: it says only whether this presenter believes it presented, and
+            // when that belief and UIKit disagree what is left is a modal listing nothing, over
+            // an app waiting for nothing, with no way out — this screen offers no manual exit
+            // while something is held. Dismissing when nothing is up is harmless.
+            let wasHolding = !pending.isEmpty
             pending = []
-            if isPresenting {
-                isPresenting = false
+            isPresenting = false
+            if wasHolding || hasPresentedController {
                 dismissEditor(self)
             }
             return
@@ -196,6 +202,32 @@ internal final class BreakpointPresenter: ObservableObject {
     ///
     /// Does nothing when the editor was put up by an injected ``presentEditor``, which is what a
     /// test does: there is no hosting controller to ask.
+    /// Drops this presenter's belief that it presented, without touching what is on screen.
+    ///
+    /// Exists so a test can reproduce the one state that turns this screen into a dead end: a
+    /// controller UIKit is still showing that the presenter no longer counts as presented.
+    func forgetPresentationForTesting() {
+        isPresenting = false
+    }
+
+    /// Takes the screen down, whatever this presenter believed about it.
+    ///
+    /// The escape hatch behind the empty list's confirm button. Nothing is held, so there is
+    /// nothing to lose by closing, and a modal with no rows and no exit is worse than any state
+    /// this can leave behind.
+    func dismiss() {
+        isPresenting = false
+        dismissEditor(self)
+    }
+
+    /// Whether this presenter still has a controller it put on screen.
+    ///
+    /// The one question UIKit can answer honestly, and the only safe basis for deciding to
+    /// dismiss.
+    private var hasPresentedController: Bool {
+        hostingController != nil
+    }
+
     private func revalidatePresentation() {
         guard isPresenting, let controller = hostingController else { return }
         guard controller.presentingViewController == nil else { return }

--- a/Sources/Scyther/Features/NetworkBreakpoints/BreakpointPresenter.swift
+++ b/Sources/Scyther/Features/NetworkBreakpoints/BreakpointPresenter.swift
@@ -77,7 +77,14 @@ internal final class BreakpointPresenter: ObservableObject {
     }
 
     /// How the editor is taken off screen. Replaced by a test.
-    var dismissEditor: @MainActor (BreakpointPresenter) -> Void = { $0.dismissFromKeyWindow() }
+    ///
+    /// The closure it is handed is called once the editor has gone. Presenting over a controller
+    /// that is still on its way out is accepted by UIKit and then never appears: the exchange is
+    /// held behind a screen nobody can see, and the app waits out the whole timeout. So a hold
+    /// taken while the last screen is leaving waits for this instead.
+    var dismissEditor: @MainActor (BreakpointPresenter, @escaping @MainActor () -> Void) -> Void = {
+        $0.dismissFromKeyWindow(whenGone: $1)
+    }
 
     /// The controller currently presented, or `nil` when nothing is on screen.
     ///
@@ -94,6 +101,13 @@ internal final class BreakpointPresenter: ObservableObject {
 
     /// Whether a dismissal arrived while the editor was still appearing, and is owed.
     private var wantsDismissal: Bool = false
+
+    /// Whether the dismissal animation is still running.
+    ///
+    /// Nothing is presented while it is: UIKit accepts a presentation over a controller that is
+    /// leaving, and then shows nothing at all. Anything held meanwhile is put up by
+    /// ``editorDidDisappear()``.
+    private var isDismissing: Bool = false
 
     /// Whether the editor reached the screen and is still expected to be on it.
     ///
@@ -187,7 +201,18 @@ internal final class BreakpointPresenter: ObservableObject {
         // exchange the app is waiting on.
         wantsDismissal = false
 
-        guard !isPresenting else { return }
+        presentIfNeeded()
+    }
+
+    /// Puts the editor up, unless it is already up or the last one is still leaving.
+    ///
+    /// A presentation over a controller that is on its way out is accepted and then never appears.
+    /// What that leaves is the worst state this feature has: an exchange held behind a screen
+    /// nobody can see, and an app that waits for the whole of the timeout with no way to tell why.
+    /// ``editorDidDisappear()`` is where the wait ends.
+    private func presentIfNeeded() {
+        guard !isPresenting, !isDismissing, !pending.isEmpty else { return }
+
         isAppearing = true
         isPresenting = presentEditor(self) { [weak self] in self?.editorDidAppear() }
         if !isPresenting {
@@ -209,7 +234,8 @@ internal final class BreakpointPresenter: ObservableObject {
         }
 
         isPresenting = false
-        dismissEditor(self)
+        isDismissing = true
+        dismissEditor(self) { [weak self] in self?.editorDidDisappear() }
     }
 
     /// Called once the presentation animation has finished, paying whatever dismissal it held up.
@@ -218,6 +244,13 @@ internal final class BreakpointPresenter: ObservableObject {
         guard wantsDismissal else { return }
         wantsDismissal = false
         requestDismissal()
+    }
+
+    /// Called once the dismissal animation has finished, putting the editor back up if anything
+    /// was held while it was leaving.
+    private func editorDidDisappear() {
+        isDismissing = false
+        presentIfNeeded()
     }
 
     /// Lets go of everything still held, because the app has left the screen.
@@ -313,6 +346,11 @@ internal final class BreakpointPresenter: ObservableObject {
             return false
         }
 
+        guard !presenter.isBeingDismissed, presenter.viewIfLoaded?.window != nil else {
+            logMessage("Breakpoint editor could not be presented: the anchor is on its way off screen. It will be offered again the next time an exchange is held.")
+            return false
+        }
+
         let controller = UIHostingController(rootView: HeldRequestsView(presenter: self))
         controller.isModalInPresentation = true
         presenter.present(controller, animated: true) {
@@ -331,9 +369,20 @@ internal final class BreakpointPresenter: ObservableObject {
     }
 
     /// Dismisses the editor, if it is on screen.
-    private func dismissFromKeyWindow() {
-        guard let controller = hostingController else { return }
+    private func dismissFromKeyWindow(whenGone: @escaping @MainActor () -> Void) {
+        guard let controller = hostingController, controller.presentingViewController != nil else {
+            // Nothing to take down, so nothing to wait for. Reporting it gone straight away is
+            // what lets a hold taken in this state be presented rather than wait on an animation
+            // that is not running.
+            hostingController = nil
+            return whenGone()
+        }
+
         hostingController = nil
-        controller.dismiss(animated: true)
+        controller.dismiss(animated: true) {
+            // UIKit runs this on the main thread; the compiler cannot see that through an
+            // unisolated closure.
+            MainActor.assumeIsolated { whenGone() }
+        }
     }
 }

--- a/Sources/Scyther/Features/NetworkBreakpoints/BreakpointPresenter.swift
+++ b/Sources/Scyther/Features/NetworkBreakpoints/BreakpointPresenter.swift
@@ -66,13 +66,34 @@ internal final class BreakpointPresenter: ObservableObject {
     ///
     /// Returns whether the editor actually reached the screen. A presentation that did not happen
     /// must say so: believing one did leaves the app paused behind nothing at all.
-    var presentEditor: @MainActor (BreakpointPresenter) -> Bool = { $0.presentOverKeyWindow() }
+    ///
+    /// The closure it is handed is called once the editor has finished appearing. UIKit ignores a
+    /// dismissal asked for while a presentation is still animating, and the exchange that put the
+    /// screen up can be resolved inside that window — by a timeout, or by a developer who is
+    /// quick — which used to leave the screen up for good with nothing behind it. Knowing when the
+    /// animation ends is what lets that dismissal be held and run afterwards.
+    var presentEditor: @MainActor (BreakpointPresenter, @escaping @MainActor () -> Void) -> Bool = {
+        $0.presentOverKeyWindow(whenAppeared: $1)
+    }
 
     /// How the editor is taken off screen. Replaced by a test.
     var dismissEditor: @MainActor (BreakpointPresenter) -> Void = { $0.dismissFromKeyWindow() }
 
     /// The controller currently presented, or `nil` when nothing is on screen.
+    ///
+    /// Held strongly, and cleared only where this presenter knows the screen has gone:
+    /// ``revalidatePresentation()`` asks the controller itself whether it is still presented, and
+    /// a reference that had been let go could not be asked.
     private var hostingController: UIViewController?
+
+    /// Whether the presentation animation is still running.
+    ///
+    /// UIKit silently ignores a dismissal asked for during it, so a dismissal that arrives here is
+    /// remembered in ``wantsDismissal`` and run when the animation ends instead of being dropped.
+    private var isAppearing: Bool = false
+
+    /// Whether a dismissal arrived while the editor was still appearing, and is owed.
+    private var wantsDismissal: Bool = false
 
     /// Whether the editor reached the screen and is still expected to be on it.
     ///
@@ -132,9 +153,10 @@ internal final class BreakpointPresenter: ObservableObject {
             // while something is held. Dismissing when nothing is up is harmless.
             let wasHolding = !pending.isEmpty
             pending = []
-            isPresenting = false
             if wasHolding || hasPresentedController {
-                dismissEditor(self)
+                requestDismissal()
+            } else {
+                isPresenting = false
             }
             return
         }
@@ -159,8 +181,43 @@ internal final class BreakpointPresenter: ObservableObject {
         }
 
         pending = items
+
+        // Something is held again, so a dismissal owed from the moment the list emptied is owed no
+        // longer: running it once the animation ends would take the screen away from under an
+        // exchange the app is waiting on.
+        wantsDismissal = false
+
         guard !isPresenting else { return }
-        isPresenting = presentEditor(self)
+        isAppearing = true
+        isPresenting = presentEditor(self) { [weak self] in self?.editorDidAppear() }
+        if !isPresenting {
+            isAppearing = false
+            wantsDismissal = false
+        }
+    }
+
+    /// Takes the screen down, or remembers to once it has finished appearing.
+    ///
+    /// UIKit drops a dismissal asked for while the presentation is still animating, and says
+    /// nothing about having done so. The exchange that put the screen up can be resolved inside
+    /// that window — a short timeout, or a developer quicker than the animation — and the dropped
+    /// dismissal used to leave an empty modal over an app waiting for nothing, with no way out.
+    private func requestDismissal() {
+        guard !isAppearing else {
+            wantsDismissal = true
+            return
+        }
+
+        isPresenting = false
+        dismissEditor(self)
+    }
+
+    /// Called once the presentation animation has finished, paying whatever dismissal it held up.
+    private func editorDidAppear() {
+        isAppearing = false
+        guard wantsDismissal else { return }
+        wantsDismissal = false
+        requestDismissal()
     }
 
     /// Lets go of everything still held, because the app has left the screen.
@@ -212,12 +269,11 @@ internal final class BreakpointPresenter: ObservableObject {
 
     /// Takes the screen down, whatever this presenter believed about it.
     ///
-    /// The escape hatch behind the empty list's confirm button. Nothing is held, so there is
+    /// The escape hatch behind the empty list's close button. Nothing is held, so there is
     /// nothing to lose by closing, and a modal with no rows and no exit is worse than any state
     /// this can leave behind.
     func dismiss() {
-        isPresenting = false
-        dismissEditor(self)
+        requestDismissal()
     }
 
     /// Whether this presenter still has a controller it put on screen.
@@ -251,7 +307,7 @@ internal final class BreakpointPresenter: ObservableObject {
     /// does.
     ///
     /// - Returns: Whether the editor is now on screen.
-    private func presentOverKeyWindow() -> Bool {
+    private func presentOverKeyWindow(whenAppeared: @escaping @MainActor () -> Void) -> Bool {
         guard let presenter = Scyther.topViewController else {
             logMessage("Breakpoint editor could not be presented: no key window to anchor to. It will be offered again the next time an exchange is held.")
             return false
@@ -259,7 +315,11 @@ internal final class BreakpointPresenter: ObservableObject {
 
         let controller = UIHostingController(rootView: HeldRequestsView(presenter: self))
         controller.isModalInPresentation = true
-        presenter.present(controller, animated: true)
+        presenter.present(controller, animated: true) {
+            // UIKit runs this on the main thread; the compiler cannot see that through an
+            // unisolated closure.
+            MainActor.assumeIsolated { whenAppeared() }
+        }
 
         guard controller.presentingViewController != nil else {
             logMessage("Breakpoint editor could not be presented: the anchor is already presenting something. It will be offered again the next time an exchange is held.")
@@ -272,7 +332,8 @@ internal final class BreakpointPresenter: ObservableObject {
 
     /// Dismisses the editor, if it is on screen.
     private func dismissFromKeyWindow() {
-        hostingController?.dismiss(animated: true)
+        guard let controller = hostingController else { return }
         hostingController = nil
+        controller.dismiss(animated: true)
     }
 }

--- a/Sources/Scyther/Features/NetworkBreakpoints/HeldRequestsView.swift
+++ b/Sources/Scyther/Features/NetworkBreakpoints/HeldRequestsView.swift
@@ -14,9 +14,14 @@ import SwiftUI
 /// immediately; several are listed, so a burst of matching requests can be worked through in any
 /// order.
 ///
-/// There is no way to dismiss it by hand. Every held exchange has to be continued, aborted, or
-/// left to its timeout, and a sheet that could be swiped away while an app sat paused behind it
-/// would be a way to lose the request without deciding anything.
+/// While anything is held there is no way to dismiss it by hand. Every held exchange has to be
+/// continued, aborted, or left to its timeout, and a sheet that could be swiped away while an app
+/// sat paused behind it would be a way to lose the request without deciding anything.
+///
+/// Once nothing is held the opposite is true. The presenter takes the screen away on its own, but
+/// if it ever fails to — its controller and UIKit having disagreed about what is on screen — a
+/// modal listing nothing, over an app that is waiting for nothing, is a dead end. So an empty list
+/// says so and offers a way out.
 struct HeldRequestsView: View {
     /// The presenter holding the live list of paused exchanges.
     @ObservedObject var presenter: BreakpointPresenter
@@ -37,7 +42,21 @@ struct HeldRequestsView: View {
                     Text(localized("The app is waiting on these. Each one continues unchanged when its timeout runs out."))
                 }
             }
+            .overlay {
+                if presenter.pending.isEmpty {
+                    emptyState
+                }
+            }
             .navigationTitle(localized("Held Requests"))
+            .toolbar {
+                // Only ever offered with nothing held: closing while an exchange waits would lose
+                // it without a decision, which is the thing this screen exists to prevent.
+                if presenter.pending.isEmpty {
+                    ToolbarItem(placement: .confirmationAction) {
+                        ConfirmButton { presenter.dismiss() }
+                    }
+                }
+            }
             .navigationDestination(for: UUID.self) { id in
                 if let pause = presenter.pending.first(where: { $0.id == id }) {
                     HeldRequestEditorView(pending: pause, coordinator: presenter.coordinator)
@@ -52,6 +71,32 @@ struct HeldRequestsView: View {
         /// the developer is left on a blank screen with the app still paused behind it.
         .onChange(of: presenter.pending.map(\.id)) { _ in
             viewModel.pendingChanged(presenter.pending)
+        }
+    }
+
+    /// Shown when nothing is held, which should only ever be the moment before the presenter takes
+    /// the screen away.
+    @ViewBuilder
+    private var emptyState: some View {
+        if #available(iOS 17.0, *) {
+            ContentUnavailableView(
+                localized("Nothing Held"),
+                systemImage: "pause.circle",
+                description: Text(localized("Every held request has been decided. The app is no longer waiting."))
+            )
+        } else {
+            VStack(spacing: 16) {
+                Image(systemName: "pause.circle")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.secondary)
+                Text(localized("Nothing Held"))
+                    .font(.headline)
+                Text(localized("Every held request has been decided. The app is no longer waiting."))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding()
         }
     }
 

--- a/Sources/Scyther/Features/NetworkBreakpoints/HeldRequestsView.swift
+++ b/Sources/Scyther/Features/NetworkBreakpoints/HeldRequestsView.swift
@@ -26,6 +26,9 @@ struct HeldRequestsView: View {
     /// The presenter holding the live list of paused exchanges.
     @ObservedObject var presenter: BreakpointPresenter
 
+    /// Closes the presentation this view was put up in, whatever the presenter believes about it.
+    @Environment(\.dismiss) private var dismiss
+
     /// The screen's view model, owning the navigation path.
     @StateObject private var viewModel = HeldRequestsViewModel()
 
@@ -39,7 +42,11 @@ struct HeldRequestsView: View {
                         }
                     }
                 } footer: {
-                    Text(localized("The app is waiting on these. Each one continues unchanged when its timeout runs out."))
+                    // The footer describes the rows above it. With nothing held there are no rows,
+                    // and an app that is waiting on nothing should not be told it is waiting.
+                    if !presenter.pending.isEmpty {
+                        Text(localized("The app is waiting on these. Each one continues unchanged when its timeout runs out."))
+                    }
                 }
             }
             .overlay {
@@ -50,10 +57,18 @@ struct HeldRequestsView: View {
             .navigationTitle(localized("Held Requests"))
             .toolbar {
                 // Only ever offered with nothing held: closing while an exchange waits would lose
-                // it without a decision, which is the thing this screen exists to prevent.
+                // it without a decision, which is the thing this screen exists to prevent. A close
+                // rather than a confirm, because there is nothing left here to agree to — the
+                // decisions have all been made, and this only puts the screen away.
                 if presenter.pending.isEmpty {
-                    ToolbarItem(placement: .confirmationAction) {
-                        ConfirmButton { presenter.dismiss() }
+                    ToolbarItem(placement: .cancellationAction) {
+                        CloseButton {
+                            presenter.dismiss()
+                            // And again from the view's own side. This button exists for the case
+                            // where the presenter's idea of what is on screen has come apart from
+                            // UIKit's, so it cannot be the only way out.
+                            dismiss()
+                        }
                     }
                 }
             }

--- a/Sources/Scyther/Features/NetworkLogger/LogDetailsView.swift
+++ b/Sources/Scyther/Features/NetworkLogger/LogDetailsView.swift
@@ -22,6 +22,13 @@ struct LogDetailsView: View {
     /// Whether the replay editor is presented.
     @State private var isReplaying: Bool = false
 
+    /// The breakpoint **Break on requests like this** built from this capture, while its editor is
+    /// presented.
+    ///
+    /// Held as the sheet's item, like ``mockDraft``, so the breakpoint is built once when the
+    /// button is tapped rather than on every evaluation of the sheet's content.
+    @State private var breakpointDraft: NetworkBreakpoint?
+
     init(httpRequest: HTTPRequest) {
         self.httpRequest = httpRequest
         _viewModel = StateObject(wrappedValue: LogDetailsViewModel(httpRequest: httpRequest))
@@ -57,6 +64,11 @@ struct LogDetailsView: View {
         .sheet(isPresented: $isReplaying) {
             NavigationStack {
                 ReplayEditorView(capture: httpRequest)
+            }
+        }
+        .sheet(item: $breakpointDraft) { breakpoint in
+            NavigationStack {
+                BreakpointEditorView(prefilled: breakpoint, store: viewModel.breakpointStore)
             }
         }
     }
@@ -330,6 +342,12 @@ struct LogDetailsView: View {
             if viewModel.canReplay {
                 Button(localized("Replay this request")) {
                     isReplaying = true
+                }
+            }
+
+            if viewModel.canAddBreakpoint {
+                Button(localized("Break on requests like this")) {
+                    breakpointDraft = viewModel.makeBreakpoint()
                 }
             }
         }

--- a/Sources/Scyther/Features/NetworkLogger/LogDetailsViewModel.swift
+++ b/Sources/Scyther/Features/NetworkLogger/LogDetailsViewModel.swift
@@ -73,6 +73,11 @@ import SwiftUI
 /// - ``ruleStore``
 /// - ``makeMockRule()``
 ///
+/// ### Breakpoints
+/// - ``canAddBreakpoint``
+/// - ``breakpointStore``
+/// - ``makeBreakpoint()``
+///
 /// ### Replays
 /// - ``canReplay``
 /// - ``replayLinks``
@@ -110,6 +115,12 @@ class LogDetailsViewModel: ViewModel {
     /// Exposed so the view can hand the same store to the editor it presents; a test passes a
     /// throwaway one so saving a mock never touches the developer's real overrides.
     let ruleStore: NetworkRuleStore
+
+    /// The breakpoint store a breakpoint built from this capture is written to.
+    ///
+    /// Exposed for the same reason ``ruleStore`` is: the view hands it to the editor it presents,
+    /// and a test passes a throwaway one so nothing here touches the developer's real breakpoints.
+    let breakpointStore: BreakpointStore
 
     /// The formatted request URL.
     @Published var requestURL: String = ""
@@ -250,19 +261,35 @@ class LogDetailsViewModel: ViewModel {
         hasResponse && !wasStubbed
     }
 
+    /// Whether the "Break on requests like this" button is offered.
+    ///
+    /// Only a URL is needed: a breakpoint is built from the request, not the response, so an
+    /// exchange that failed or that an override answered can still name an endpoint worth
+    /// holding. That is the opposite of ``canSaveAsMock``, which needs a response off the wire to
+    /// copy — and deliberately so: seeing what the app *sent* to a stubbed endpoint is one of the
+    /// things a breakpoint is for.
+    var canAddBreakpoint: Bool {
+        !requestURL.isEmpty
+    }
+
     /// Creates a new log details view model.
     ///
     /// - Parameters:
     ///   - httpRequest: The HTTP request to display details for
     ///   - store: The override store a mock built from this capture is written to. Defaults to
     ///     the shared store; a test passes a throwaway one.
+    ///   - breakpointStore: The breakpoint store a breakpoint built from this capture is written
+    ///     to. Defaults to the shared store; a test passes a throwaway one.
     ///
     /// - Note: Isolated to the main actor because the default store is, and because the view that
     ///   builds this view model is itself main-actor isolated.
     @MainActor
-    init(httpRequest: HTTPRequest, store: NetworkRuleStore = .shared) {
+    init(httpRequest: HTTPRequest,
+         store: NetworkRuleStore = .shared,
+         breakpointStore: BreakpointStore = .shared) {
         self.httpRequest = httpRequest
         self.ruleStore = store
+        self.breakpointStore = breakpointStore
         super.init()
     }
 
@@ -452,18 +479,51 @@ class LogDetailsViewModel: ViewModel {
     /// - Returns: The pre-filled override, not yet added to ``ruleStore``. The response body
     ///   travels with the override rather than being written here, so abandoning the editor leaves
     ///   nothing on disk to reclaim.
+    /// Builds a breakpoint that holds requests like this one, ready for the editor.
+    ///
+    /// The matcher is the one ``makeMockRule()`` builds — captured method, host and path, with the
+    /// query left unconstrained — because a breakpoint matches with the same ``NetworkRuleMatch``
+    /// an override does, and two ways of turning one capture into a matcher would eventually
+    /// disagree.
+    ///
+    /// It arrives **enabled**, where a mock arrives disabled. Enabling a mock changes what the app
+    /// sees with nothing on screen to say so; a breakpoint announces itself by stopping the
+    /// request and putting a screen in front of the developer, which is the whole reason they
+    /// built it from this page. Nothing is written until the editor is confirmed either way.
+    ///
+    /// - Returns: The pre-filled breakpoint, not yet added to ``breakpointStore``.
     @MainActor
-    func makeMockRule() -> NetworkRule {
+    func makeBreakpoint() -> NetworkBreakpoint {
+        NetworkBreakpoint(name: captureName, match: capturedMatch)
+    }
+
+    /// The `METHOD /path` label both the mock and the breakpoint are named after.
+    private var captureName: String {
+        let components = httpRequest.requestURL.flatMap { URLComponents(string: $0) }
+        let method = (httpRequest.requestMethod ?? "GET").uppercased()
+        let path = (components?.percentEncodedPath).flatMap { $0.isEmpty ? nil : $0 } ?? "/"
+        return "\(method) \(path)" // scyther:unlocalised a method and a path, neither of them words
+    }
+
+    /// The matcher built from this capture: its method, host and path, exactly as they went out.
+    ///
+    /// The query is deliberately left unconstrained — pinning to the page number that happened to
+    /// be captured is almost never what was meant — and the path is taken percent-encoded, because
+    /// that is the form ``NetworkRuleMatch/matches(_:)`` compares against.
+    private var capturedMatch: NetworkRuleMatch {
         let components = httpRequest.requestURL.flatMap { URLComponents(string: $0) }
         let method = (httpRequest.requestMethod ?? "GET").uppercased()
         let path = (components?.percentEncodedPath).flatMap { $0.isEmpty ? nil : $0 } ?? "/"
 
-        let match = NetworkRuleMatch(
+        return NetworkRuleMatch(
             methods: [method],
             host: components?.host.map { NetworkRulePattern(kind: .exact, value: $0) },
             path: NetworkRulePattern(kind: .exact, value: path)
         )
+    }
 
+    @MainActor
+    func makeMockRule() -> NetworkRule {
         var headers: [String: String] = [:]
         for (key, value) in httpRequest.responseHeaders ?? [:] {
             guard let key = key as? String, let value = value as? String,
@@ -481,9 +541,9 @@ class LogDetailsViewModel: ViewModel {
         }
 
         return NetworkRule(
-            name: "\(method) \(path)",
+            name: captureName,
             isEnabled: false,
-            match: match,
+            match: capturedMatch,
             actions: NetworkRuleActions(stub: .mock(mock))
         )
     }

--- a/Sources/Scyther/Features/NetworkLogger/NetworkLogExportSheet.swift
+++ b/Sources/Scyther/Features/NetworkLogger/NetworkLogExportSheet.swift
@@ -44,13 +44,8 @@ struct NetworkLogExportSheet: View {
             .navigationTitle(localized("Export Network Log"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel(localized("Close"))
+                ToolbarItem(placement: .cancellationAction) {
+                    CloseButton { dismiss() }
                 }
             }
             .alert(localized("Export Sensitive Data?"), isPresented: $showingWarning) {

--- a/Sources/Scyther/Resources/Localizable.xcstrings
+++ b/Sources/Scyther/Resources/Localizable.xcstrings
@@ -9019,6 +9019,83 @@
         }
       }
     },
+    "Break on requests like this": {
+      "comment": "Button on a network log entry that creates a breakpoint matching requests like it",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "إيقاف الطلبات المشابهة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Bei ähnlichen Anfragen anhalten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Interrumpir solicitudes similares"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Interrompre les requêtes similaires"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Interrompi richieste simili"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "同様のリクエストで停止"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "유사한 요청에서 중단"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Onderbreek vergelijkbare verzoeken"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Interromper solicitações semelhantes"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Останавливать похожие запросы"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "在类似请求处中断"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "在類似請求處中斷"
+          }
+        }
+      }
+    },
     "Breakpoint": {
       "comment": "Row naming the breakpoint that is holding the exchange on screen",
       "localizations": {

--- a/Sources/Scyther/Resources/Localizable.xcstrings
+++ b/Sources/Scyther/Resources/Localizable.xcstrings
@@ -20820,6 +20820,83 @@
         }
       }
     },
+    "Every held request has been decided. The app is no longer waiting.": {
+      "comment": "Description of the empty state on the held requests screen",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "تمت معالجة كل طلب محتجز. لم يعد التطبيق ينتظر."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Jede angehaltene Anfrage wurde entschieden. Die App wartet nicht mehr."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Se ha resuelto cada solicitud retenida. La app ya no está esperando."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Chaque requête retenue a été traitée. L’application n’attend plus."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ogni richiesta in attesa è stata decisa. L’app non sta più aspettando."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "保留中のリクエストはすべて処理されました。アプリはもう待機していません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "보류된 요청이 모두 처리되었습니다. 앱은 더 이상 기다리지 않습니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Elk vastgehouden verzoek is afgehandeld. De app wacht niet meer."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Todas as requisições retidas foram decididas. O app não está mais esperando."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Все удержанные запросы обработаны. Приложение больше не ждёт."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "所有暂停的请求都已处理，应用不再等待。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "所有暫停的請求都已處理，應用程式不再等待。"
+          }
+        }
+      }
+    },
     "Exact": {
       "comment": "Pattern comparison that requires the whole value to be equal",
       "localizations": {
@@ -34542,6 +34619,83 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "未設定"
+          }
+        }
+      }
+    },
+    "Nothing Held": {
+      "comment": "Title of the empty state on the held requests screen, shown when every hold has been decided",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "لا شيء محتجز"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nichts angehalten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nada retenido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rien en attente"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nulla in attesa"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "保留なし"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "보류 없음"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Niets vastgehouden"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nada retido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ничего не удерживается"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "无暂停请求"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "無暫停請求"
           }
         }
       }

--- a/Sources/Scyther/Resources/Localizable.xcstrings
+++ b/Sources/Scyther/Resources/Localizable.xcstrings
@@ -11715,7 +11715,7 @@
       }
     },
     "Close": {
-      "comment": "Accessibility label of the button that dismisses the export sheet",
+      "comment": "Accessibility label of the button that closes a screen without deciding anything",
       "localizations": {
         "ar": {
           "stringUnit": {

--- a/Sources/Scyther/Scyther.docc/NetworkDebugging.md
+++ b/Sources/Scyther/Scyther.docc/NetworkDebugging.md
@@ -451,6 +451,20 @@ a timeout.
 The editor refuses an unnamed breakpoint and one whose match names no endpoint: a match that
 applies to everything would hold every request the app makes for the timeout each.
 
+### Breaking on a captured request
+
+The request details page carries a **Break on requests like this** button, beside **Save as mock**
+and **Replay this request**. It opens the editor pre-filled from the capture, on the same matcher
+a mock built from that page uses: the captured method, host and path exactly, with the query left
+unconstrained, holding the request stage for the default minute.
+
+It arrives enabled, where a mock arrives disabled. Enabling a mock changes what the app sees with
+nothing on screen to say so; a breakpoint announces itself by stopping the request and putting a
+screen in front of the developer. Nothing is written until the editor is confirmed either way.
+
+The button is offered wherever the entry has a URL, including one an override answered — seeing
+what the app sent to a stubbed endpoint is one of the things a breakpoint is for.
+
 ### When one fires
 
 The editor is presented over the key window. One held exchange opens straight into its page;

--- a/Sources/Scyther/Shared/Components/CloseButton.swift
+++ b/Sources/Scyther/Shared/Components/CloseButton.swift
@@ -1,0 +1,37 @@
+//
+//  CloseButton.swift
+//  Scyther
+//
+
+import SwiftUI
+
+/// The button that closes a screen without deciding anything.
+///
+/// The counterpart to ``ConfirmButton``, and deliberately not it: a tick says the developer is
+/// committing what is in front of them, and a screen with nothing left on it has nothing to
+/// commit. Uses the system close role and its system-provided label on iOS 26, which renders as
+/// the circular glass cross, and a cross in a bordered capsule on earlier releases.
+struct CloseButton: View {
+    /// Called when the button is tapped.
+    let action: () -> Void
+
+    /// Creates the button.
+    ///
+    /// - Parameter action: Called when the button is tapped.
+    init(action: @escaping () -> Void) {
+        self.action = action
+    }
+
+    var body: some View {
+        if #available(iOS 26.0, *) {
+            Button(role: .close, action: action)
+        } else {
+            Button(action: action) {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.capsule)
+            .accessibilityLabel(localized("Close"))
+        }
+    }
+}

--- a/Tests/ScytherTests/Features/BreakpointPresenterTests.swift
+++ b/Tests/ScytherTests/Features/BreakpointPresenterTests.swift
@@ -94,6 +94,7 @@ final class BreakpointPresenterTests: XCTestCase {
         let log: PresentationLog
         let appearances: Animations
         let dismissals: Animations
+        let retries: Animations
     }
 
     /// Builds and starts a presenter. Static, so nothing about the test case is captured.
@@ -104,6 +105,11 @@ final class BreakpointPresenterTests: XCTestCase {
         let log = PresentationLog()
         let appearances = Animations()
         let dismissals = Animations()
+        // Retries are always held: a test that cares runs them by hand, and one that does not is
+        // spared a presenter that keeps trying in the background while it makes its assertions.
+        let retries = Animations()
+        retries.isDeferring = true
+        presenter.scheduleRetry = { work in retries.record(work) }
         presenter.presentEditor = { _, appeared in
             let didPresent = log.recordPresentation()
             if didPresent { appearances.record(appeared) }
@@ -120,7 +126,8 @@ final class BreakpointPresenterTests: XCTestCase {
             presenter: presenter,
             log: log,
             appearances: appearances,
-            dismissals: dismissals
+            dismissals: dismissals,
+            retries: retries
         )
     }
 
@@ -135,6 +142,7 @@ final class BreakpointPresenterTests: XCTestCase {
     private var log: PresentationLog { fixture.log }
     private var appearances: Animations { fixture.appearances }
     private var dismissals: Animations { fixture.dismissals }
+    private var retries: Animations { fixture.retries }
 
     /// Builds the fixture on the main actor, which is where XCTest runs a synchronous test body
     /// of a `@MainActor` suite. `makeFixture()` is static, so no part of the test case crosses
@@ -341,6 +349,37 @@ final class BreakpointPresenterTests: XCTestCase {
         XCTAssertTrue(waitUntil { self.log.presented == 2 },
                       "a refused presentation must be offered again rather than swallowed")
         XCTAssertTrue(firstRecorder.resolutions.isEmpty, "and the first exchange is still held")
+    }
+
+    /// A refusal is momentary — the anchor is a sheet on its way out, or a screen on its way in —
+    /// and the app is paused behind it. Waiting for the next hold meant a replayed request that
+    /// was held while its own editor was dismissing sat invisible for the whole of its timeout.
+    func testARefusedPresentationIsTriedAgainWhileTheExchangeIsHeld() {
+        log.willReport([false])
+
+        hold()
+        XCTAssertTrue(waitUntil { self.presenter.pending.count == 1 })
+        XCTAssertEqual(log.presented, 1, "it was tried")
+
+        retries.finish()
+
+        XCTAssertEqual(log.presented, 2, "and tried again, without waiting for another hold")
+    }
+
+    /// Nothing is booked once the exchange has gone: the retry is for a paused app, and an app
+    /// that is not paused has nothing to show.
+    func testNoRetryIsBookedOnceNothingIsHeld() throws {
+        log.willReport([false])
+
+        hold()
+        XCTAssertTrue(waitUntil { self.presenter.pending.count == 1 })
+        let id = try XCTUnwrap(presenter.pending.first?.id)
+        coordinator.resolve(id: id, with: .timedOut)
+        XCTAssertTrue(waitUntil { self.presenter.pending.isEmpty })
+
+        retries.finish()
+
+        XCTAssertEqual(log.presented, 1, "there is nothing left to present")
     }
 
     /// Once one succeeds, the editor is on screen and further holds join it.

--- a/Tests/ScytherTests/Features/BreakpointPresenterTests.swift
+++ b/Tests/ScytherTests/Features/BreakpointPresenterTests.swift
@@ -57,6 +57,33 @@ final class BreakpointPresenterTests: XCTestCase {
         func recordDismissal() { lock.withLock { dismissals += 1 } }
     }
 
+    /// Holds the "the editor has finished appearing" callbacks, so a test can decide when — or
+    /// whether — the presentation animation ends.
+    ///
+    /// Main-actor isolated, like everything it stands in for: the presenter hands these callbacks
+    /// out and calls them back on the main actor, so no lock is needed here.
+    @MainActor
+    private final class Appearances {
+        /// Whether callbacks are held rather than run as they arrive. `false` presents instantly,
+        /// which is what every test that is not about the animation wants.
+        var isDeferring = false
+
+        private var held: [() -> Void] = []
+
+        /// Takes one presentation's callback.
+        func record(_ completion: @escaping () -> Void) {
+            guard isDeferring else { return completion() }
+            held.append(completion)
+        }
+
+        /// Ends every animation in flight.
+        func finish() {
+            let all = held
+            held = []
+            all.forEach { $0() }
+        }
+    }
+
     /// A started presenter over a coordinator of its own, with its UIKit hooks recorded.
     ///
     /// Sendable — every member is either lock-guarded or main-actor isolated — so it can be
@@ -65,6 +92,7 @@ final class BreakpointPresenterTests: XCTestCase {
         let coordinator: BreakpointCoordinator
         let presenter: BreakpointPresenter
         let log: PresentationLog
+        let appearances: Appearances
     }
 
     /// Builds and starts a presenter. Static, so nothing about the test case is captured.
@@ -73,11 +101,16 @@ final class BreakpointPresenterTests: XCTestCase {
         let coordinator = BreakpointCoordinator()
         let presenter = BreakpointPresenter(coordinator: coordinator)
         let log = PresentationLog()
-        presenter.presentEditor = { _ in log.recordPresentation() }
+        let appearances = Appearances()
+        presenter.presentEditor = { _, appeared in
+            let didPresent = log.recordPresentation()
+            if didPresent { appearances.record(appeared) }
+            return didPresent
+        }
         presenter.dismissEditor = { _ in log.recordDismissal() }
         presenter.applicationState = { .active }
         presenter.start()
-        return Fixture(coordinator: coordinator, presenter: presenter, log: log)
+        return Fixture(coordinator: coordinator, presenter: presenter, log: log, appearances: appearances)
     }
 
     /// Declared `nonisolated(unsafe)` because `setUp()` and `tearDown()` are inherited
@@ -89,6 +122,7 @@ final class BreakpointPresenterTests: XCTestCase {
     private var coordinator: BreakpointCoordinator { fixture.coordinator }
     private var presenter: BreakpointPresenter { fixture.presenter }
     private var log: PresentationLog { fixture.log }
+    private var appearances: Appearances { fixture.appearances }
 
     /// Builds the fixture on the main actor, which is where XCTest runs a synchronous test body
     /// of a `@MainActor` suite. `makeFixture()` is static, so no part of the test case crosses
@@ -167,7 +201,44 @@ final class BreakpointPresenterTests: XCTestCase {
         XCTAssertEqual(log.dismissed, 1, "the screen has to come down even when the flag says it is not up")
     }
 
-    /// The escape hatch behind the empty list's confirm button.
+    /// UIKit drops a dismissal asked for while the presentation is still animating, and says
+    /// nothing about having done so. A short timeout, or a developer quicker than the animation,
+    /// resolves the exchange inside that window — and the dropped dismissal left an empty modal
+    /// over an app waiting for nothing, with no way out, which is exactly what this screen must
+    /// never be.
+    func testADismissalAskedForWhileTheEditorIsAppearingHappensOnceItHas() throws {
+        appearances.isDeferring = true
+        hold()
+        XCTAssertTrue(waitUntil { self.presenter.pending.count == 1 })
+
+        let id = try XCTUnwrap(presenter.pending.first?.id)
+        coordinator.resolve(id: id, with: .timedOut)
+        XCTAssertTrue(waitUntil { self.presenter.pending.isEmpty })
+        XCTAssertEqual(log.dismissed, 0, "UIKit would ignore this one, so it is not asked for yet")
+
+        appearances.finish()
+
+        XCTAssertEqual(log.dismissed, 1, "it is owed, and paid once the animation ends")
+    }
+
+    /// Unless something is held again first, in which case the screen is wanted after all.
+    func testAnExchangeHeldWhileADismissalIsOwedKeepsTheScreenUp() throws {
+        appearances.isDeferring = true
+        hold(name: "cart")
+        XCTAssertTrue(waitUntil { self.presenter.pending.count == 1 })
+        let id = try XCTUnwrap(presenter.pending.first?.id)
+        coordinator.resolve(id: id, with: .timedOut)
+        XCTAssertTrue(waitUntil { self.presenter.pending.isEmpty })
+
+        hold(name: "checkout")
+        XCTAssertTrue(waitUntil { self.presenter.pending.count == 1 })
+        appearances.finish()
+
+        XCTAssertEqual(log.dismissed, 0, "the app is waiting on something again")
+        XCTAssertEqual(log.presented, 1, "and the screen it is waiting behind never left")
+    }
+
+    /// The escape hatch behind the empty list's close button.
     func testDismissingByHandTakesTheScreenDown() {
         hold()
         XCTAssertTrue(waitUntil { self.presenter.pending.count == 1 })

--- a/Tests/ScytherTests/Features/BreakpointPresenterTests.swift
+++ b/Tests/ScytherTests/Features/BreakpointPresenterTests.swift
@@ -57,20 +57,20 @@ final class BreakpointPresenterTests: XCTestCase {
         func recordDismissal() { lock.withLock { dismissals += 1 } }
     }
 
-    /// Holds the "the editor has finished appearing" callbacks, so a test can decide when — or
-    /// whether — the presentation animation ends.
+    /// Holds the "that animation has finished" callbacks, so a test can decide when — or whether —
+    /// a presentation or a dismissal completes.
     ///
     /// Main-actor isolated, like everything it stands in for: the presenter hands these callbacks
     /// out and calls them back on the main actor, so no lock is needed here.
     @MainActor
-    private final class Appearances {
-        /// Whether callbacks are held rather than run as they arrive. `false` presents instantly,
-        /// which is what every test that is not about the animation wants.
+    private final class Animations {
+        /// Whether callbacks are held rather than run as they arrive. `false` animates instantly,
+        /// which is what every test that is not about the animations wants.
         var isDeferring = false
 
         private var held: [() -> Void] = []
 
-        /// Takes one presentation's callback.
+        /// Takes one animation's callback.
         func record(_ completion: @escaping () -> Void) {
             guard isDeferring else { return completion() }
             held.append(completion)
@@ -92,7 +92,8 @@ final class BreakpointPresenterTests: XCTestCase {
         let coordinator: BreakpointCoordinator
         let presenter: BreakpointPresenter
         let log: PresentationLog
-        let appearances: Appearances
+        let appearances: Animations
+        let dismissals: Animations
     }
 
     /// Builds and starts a presenter. Static, so nothing about the test case is captured.
@@ -101,16 +102,26 @@ final class BreakpointPresenterTests: XCTestCase {
         let coordinator = BreakpointCoordinator()
         let presenter = BreakpointPresenter(coordinator: coordinator)
         let log = PresentationLog()
-        let appearances = Appearances()
+        let appearances = Animations()
+        let dismissals = Animations()
         presenter.presentEditor = { _, appeared in
             let didPresent = log.recordPresentation()
             if didPresent { appearances.record(appeared) }
             return didPresent
         }
-        presenter.dismissEditor = { _ in log.recordDismissal() }
+        presenter.dismissEditor = { _, gone in
+            log.recordDismissal()
+            dismissals.record(gone)
+        }
         presenter.applicationState = { .active }
         presenter.start()
-        return Fixture(coordinator: coordinator, presenter: presenter, log: log, appearances: appearances)
+        return Fixture(
+            coordinator: coordinator,
+            presenter: presenter,
+            log: log,
+            appearances: appearances,
+            dismissals: dismissals
+        )
     }
 
     /// Declared `nonisolated(unsafe)` because `setUp()` and `tearDown()` are inherited
@@ -122,7 +133,8 @@ final class BreakpointPresenterTests: XCTestCase {
     private var coordinator: BreakpointCoordinator { fixture.coordinator }
     private var presenter: BreakpointPresenter { fixture.presenter }
     private var log: PresentationLog { fixture.log }
-    private var appearances: Appearances { fixture.appearances }
+    private var appearances: Animations { fixture.appearances }
+    private var dismissals: Animations { fixture.dismissals }
 
     /// Builds the fixture on the main actor, which is where XCTest runs a synchronous test body
     /// of a `@MainActor` suite. `makeFixture()` is static, so no part of the test case crosses
@@ -236,6 +248,27 @@ final class BreakpointPresenterTests: XCTestCase {
 
         XCTAssertEqual(log.dismissed, 0, "the app is waiting on something again")
         XCTAssertEqual(log.presented, 1, "and the screen it is waiting behind never left")
+    }
+
+    /// UIKit accepts a presentation over a controller that is still leaving, and then shows
+    /// nothing at all. An exchange held in that moment — the developer continues one request and
+    /// makes the next straight away — sat behind a screen nobody could see while the app waited
+    /// out the whole timeout.
+    func testAnExchangeHeldWhileTheScreenIsLeavingIsShownOnceItHasGone() throws {
+        dismissals.isDeferring = true
+        hold(name: "cart")
+        XCTAssertTrue(waitUntil { self.presenter.pending.count == 1 })
+        let id = try XCTUnwrap(presenter.pending.first?.id)
+        coordinator.resolve(id: id, with: .timedOut)
+        XCTAssertTrue(waitUntil { self.log.dismissed == 1 })
+
+        hold(name: "checkout")
+        XCTAssertTrue(waitUntil { self.presenter.pending.count == 1 })
+        XCTAssertEqual(log.presented, 1, "nothing is presented over a screen that is on its way out")
+
+        dismissals.finish()
+
+        XCTAssertEqual(log.presented, 2, "and the wait ends when it has gone")
     }
 
     /// The escape hatch behind the empty list's close button.

--- a/Tests/ScytherTests/Features/BreakpointPresenterTests.swift
+++ b/Tests/ScytherTests/Features/BreakpointPresenterTests.swift
@@ -150,6 +150,33 @@ final class BreakpointPresenterTests: XCTestCase {
         XCTAssertEqual(log.dismissed, 1)
     }
 
+    /// The screen has no manual exit while anything is held, so if the presenter's belief about
+    /// what is on screen ever diverges from UIKit's, an empty modal over an app that is waiting
+    /// for nothing is a dead end. Dismissal therefore keys on there being a controller, not on
+    /// the flag.
+    func testTheEditorIsDismissedEvenIfThePresenterNoLongerBelievesItPresented() throws {
+        hold()
+        XCTAssertTrue(waitUntil { self.presenter.pending.count == 1 })
+
+        presenter.forgetPresentationForTesting()
+
+        let id = try XCTUnwrap(presenter.pending.first?.id)
+        coordinator.resolve(id: id, with: .timedOut)
+
+        XCTAssertTrue(waitUntil { self.presenter.pending.isEmpty })
+        XCTAssertEqual(log.dismissed, 1, "the screen has to come down even when the flag says it is not up")
+    }
+
+    /// The escape hatch behind the empty list's confirm button.
+    func testDismissingByHandTakesTheScreenDown() {
+        hold()
+        XCTAssertTrue(waitUntil { self.presenter.pending.count == 1 })
+
+        presenter.dismiss()
+
+        XCTAssertEqual(log.dismissed, 1)
+    }
+
     /// A held request the developer cannot see is indistinguishable from a hang, and the developer
     /// is by definition not looking at an app that is not on screen.
     func testAPauseTakenWhileBackgroundedIsSkippedAndResumedUnchanged() throws {

--- a/Tests/ScytherTests/Features/BreakpointsViewModelTests.swift
+++ b/Tests/ScytherTests/Features/BreakpointsViewModelTests.swift
@@ -171,6 +171,37 @@ final class BreakpointEditorViewModelTests: XCTestCase {
         XCTAssertEqual(store.breakpoints.first?.stage, .both)
     }
 
+    /// A breakpoint built from a log entry carries an identifier the store has never seen, so it
+    /// has to be *added*. Routing it through the editing initialiser would treat it as an edit and
+    /// update nothing at all.
+    func testSavingAPrefilledBreakpointAddsIt() {
+        let store = makeStore()
+        let prefilled = NetworkBreakpoint(name: "GET /v1/users", match: .path("/v1/users"))
+
+        let viewModel = BreakpointEditorViewModel(prefilled: prefilled, store: store)
+        XCTAssertEqual(viewModel.title, localized("New Breakpoint"))
+        XCTAssertTrue(viewModel.save())
+
+        XCTAssertEqual(store.breakpoints.map(\.name), ["GET /v1/users"])
+    }
+
+    /// Its fields arrive filled in, so the editor opens on the endpoint the log entry named rather
+    /// than on a blank form.
+    func testAPrefilledBreakpointOpensOnItsOwnMatch() {
+        let prefilled = NetworkBreakpoint(
+            name: "GET /v1/users",
+            match: NetworkRuleMatch(methods: ["GET"],
+                                    host: NetworkRulePattern(kind: .exact, value: "api.example.com"),
+                                    path: NetworkRulePattern(kind: .exact, value: "/v1/users"))
+        )
+
+        let viewModel = BreakpointEditorViewModel(prefilled: prefilled, store: makeStore())
+
+        XCTAssertEqual(viewModel.hostText, "api.example.com")
+        XCTAssertEqual(viewModel.pathText, "/v1/users")
+        XCTAssertTrue(viewModel.isValid)
+    }
+
     func testSavingAnEditedBreakpointUpdatesItInPlace() {
         let store = makeStore()
         let breakpoint = NetworkBreakpoint(name: "cart", match: .path("/v1/cart"))

--- a/Tests/ScytherTests/Features/LogDetailsViewModelTests.swift
+++ b/Tests/ScytherTests/Features/LogDetailsViewModelTests.swift
@@ -271,6 +271,59 @@ final class LogDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.canSaveAsMock)
     }
 
+    // MARK: - Building a breakpoint
+
+    /// The whole point of building one from the log is to catch the next request like it, so it
+    /// arrives switched on. Nothing is written until the editor is confirmed.
+    func testMakeBreakpointIsEnabledAndNamedAfterTheCapture() async throws {
+        let viewModel = LogDetailsViewModel(httpRequest: try makeCapture(), store: makeStore())
+        await viewModel.onFirstAppear()
+
+        let breakpoint = viewModel.makeBreakpoint()
+
+        XCTAssertTrue(breakpoint.isEnabled)
+        XCTAssertEqual(breakpoint.name, "GET /v1/users")
+        XCTAssertEqual(breakpoint.stage, .request)
+    }
+
+    /// The same matcher the mock builds, for the same reasons: the query is left unconstrained so
+    /// the breakpoint is not pinned to the page that happened to be captured.
+    func testMakeBreakpointMatchesTheCapturedMethodHostAndPath() async throws {
+        let capture = try makeCapture(url: "https://api.example.com/v1/users?page=2", method: "post")
+        let viewModel = LogDetailsViewModel(httpRequest: capture, store: makeStore())
+        await viewModel.onFirstAppear()
+
+        let match = viewModel.makeBreakpoint().match
+
+        XCTAssertEqual(match.methods, ["POST"])
+        XCTAssertEqual(match.host, NetworkRulePattern(kind: .exact, value: "api.example.com"))
+        XCTAssertEqual(match.path, NetworkRulePattern(kind: .exact, value: "/v1/users"))
+        XCTAssertTrue(match.query.isEmpty)
+    }
+
+    /// A capture with no URL has no endpoint to break on.
+    func testABreakpointIsNotOfferedWithoutAURL() async throws {
+        let request = try makeCapture()
+        request.requestURL = nil
+
+        let viewModel = LogDetailsViewModel(httpRequest: request, store: makeStore())
+        await viewModel.onFirstAppear()
+
+        XCTAssertFalse(viewModel.canAddBreakpoint)
+    }
+
+    /// Unlike the mock, a stubbed capture can still be broken on: the request is still made, and
+    /// holding it is how the developer sees what the app sent before an override answered it.
+    func testABreakpointIsOfferedForAStubbedCapture() async throws {
+        let request = try makeCapture()
+        request.wasStubbed = true
+
+        let viewModel = LogDetailsViewModel(httpRequest: request, store: makeStore())
+        await viewModel.onFirstAppear()
+
+        XCTAssertTrue(viewModel.canAddBreakpoint)
+    }
+
     // MARK: - Building the mock
 
     func testMakeMockRuleStartsDisabledAndNamedAfterTheCapture() async throws {


### PR DESCRIPTION
Five fixes to request breakpoints, all found on device, and one new affordance on the log.

## The held requests screen could be a dead end

Three separate races left the screen in a state with no way out, or held a request behind a screen nobody could see.

- **A dismissal asked for mid-animation was dropped.** UIKit ignores one while the presentation is still animating and says nothing about it, so an exchange resolved inside that window — a short timeout, or a decision quicker than the animation — left the screen up for good with nothing behind it. The presenter now learns when the presentation has finished appearing and pays whatever dismissal it held up, unless something is held again first.
- **A presentation over a controller that was still leaving was accepted and then showed nothing.** Continuing a held request and making the next one straight away left the app waiting out the whole 60-second timeout with no editor on screen and nothing logged, because nothing had been refused. Presentation now waits for the dismissal to complete, and anything held while the screen was leaving is put up then.
- **A refused presentation was dropped rather than retried.** Replaying a request a breakpoint matched did nothing at all: the hold arrived while the replay sheet was dismissing, the anchor was refused, and the exchange sat invisible until it timed out. Refusals are now retried while anything is held, and stop as soon as the list empties.

## The screen now says when it is empty, and offers a way out

An empty list gets a **Nothing Held** state and a close button — a cross, through a new shared `CloseButton` that uses the system close role on iOS 26. A confirm tick was wrong there: every decision has already been made and the button only puts the screen away. The export sheet's hand-rolled cross goes through the same component now. The list's footer no longer claims the app is waiting on requests that are not there.

## Break on requests like this

The request details page could turn a capture into a mock and could resend it, but catching the next request like it meant retyping its method, host and path by hand. A third button opens the breakpoint editor pre-filled from the capture, on the matcher the mock already builds — captured method, host and path, query left unconstrained — holding the request stage for the default minute. That matcher is built once and shared, so the two buttons cannot drift apart.

It arrives enabled, where a mock arrives disabled: enabling a mock changes what the app sees with nothing on screen to say so, while a breakpoint announces itself by stopping the request. It is offered wherever the entry has a URL, including one an override answered — seeing what the app sent to a stubbed endpoint is one of the things a breakpoint is for.

## Verification

Every fix was reproduced on device before it was written and confirmed after:

- three back-to-back hold → continue → immediate re-request cycles, all presented and completed;
- `Make Multiple Requests` — six simultaneous holds worked through one by one, screen dismissing itself at the end;
- a replay of a held request: two refusals retried, editor appeared, replay landed in the Replays section as `GET 200`;
- the new button on a log entry: editor opened pre-filled and the breakpoint was added alongside the existing one, not in place of it.

Each fix carries a regression test that was confirmed failing without it. Suite 1,262 → 1,273, zero failures. Bumps to 4.1.1.