### PR TITLE
Release 4.2.0

### DIFF
--- a/Scyther.podspec
+++ b/Scyther.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Scyther'
-  s.version          = '4.1.1'
+  s.version          = '4.2.0'
   s.summary          = 'Just like scyther, this menu helps you cut through bugs in your iOS app.'
 
   s.homepage         = 'https://github.com/bstillitano/Scyther'


### PR DESCRIPTION
The last release added **Break on requests like this** to the request details page. That is new behaviour, so it is a minor version, not the patch it was tagged as. 4.1.1 has been withdrawn — its tag and release are deleted — and this bumps the podspec to 4.2.0 for the same tree.