### PR TITLE
Make Right to Left a next-launch setting, and add Show Boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,31 +246,30 @@ Scyther's own menu and nothing else. That is a demonstration of the idea against
 SwiftUI interface, not a test of your screens. On a UIKit or `NSLocalizedString`-based app it is a
 test of your screens.
 
-**Right to Left is a different mechanism with a different shape.** It changes no text, so it does
-not care how your copy is loaded — but layout direction cannot be forced onto views that already
-exist, so the two halves run on two timescales:
+**Right to Left is a different mechanism, and it is a next-launch setting.** It changes no text, so
+it does not care how your copy is loaded — and nothing at all happens in the session where you flick
+the switch:
 
-| Surface | When it mirrors | Checked on a simulator |
+| Surface | When it mirrors | Checked on a device |
 | --- | --- | --- |
-| The Pseudo-localisation page | Immediately, as you flick the switch | yes |
-| The rest of the Scyther menu, and every page reached from it | Immediately | yes |
-| Your app's UIKit views | On its next launch | not yet |
-| Your app's SwiftUI views | On its next launch | not yet |
+| Your app's UIKit views | On its next launch | yes |
+| Your app's SwiftUI views | On its next launch | yes |
+| The Scyther menu and every page in it | On its next launch | yes |
 
-Switching it **off** unwinds in the same shape: Scyther's own interface immediately, your app on
-its next launch.
+Switching it **off** unwinds the same way: everything comes back left-to-right on the launch after
+you switch it off. Both directions were checked on a device — relaunched with the keys present, and
+relaunched with them absent.
 
-The third column is there because this mode's reach has been claimed wrongly more than once. The
-rows marked "not yet" rest on the mechanism below being the same one Xcode's scheme option uses;
-they have not been observed here.
+Because nothing takes effect until then, the toggle raises the same **Relaunch required** alert the
+Language page raises, with **Later** and **Quit App**. This is exactly how Xcode's own **Right to
+Left Pseudolanguage** scheme option behaves.
 
-The asymmetry is stated on the toggle itself, not only here: *"Mirrors Scyther's interface now, and
-your whole app — UIKit and SwiftUI — on its next launch. Switching it off restores your app on the
-launch after that."*
+Earlier versions mirrored Scyther's own menu the moment the switch moved. That is deliberately gone:
+anything that changed mid-session disagreed with something that had not, and UIKit answers a
+disagreement by mirroring text that has already been laid out — which draws it backwards, `Fonts` as
+`stnoF`. Waiting for a relaunch is the price of never seeing that.
 
-**How each half works.** Scyther's own interface mirrors immediately because Scyther installs
-`\.layoutDirection` itself, in its own views, and can therefore change it whenever it likes. Your
-app mirrors at launch because Scyther writes `AppleTextDirection` and
+**How it works.** Scyther writes `AppleTextDirection` and
 `NSForceRightToLeftWritingDirection` into your standard `UserDefaults` — the two keys Xcode's own
 **Right to Left Pseudolanguage** scheme option passes on the command line, which iOS resolves
 before any view exists and which reach UIKit and SwiftUI alike. It is the same move the Language
@@ -319,11 +318,12 @@ defect the developer will spend an afternoon chasing in their own code.
 - The **text** of the Pseudo-localisation page and its menu row is never transformed, so the modes
   can always be switched off — there is a **Turn Everything Off** button, and a **Sample** row that
   shows what the modes do on the one page where they do not apply. Right to Left flips this page
-  along with the rest of Scyther's interface; the text stays legible, which is what the exemption
-  is for.
-- Right to Left mirrors Scyther's own interface immediately and your whole app on its next launch,
-  in both directions; see the table above. It writes two keys into your app's standard
-  `UserDefaults` to do it, and removes them when switched off.
+  along with the rest of the app after a relaunch; the text stays legible, which is what the
+  exemption is for.
+- Right to Left applies on the next launch and nothing changes before then, in either direction;
+  see the table above. It writes two keys into your app's standard `UserDefaults` to do it, and
+  removes them when switched off. The toggle raises a **Relaunch required** alert so this is never
+  a surprise.
 
 #### Adding or correcting a translation
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ languages independently of the package's own catalog.
 ### Pseudo-localisation
 
 **UI/UX → Pseudo-localisation** renders the interface with copy that behaves like a translation
-without being one, to find layout problems before any translation exists. Four switches, all off
-by default and all combinable:
+without being one, to find layout problems before any translation exists. Four modes, all off by
+default and all combinable:
 
 | Mode | What it does | What it finds |
 | --- | --- | --- |
@@ -216,6 +216,12 @@ by default and all combinable:
 
 The brackets Lengthened adds are the point of it: a label missing its closing `]` was truncated,
 which is easier to see than judging whether accented text looks a few characters short.
+
+A fifth switch, **Show Boundaries**, decides whether those brackets are drawn, and it is the one
+switch that ships **on**. The padding dots already say a string grew; only the closing bracket says
+whether the end of it was cut off, which is the thing Lengthened exists to reveal — so the brackets
+stay by default, and the switch is there for when you want the expansion without the punctuation.
+It transforms nothing itself, so with every text mode off it does nothing at all.
 
 #### What it reaches, and what it does not
 
@@ -286,7 +292,9 @@ The rule Scyther holds itself to here is that it must never produce broken text 
 localisation problem. A mangled link or a plural that stops expanding is not a finding; it is a
 defect the developer will spend an afternoon chasing in their own code.
 
-- Off by default, persisted under `Scyther_pseudo_localization_*` in `UserDefaults.scyther`.
+- Off by default, persisted under `Scyther_pseudo_localization_*` in `UserDefaults.scyther`. Show
+  Boundaries is the one exception: it reads as on when nothing has been stored for it, so an
+  existing install behaves exactly as it did before the switch existed.
 - The swizzle is installed only while a text mode is on and removed when the last one is switched
   off. An app that never opens the page never has its string loading touched.
 - Only `Bundle.main` is transformed, so UIKit's own "Cancel" and "Done" are left alone — and

--- a/README.md
+++ b/README.md
@@ -256,6 +256,13 @@ That last row is the important one, and it is stated on the toggle itself, not o
 Scyther's interface now, and your app's UIKit views on its next launch. Your app's SwiftUI views are
 unaffected: Scyther cannot reach their environment."*
 
+Switching the mode **off** un-mirrors Scyther's own interface just as immediately, which took a fix:
+`UIView.appearance()` stamps its value onto each view as the view joins a window and never revisits
+it, so setting the proxy back cannot undo a view that already exists. Scyther therefore resets the
+views it owns — its menu, everything presented from it, and its overlays — directly. Your app's
+UIKit views are not touched either way; they un-mirror on the next launch, for the same reason they
+mirror on one.
+
 A SwiftUI view takes its direction from `\.layoutDirection` in **its own** environment, which your
 app owns. No public API lets a library modify another view tree's environment, and
 `UIView.appearance()` — which is what mirrors UIKit — does not seed it. Being early does not help
@@ -305,7 +312,9 @@ defect the developer will spend an afternoon chasing in their own code.
   and does flip this page along with everything else; the text stays legible, which is what the
   exemption is for.
 - Right to Left mirrors Scyther's own interface immediately and your app's UIKit views on its next
-  launch. It does not mirror your app's SwiftUI views at all; see the table above.
+  launch. It does not mirror your app's SwiftUI views at all; see the table above. Switching it off
+  is immediate for Scyther's own views too — Scyther resets the ones it owns rather than waiting for
+  the appearance proxy, which cannot undo a view it has already stamped.
 
 #### Adding or correcting a translation
 

--- a/README.md
+++ b/README.md
@@ -262,12 +262,15 @@ That last row is the important one, and it is stated on the toggle itself, not o
 Scyther's interface now, and your app's UIKit views on its next launch. Your app's SwiftUI views are
 unaffected: Scyther cannot reach their environment."*
 
-Switching the mode **off** un-mirrors Scyther's own interface just as immediately, which took a fix:
-`UIView.appearance()` stamps its value onto each view as the view joins a window and never revisits
-it, so setting the proxy back cannot undo a view that already exists. Scyther therefore resets the
-views it owns — its menu, everything presented from it, and its overlays — directly. Your app's
-UIKit views are not touched either way; they un-mirror on the next launch, for the same reason they
-mirror on one.
+Switching the mode **off** needed a fix of its own, because the appearance proxy cannot undo
+itself: it stamps its value onto each view as the view joins a window and never revisits it, so
+putting the proxy back leaves everything built while the mode was on still mirrored. Scyther takes
+that stamp back off its own UIKit chrome — the navigation container its menu is presented in, and
+the overlays it installs into your window — and writes nothing else. What SwiftUI draws is left to
+the environment value Scyther installs in its own views, which is what mirrors and un-mirrors the
+interface in both directions; forcing the UIKit attribute onto a hosting view instead makes it
+mirror the text it renders, which is unreadable rather than mirrored. Your app's UIKit views are
+untouched either way — they un-mirror on the next launch, for the same reason they mirror on one.
 
 A SwiftUI view takes its direction from `\.layoutDirection` in **its own** environment, which your
 app owns. No public API lets a library modify another view tree's environment, and
@@ -321,8 +324,8 @@ defect the developer will spend an afternoon chasing in their own code.
   exemption is for.
 - Right to Left mirrors Scyther's own interface immediately and your app's UIKit views on its next
   launch. It does not mirror your app's SwiftUI views at all; see the table above. Switching it off
-  is immediate for Scyther's own views too — Scyther resets the ones it owns rather than waiting for
-  the appearance proxy, which cannot undo a view it has already stamped.
+  is immediate for Scyther's own interface too: the environment value flips back, and Scyther
+  clears the appearance proxy's stamp from its own UIKit chrome, which the proxy cannot do itself.
 
 #### Adding or correcting a translation
 

--- a/README.md
+++ b/README.md
@@ -264,13 +264,14 @@ unaffected: Scyther cannot reach their environment."*
 
 Switching the mode **off** needed a fix of its own, because the appearance proxy cannot undo
 itself: it stamps its value onto each view as the view joins a window and never revisits it, so
-putting the proxy back leaves everything built while the mode was on still mirrored. Scyther takes
-that stamp back off its own UIKit chrome — the navigation container its menu is presented in, and
-the overlays it installs into your window — and writes nothing else. What SwiftUI draws is left to
-the environment value Scyther installs in its own views, which is what mirrors and un-mirrors the
-interface in both directions; forcing the UIKit attribute onto a hosting view instead makes it
-mirror the text it renders, which is unreadable rather than mirrored. Your app's UIKit views are
-untouched either way — they un-mirror on the next launch, for the same reason they mirror on one.
+putting the proxy back leaves everything built while the mode was on still forcing a direction the
+rest of the interface has left behind. Scyther takes that stamp back off its own views — its menu
+and everything inside it, and the overlays it installs into your window — and the only value it
+ever writes is `.unspecified`. It never forces a direction onto a view, in either direction:
+mirroring Scyther's interface is the environment value Scyther installs in its own views, and
+forcing the UIKit attribute as well makes a hosting view mirror the text it *renders*, which is
+unreadable rather than mirrored. Your app's UIKit views are untouched either way — they un-mirror
+on the next launch, for the same reason they mirror on one.
 
 A SwiftUI view takes its direction from `\.layoutDirection` in **its own** environment, which your
 app owns. No public API lets a library modify another view tree's environment, and
@@ -325,7 +326,7 @@ defect the developer will spend an afternoon chasing in their own code.
 - Right to Left mirrors Scyther's own interface immediately and your app's UIKit views on its next
   launch. It does not mirror your app's SwiftUI views at all; see the table above. Switching it off
   is immediate for Scyther's own interface too: the environment value flips back, and Scyther
-  clears the appearance proxy's stamp from its own UIKit chrome, which the proxy cannot do itself.
+  clears the appearance proxy's stamp from its own views, which the proxy cannot do itself.
 
 #### Adding or correcting a translation
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A comprehensive iOS debugging toolkit that helps you cut through bugs in your iO
 - **Font Browser**: View all available system fonts
 - **Interface Previews**: Browse registered UI components
 - **Language**: Force the app's language from the debug menu (applies on next launch; Scyther's own menu switches immediately)
-- **Pseudo-localisation**: Accent, lengthen, flip to RTL, or show catalog keys, to find layout problems before a translator is briefed — see [Pseudo-localisation](#pseudo-localisation) for exactly which strings it can and cannot reach
+- **Pseudo-localisation**: Accent, lengthen, flip to RTL, or show catalog keys, to find layout problems before a translator is briefed — see [Pseudo-localisation](#pseudo-localisation) for exactly which strings it can and cannot reach, and when RTL takes effect
 
 ### Development Tools
 - **Console Logger**: Capture and view stdout/stderr output
@@ -246,49 +246,46 @@ Scyther's own menu and nothing else. That is a demonstration of the idea against
 SwiftUI interface, not a test of your screens. On a UIKit or `NSLocalizedString`-based app it is a
 test of your screens.
 
-**Right to Left is a different mechanism with a different limit.** It changes no text, so it does
-not care how your copy is loaded — but layout direction is not something that can simply be forced
-onto views that already exist, and the honest account of what flips and when is:
+**Right to Left is a different mechanism with a different shape.** It changes no text, so it does
+not care how your copy is loaded — but layout direction cannot be forced onto views that already
+exist, so the two halves run on two timescales:
 
-| Surface | When it mirrors |
-| --- | --- |
-| The Pseudo-localisation page | Immediately, as you flick the switch |
-| The rest of the Scyther menu, and every page reached from it | Immediately |
-| Your app's UIKit views created after the switch | Immediately, as you navigate to them |
-| Your app's UIKit views generally | On the next launch |
-| **Your app's SwiftUI views** | **Never** |
+| Surface | When it mirrors | Checked on a simulator |
+| --- | --- | --- |
+| The Pseudo-localisation page | Immediately, as you flick the switch | yes |
+| The rest of the Scyther menu, and every page reached from it | Immediately | yes |
+| Your app's UIKit views | On its next launch | not yet |
+| Your app's SwiftUI views | On its next launch | not yet |
 
-That last row is the important one, and it is stated on the toggle itself, not only here: *"Mirrors
-Scyther's interface now, and your app's UIKit views on its next launch. Your app's SwiftUI views are
-unaffected: Scyther cannot reach their environment."*
+Switching it **off** unwinds in the same shape: Scyther's own interface immediately, your app on
+its next launch.
 
-Switching the mode **off** needed a fix of its own, because the appearance proxy cannot undo
-itself: it stamps its value onto each view as the view joins a window and never revisits it, so
-putting the proxy back leaves everything built while the mode was on still forcing a direction the
-rest of the interface has left behind. Scyther takes that stamp back off its own views — its menu
-and everything inside it, and the overlays it installs into your window — and the only value it
-ever writes is `.unspecified`. It never forces a direction onto a view, in either direction:
-mirroring Scyther's interface is the environment value Scyther installs in its own views, and
-forcing the UIKit attribute as well makes a hosting view mirror the text it *renders*, which is
-unreadable rather than mirrored. Your app's UIKit views are untouched either way — they un-mirror
-on the next launch, for the same reason they mirror on one.
+The third column is there because this mode's reach has been claimed wrongly more than once. The
+rows marked "not yet" rest on the mechanism below being the same one Xcode's scheme option uses;
+they have not been observed here.
 
-A SwiftUI view takes its direction from `\.layoutDirection` in **its own** environment, which your
-app owns. No public API lets a library modify another view tree's environment, and
-`UIView.appearance()` — which is what mirrors UIKit — does not seed it. Being early does not help
-either: setting the proxy before any view exists still leaves SwiftUI reading a value the proxy
-never touches. Scyther's own interface mirrors instantly only because Scyther installs that
-environment value itself, in its own views, and can therefore change it.
+The asymmetry is stated on the toggle itself, not only here: *"Mirrors Scyther's interface now, and
+your whole app — UIKit and SwiftUI — on its next launch. Switching it off restores your app on the
+launch after that."*
 
-There *is* a route to a SwiftUI host app, and it is deliberately not taken. Xcode's "Right to Left
-Pseudolanguage" scheme option works by launching with `-AppleTextDirection YES` and
-`-NSForceRightToLeftWritingDirection YES`, which are resolved at launch and do reach SwiftUI;
-Scyther could write those into your standard `UserDefaults` the same way the Language page already
-writes `AppleLanguages`. It is not built because it writes into your app's defaults domain for a
-second reason, relies on an undocumented defaults key rather than a launch argument, cannot be
-undone within the session that sets it — and cannot be verified by anything in this repository. If
-you want SwiftUI mirrored today, Xcode's scheme option does it properly: **Edit Scheme → Run →
-Options → App Language → Right to Left Pseudolanguage**.
+**How each half works.** Scyther's own interface mirrors immediately because Scyther installs
+`\.layoutDirection` itself, in its own views, and can therefore change it whenever it likes. Your
+app mirrors at launch because Scyther writes `AppleTextDirection` and
+`NSForceRightToLeftWritingDirection` into your standard `UserDefaults` — the two keys Xcode's own
+**Right to Left Pseudolanguage** scheme option passes on the command line, which iOS resolves
+before any view exists and which reach UIKit and SwiftUI alike. It is the same move the Language
+page already makes with `AppleLanguages`.
+
+Switching the mode off **removes** both keys rather than setting them false, so your app goes back
+to exactly the state it was in before Scyther was asked, on its next launch. Nothing is written on
+an App Store build, and a stale key from a TestFlight build is cleared rather than kept.
+
+An earlier version tried to mirror your app through `UIView.appearance()` instead. It is gone: the
+appearance proxy stamps a view once, as the view joins a window, and never revisits it, so
+switching the mode off could not undo the views it had already stamped — and a leftover stamp
+disagreeing with SwiftUI's own layout direction makes UIKit mirror text that has already been laid
+out, which renders it backwards (`Fonts` as `stnoF`). It also never reached a SwiftUI view at all.
+The defaults keys do what it was reaching for, at the only moment it can be done properly.
 
 #### Safety and limits
 
@@ -316,17 +313,17 @@ defect the developer will spend an afternoon chasing in their own code.
   addresses. `https://example.com` stays a working link rather than becoming
   `ĥţţþš://éẋåɱþļé.çöɱ`.
 - Nothing is installed on an App Store build or under XCTest. That guard sits on the swizzle and on
-  the layout override themselves, not only on their caller, and an App Store build honours no
-  persisted mode.
+  the defaults write themselves, not only on their caller, and an App Store build honours no
+  persisted mode. The one thing an App Store build still does is *remove* a right-to-left key left
+  behind by a TestFlight build, which is the safe direction to err in.
 - The **text** of the Pseudo-localisation page and its menu row is never transformed, so the modes
   can always be switched off — there is a **Turn Everything Off** button, and a **Sample** row that
-  shows what the modes do on the one page where they do not apply. Right to Left is process-wide
-  and does flip this page along with everything else; the text stays legible, which is what the
-  exemption is for.
-- Right to Left mirrors Scyther's own interface immediately and your app's UIKit views on its next
-  launch. It does not mirror your app's SwiftUI views at all; see the table above. Switching it off
-  is immediate for Scyther's own interface too: the environment value flips back, and Scyther
-  clears the appearance proxy's stamp from its own views, which the proxy cannot do itself.
+  shows what the modes do on the one page where they do not apply. Right to Left flips this page
+  along with the rest of Scyther's interface; the text stays legible, which is what the exemption
+  is for.
+- Right to Left mirrors Scyther's own interface immediately and your whole app on its next launch,
+  in both directions; see the table above. It writes two keys into your app's standard
+  `UserDefaults` to do it, and removes them when switched off.
 
 #### Adding or correcting a translation
 

--- a/Scripts/localization/strings/PseudoLocalization.json
+++ b/Scripts/localization/strings/PseudoLocalization.json
@@ -15,7 +15,7 @@
     "ar": "الترجمة الزائفة"
   },
   "Modes": {
-    "comment": "Section header above the four pseudo-localisation switches",
+    "comment": "Section header above the pseudo-localisation mode switches",
     "fr": "Modes",
     "de": "Modi",
     "es": "Modos",
@@ -268,5 +268,50 @@
     "ko": "Scyther 인터페이스는 지금, 앱의 UIKit 뷰는 다음 실행 시 좌우 반전됩니다. 앱의 SwiftUI 뷰는 영향을 받지 않습니다. Scyther가 그 environment에 접근할 수 없기 때문입니다.",
     "ru": "Отражает интерфейс Scyther сразу, а UIKit-представления вашего приложения — при следующем запуске. SwiftUI-представления не затрагиваются: Scyther не может добраться до их environment.",
     "ar": "يعكس واجهة Scyther الآن، ويعكس عروض UIKit في تطبيقك عند التشغيل التالي. أما عروض SwiftUI في تطبيقك فلا تتأثر: إذ لا يمكن لـ Scyther الوصول إلى بيئتها."
+  },
+  "Boundaries": {
+    "comment": "Section header above the switch that keeps the brackets around a lengthened string",
+    "fr": "Délimiteurs",
+    "de": "Begrenzungen",
+    "es": "Delimitadores",
+    "it": "Delimitatori",
+    "pt-BR": "Delimitadores",
+    "nl": "Begrenzingen",
+    "ja": "区切り",
+    "zh-Hans": "边界标记",
+    "zh-Hant": "邊界標記",
+    "ko": "경계",
+    "ru": "Границы",
+    "ar": "الحدود"
+  },
+  "Show Boundaries": {
+    "comment": "Switch label for keeping the brackets that mark where a transformed string starts and ends",
+    "fr": "Afficher les délimiteurs",
+    "de": "Begrenzungen anzeigen",
+    "es": "Mostrar delimitadores",
+    "it": "Mostra delimitatori",
+    "pt-BR": "Mostrar delimitadores",
+    "nl": "Begrenzingen tonen",
+    "ja": "区切りを表示",
+    "zh-Hans": "显示边界标记",
+    "zh-Hant": "顯示邊界標記",
+    "ko": "경계 표시",
+    "ru": "Показывать границы",
+    "ar": "إظهار الحدود"
+  },
+  "Marks where each string starts and ends, so you can see when one has been cut off. Only shows up when another text mode is on.": {
+    "comment": "Subtitle for the Show Boundaries switch",
+    "fr": "Marque le début et la fin de chaque chaîne, pour repérer celles qui sont tronquées. N’apparaît que si un autre mode de texte est activé.",
+    "de": "Markiert Anfang und Ende jeder Zeichenkette, damit sichtbar wird, wenn eine abgeschnitten wurde. Erscheint nur, wenn ein anderer Textmodus aktiv ist.",
+    "es": "Marca dónde empieza y termina cada cadena, para que veas cuándo se ha cortado alguna. Solo aparece cuando hay otro modo de texto activado.",
+    "it": "Segna dove inizia e finisce ogni stringa, così vedi quando ne viene troncata una. Compare solo quando è attiva un’altra modalità di testo.",
+    "pt-BR": "Marca onde cada texto começa e termina, para você ver quando algum foi cortado. Só aparece quando outro modo de texto está ativado.",
+    "nl": "Markeert waar elke tekst begint en eindigt, zodat je ziet wanneer er een is afgekapt. Verschijnt alleen als een andere tekstmodus aanstaat.",
+    "ja": "各文字列の始まりと終わりを示し、途中で切れているかどうかを確認できます。ほかのテキストモードがオンのときのみ表示されます。",
+    "zh-Hans": "标出每条字符串的开头和结尾，便于发现被截断的文本。仅在开启其他文本模式时显示。",
+    "zh-Hant": "標出每條字串的開頭和結尾，便於發現被截斷的文字。僅在開啟其他文字模式時顯示。",
+    "ko": "각 문자열의 시작과 끝을 표시해 잘린 문자열을 확인할 수 있습니다. 다른 텍스트 모드가 켜져 있을 때만 나타납니다.",
+    "ru": "Отмечает начало и конец каждой строки, чтобы было видно, когда строка обрезана. Появляется только при включённом другом текстовом режиме.",
+    "ar": "يحدّد بداية كل نص ونهايته، لتلاحظ ما إذا كان قد اقتُطع. لا يظهر إلا عند تفعيل وضع نصي آخر."
   }
 }

--- a/Scripts/localization/strings/PseudoLocalization.json
+++ b/Scripts/localization/strings/PseudoLocalization.json
@@ -254,20 +254,20 @@
     "ru": "Собственный интерфейс Scyther преобразуется всегда. В вашем приложении — только строки, загруженные через NSLocalizedString: String(localized:) и Text из SwiftUI Foundation разрешает, не проходя ни через один перехватываемый метод.",
     "ar": "تُحوَّل واجهة Scyther نفسها دائمًا. أما في تطبيقك فتُحوَّل السلاسل المحمّلة عبر NSLocalizedString فقط: إذ يحلّ Foundation كلًا من String(localized:) وText في SwiftUI دون المرور بأي دالة قابلة للاعتراض."
   },
-  "Mirrors Scyther's interface now, and your app's UIKit views on its next launch. Your app's SwiftUI views are unaffected: Scyther cannot reach their environment.": {
-    "comment": "Subtitle under the Right to Left switch, stating exactly which surfaces mirror and when",
-    "fr": "Met en miroir l’interface de Scyther maintenant, et les vues UIKit de votre app au prochain lancement. Les vues SwiftUI de votre app ne sont pas affectées : Scyther ne peut pas atteindre leur environnement.",
-    "de": "Spiegelt Scythers Oberfläche sofort und die UIKit-Views deiner App beim nächsten Start. Die SwiftUI-Views deiner App bleiben unberührt: Scyther kommt an ihre Environment nicht heran.",
-    "es": "Refleja la interfaz de Scyther ahora, y las vistas UIKit de tu app en el próximo arranque. Las vistas SwiftUI de tu app no se ven afectadas: Scyther no puede acceder a su entorno.",
-    "it": "Rispecchia subito l’interfaccia di Scyther, e le view UIKit della tua app al prossimo avvio. Le view SwiftUI della tua app non sono interessate: Scyther non può raggiungere il loro environment.",
-    "pt-BR": "Espelha a interface do Scyther agora, e as views UIKit do seu app na próxima abertura. As views SwiftUI do seu app não são afetadas: o Scyther não alcança o environment delas.",
-    "nl": "Spiegelt Scythers interface nu, en de UIKit-views van je app bij de volgende start. De SwiftUI-views van je app blijven ongemoeid: Scyther kan hun environment niet bereiken.",
-    "ja": "ScytherのUIは今すぐ、AppのUIKitビューは次回起動時にミラーリングされます。AppのSwiftUIビューは対象外です。Scytherはそのenvironmentに介入できません。",
-    "zh-Hans": "立即镜像 Scyther 界面，你的 App 的 UIKit 视图在下次启动时生效。你的 App 的 SwiftUI 视图不受影响：Scyther 无法访问它们的 environment。",
-    "zh-Hant": "立即鏡像 Scyther 介面，你的 App 的 UIKit 視圖於下次啟動時生效。你的 App 的 SwiftUI 視圖不受影響：Scyther 無法存取它們的 environment。",
-    "ko": "Scyther 인터페이스는 지금, 앱의 UIKit 뷰는 다음 실행 시 좌우 반전됩니다. 앱의 SwiftUI 뷰는 영향을 받지 않습니다. Scyther가 그 environment에 접근할 수 없기 때문입니다.",
-    "ru": "Отражает интерфейс Scyther сразу, а UIKit-представления вашего приложения — при следующем запуске. SwiftUI-представления не затрагиваются: Scyther не может добраться до их environment.",
-    "ar": "يعكس واجهة Scyther الآن، ويعكس عروض UIKit في تطبيقك عند التشغيل التالي. أما عروض SwiftUI في تطبيقك فلا تتأثر: إذ لا يمكن لـ Scyther الوصول إلى بيئتها."
+  "Mirrors Scyther's interface now, and your whole app — UIKit and SwiftUI — on its next launch. Switching it off restores your app on the launch after that.": {
+    "comment": "Subtitle for the Right to Left switch",
+    "fr": "Reflète l’interface de Scyther immédiatement, et toute votre app — UIKit comme SwiftUI — au prochain lancement. La désactiver rétablit votre app au lancement suivant.",
+    "de": "Spiegelt Scythers Oberfläche sofort und deine gesamte App – UIKit wie SwiftUI – beim nächsten Start. Ausschalten stellt deine App beim übernächsten Start wieder her.",
+    "es": "Refleja la interfaz de Scyther al instante y toda tu app —UIKit y SwiftUI— en el próximo inicio. Desactivarlo la restaura en el inicio siguiente.",
+    "it": "Riflette subito l’interfaccia di Scyther e tutta la tua app — UIKit e SwiftUI — al prossimo avvio. Disattivandolo, la tua app torna normale all’avvio successivo.",
+    "pt-BR": "Espelha a interface do Scyther na hora e todo o seu app — UIKit e SwiftUI — na próxima inicialização. Desativar restaura o app na inicialização seguinte.",
+    "nl": "Spiegelt Scythers interface meteen en je hele app — UIKit én SwiftUI — bij de volgende start. Uitzetten herstelt je app bij de start daarna.",
+    "ja": "Scyther のインターフェイスはすぐに、アプリ全体（UIKit と SwiftUI の両方）は次回起動時にミラーリングされます。オフにすると、その次の起動でアプリは元に戻ります。",
+    "zh-Hans": "立即镜像 Scyther 的界面，并在下次启动时镜像你的整个 App（UIKit 与 SwiftUI 均可）。关闭后，App 会在再下次启动时恢复。",
+    "zh-Hant": "立即鏡像 Scyther 的介面，並在下次啟動時鏡像你的整個 App（UIKit 與 SwiftUI 皆可）。關閉後，App 會在再下次啟動時恢復。",
+    "ko": "Scyther의 인터페이스는 즉시, 앱 전체(UIKit과 SwiftUI 모두)는 다음 실행 때 미러링됩니다. 끄면 그다음 실행에서 앱이 원래대로 돌아갑니다.",
+    "ru": "Зеркалит интерфейс Scyther сразу, а всё ваше приложение — и UIKit, и SwiftUI — при следующем запуске. Выключение возвращает приложение при следующем после этого запуске.",
+    "ar": "يعكس واجهة Scyther فورًا، وتطبيقك بالكامل — UIKit وSwiftUI معًا — عند التشغيل التالي. وإيقافه يعيد تطبيقك إلى حالته عند التشغيل الذي يليه."
   },
   "Boundaries": {
     "comment": "Section header above the switch that keeps the brackets around a lengthened string",

--- a/Scripts/localization/strings/PseudoLocalization.json
+++ b/Scripts/localization/strings/PseudoLocalization.json
@@ -254,20 +254,20 @@
     "ru": "Собственный интерфейс Scyther преобразуется всегда. В вашем приложении — только строки, загруженные через NSLocalizedString: String(localized:) и Text из SwiftUI Foundation разрешает, не проходя ни через один перехватываемый метод.",
     "ar": "تُحوَّل واجهة Scyther نفسها دائمًا. أما في تطبيقك فتُحوَّل السلاسل المحمّلة عبر NSLocalizedString فقط: إذ يحلّ Foundation كلًا من String(localized:) وText في SwiftUI دون المرور بأي دالة قابلة للاعتراض."
   },
-  "Mirrors Scyther's interface now, and your whole app — UIKit and SwiftUI — on its next launch. Switching it off restores your app on the launch after that.": {
+  "Mirrors the whole app on its next launch, to find hard-coded leading and trailing edges.": {
     "comment": "Subtitle for the Right to Left switch",
-    "fr": "Reflète l’interface de Scyther immédiatement, et toute votre app — UIKit comme SwiftUI — au prochain lancement. La désactiver rétablit votre app au lancement suivant.",
-    "de": "Spiegelt Scythers Oberfläche sofort und deine gesamte App – UIKit wie SwiftUI – beim nächsten Start. Ausschalten stellt deine App beim übernächsten Start wieder her.",
-    "es": "Refleja la interfaz de Scyther al instante y toda tu app —UIKit y SwiftUI— en el próximo inicio. Desactivarlo la restaura en el inicio siguiente.",
-    "it": "Riflette subito l’interfaccia di Scyther e tutta la tua app — UIKit e SwiftUI — al prossimo avvio. Disattivandolo, la tua app torna normale all’avvio successivo.",
-    "pt-BR": "Espelha a interface do Scyther na hora e todo o seu app — UIKit e SwiftUI — na próxima inicialização. Desativar restaura o app na inicialização seguinte.",
-    "nl": "Spiegelt Scythers interface meteen en je hele app — UIKit én SwiftUI — bij de volgende start. Uitzetten herstelt je app bij de start daarna.",
-    "ja": "Scyther のインターフェイスはすぐに、アプリ全体（UIKit と SwiftUI の両方）は次回起動時にミラーリングされます。オフにすると、その次の起動でアプリは元に戻ります。",
-    "zh-Hans": "立即镜像 Scyther 的界面，并在下次启动时镜像你的整个 App（UIKit 与 SwiftUI 均可）。关闭后，App 会在再下次启动时恢复。",
-    "zh-Hant": "立即鏡像 Scyther 的介面，並在下次啟動時鏡像你的整個 App（UIKit 與 SwiftUI 皆可）。關閉後，App 會在再下次啟動時恢復。",
-    "ko": "Scyther의 인터페이스는 즉시, 앱 전체(UIKit과 SwiftUI 모두)는 다음 실행 때 미러링됩니다. 끄면 그다음 실행에서 앱이 원래대로 돌아갑니다.",
-    "ru": "Зеркалит интерфейс Scyther сразу, а всё ваше приложение — и UIKit, и SwiftUI — при следующем запуске. Выключение возвращает приложение при следующем после этого запуске.",
-    "ar": "يعكس واجهة Scyther فورًا، وتطبيقك بالكامل — UIKit وSwiftUI معًا — عند التشغيل التالي. وإيقافه يعيد تطبيقك إلى حالته عند التشغيل الذي يليه."
+    "fr": "Reflète toute l’app au prochain lancement, pour repérer les bords gauche et droit codés en dur.",
+    "de": "Spiegelt die gesamte App beim nächsten Start, um fest verdrahtete linke und rechte Kanten zu finden.",
+    "es": "Refleja toda la app en el próximo inicio, para detectar bordes izquierdo y derecho fijados en el código.",
+    "it": "Riflette tutta l’app al prossimo avvio, per trovare bordi sinistro e destro scritti a mano.",
+    "pt-BR": "Espelha o app inteiro na próxima inicialização, para achar bordas esquerda e direita fixas no código.",
+    "nl": "Spiegelt de hele app bij de volgende start, om hardgecodeerde linker- en rechterranden te vinden.",
+    "ja": "次回起動時にアプリ全体をミラーリングし、左右の端を直書きしている箇所を見つけます。",
+    "zh-Hans": "在下次启动时镜像整个 App，用于发现硬编码的左右边距。",
+    "zh-Hant": "在下次啟動時鏡像整個 App，用於發現硬編碼的左右邊界。",
+    "ko": "다음 실행 때 앱 전체를 미러링해 하드코딩된 좌우 가장자리를 찾습니다.",
+    "ru": "Зеркалит всё приложение при следующем запуске, чтобы найти жёстко заданные левый и правый края.",
+    "ar": "يعكس التطبيق بالكامل عند التشغيل التالي، لاكتشاف الحواف اليمنى واليسرى المكتوبة بشكل ثابت."
   },
   "Boundaries": {
     "comment": "Section header above the switch that keeps the brackets around a lengthened string",
@@ -313,5 +313,20 @@
     "ko": "각 문자열의 시작과 끝을 표시해 잘린 문자열을 확인할 수 있습니다. 다른 텍스트 모드가 켜져 있을 때만 나타납니다.",
     "ru": "Отмечает начало и конец каждой строки, чтобы было видно, когда строка обрезана. Появляется только при включённом другом текстовом режиме.",
     "ar": "يحدّد بداية كل نص ونهايته، لتلاحظ ما إذا كان قد اقتُطع. لا يظهر إلا عند تفعيل وضع نصي آخر."
+  },
+  "Right to Left applies the next time the app launches — your app and Scyther's menu, UIKit and SwiftUI alike. Switching it off restores everything on the launch after that.": {
+    "comment": "Message in the Relaunch required alert raised by the Right to Left switch",
+    "fr": "Le mode Droite à gauche s’applique au prochain lancement de l’app — votre app comme le menu de Scyther, UIKit comme SwiftUI. Le désactiver rétablit tout au lancement suivant.",
+    "de": "Rechts-nach-links gilt ab dem nächsten Start der App – deine App wie auch Scythers Menü, UIKit wie SwiftUI. Ausschalten stellt beim übernächsten Start alles wieder her.",
+    "es": "De derecha a izquierda se aplica en el próximo inicio de la app: tu app y el menú de Scyther, tanto UIKit como SwiftUI. Desactivarlo lo restaura todo en el inicio siguiente.",
+    "it": "Da destra a sinistra si applica al prossimo avvio dell’app — la tua app e il menu di Scyther, sia UIKit sia SwiftUI. Disattivandolo, tutto torna normale all’avvio successivo.",
+    "pt-BR": "Da direita para a esquerda passa a valer na próxima inicialização do app — o seu app e o menu do Scyther, em UIKit e SwiftUI. Desativar restaura tudo na inicialização seguinte.",
+    "nl": "Rechts-naar-links geldt vanaf de volgende start van de app — je app én Scythers menu, UIKit én SwiftUI. Uitzetten herstelt alles bij de start daarna.",
+    "ja": "右から左は次回のアプリ起動時に適用されます。あなたのアプリも Scyther のメニューも、UIKit と SwiftUI の両方が対象です。オフにすると、その次の起動ですべて元に戻ります。",
+    "zh-Hans": "从右到左将在 App 下次启动时生效——你的 App 和 Scyther 菜单都包括在内，UIKit 与 SwiftUI 均可。关闭后，一切会在再下次启动时恢复。",
+    "zh-Hant": "從右到左將在 App 下次啟動時生效——你的 App 與 Scyther 選單都包括在內，UIKit 與 SwiftUI 皆可。關閉後，一切會在再下次啟動時恢復。",
+    "ko": "오른쪽에서 왼쪽 설정은 앱을 다음에 실행할 때 적용됩니다. 사용자의 앱과 Scyther 메뉴 모두, UIKit과 SwiftUI 모두에 적용됩니다. 끄면 그다음 실행에서 모두 원래대로 돌아갑니다.",
+    "ru": "Режим «справа налево» применится при следующем запуске приложения — и к вашему приложению, и к меню Scyther, в UIKit и SwiftUI. Выключение вернёт всё при следующем после этого запуске.",
+    "ar": "يُطبَّق وضع «من اليمين إلى اليسار» عند التشغيل التالي للتطبيق — تطبيقك وقائمة Scyther معًا، في UIKit وSwiftUI. وإيقافه يعيد كل شيء عند التشغيل الذي يليه."
   }
 }

--- a/Sources/Scyther/Core/ScytherPresentation.swift
+++ b/Sources/Scyther/Core/ScytherPresentation.swift
@@ -287,9 +287,16 @@ internal enum ScytherPresentation {
     /// add another level and none of this is hot code — it runs once per audit, over a chain that
     /// is nearly always empty.
     ///
+    /// - Note: Internal rather than private because ``PseudoLocalizationLayout`` needs the same
+    ///   answer for the same reason: when it resets the layout direction of Scyther's own views it
+    ///   has to recognise the whole of Scyther's menu, and the outermost view of that menu belongs
+    ///   to the stock `UINavigationController` rather than to the ``ScytherHostingController``
+    ///   inside it. A navigation bar left mirrored above an un-mirrored list is exactly the
+    ///   half-reset this containment search prevents.
+    ///
     /// - Parameter controller: The controller to inspect.
     /// - Returns: `true` when it or one of its descendants is Scyther's.
-    private static func containsScytherUI(_ controller: UIViewController) -> Bool {
+    internal static func containsScytherUI(_ controller: UIViewController) -> Bool {
         if controller is ScytherPresentedUI { return true }
         return controller.children.contains(where: containsScytherUI)
     }

--- a/Sources/Scyther/Core/ScytherPresentation.swift
+++ b/Sources/Scyther/Core/ScytherPresentation.swift
@@ -287,16 +287,9 @@ internal enum ScytherPresentation {
     /// add another level and none of this is hot code — it runs once per audit, over a chain that
     /// is nearly always empty.
     ///
-    /// - Note: Internal rather than private because ``PseudoLocalizationLayout`` needs the same
-    ///   answer for the same reason: when it resets the layout direction of Scyther's own views it
-    ///   has to recognise the whole of Scyther's menu, and the outermost view of that menu belongs
-    ///   to the stock `UINavigationController` rather than to the ``ScytherHostingController``
-    ///   inside it. A navigation bar left mirrored above an un-mirrored list is exactly the
-    ///   half-reset this containment search prevents.
-    ///
     /// - Parameter controller: The controller to inspect.
     /// - Returns: `true` when it or one of its descendants is Scyther's.
-    internal static func containsScytherUI(_ controller: UIViewController) -> Bool {
+    private static func containsScytherUI(_ controller: UIViewController) -> Bool {
         if controller is ScytherPresentedUI { return true }
         return controller.children.contains(where: containsScytherUI)
     }

--- a/Sources/Scyther/Features/AccessibilityAudit/AuditNode.swift
+++ b/Sources/Scyther/Features/AccessibilityAudit/AuditNode.swift
@@ -116,17 +116,10 @@ extension AuditNode {
 /// directly, and the `"Scyther"`-prefix fallback catches anything else Scyther draws without this
 /// file having to list every one of them and rot the moment a feature is added.
 ///
-/// - Note: Internal rather than private because it is the *definition* of "this object is
-///   Scyther's own", and a second definition is the thing to avoid.
-///   ``PseudoLocalizationLayout/isScytherOwned(_:)`` asks the same question when it walks down a
-///   window resetting the layout direction of Scyther's own views, and a rule that drifted between
-///   the two would mean the accessibility audit and the pseudo-localisation refresh disagreeing
-///   about which views belong to Scyther.
-///
 /// - Parameter object: The view, controller or element to test.
 /// - Returns: `true` when `object` is itself one of Scyther's own.
 @MainActor
-internal func isScytherOwnedType(_ object: AnyObject) -> Bool {
+private func isScytherOwnedType(_ object: AnyObject) -> Bool {
     object is ScytherPresentedUI
         || object is TopLevelViewsWrapper
         || object is TopLevelView

--- a/Sources/Scyther/Features/AccessibilityAudit/AuditNode.swift
+++ b/Sources/Scyther/Features/AccessibilityAudit/AuditNode.swift
@@ -116,10 +116,17 @@ extension AuditNode {
 /// directly, and the `"Scyther"`-prefix fallback catches anything else Scyther draws without this
 /// file having to list every one of them and rot the moment a feature is added.
 ///
+/// - Note: Internal rather than private because it is the *definition* of "this object is
+///   Scyther's own", and a second definition is the thing to avoid.
+///   ``PseudoLocalizationLayout/isScytherOwned(_:)`` asks the same question when it walks down a
+///   window resetting the layout direction of Scyther's own views, and a rule that drifted between
+///   the two would mean the accessibility audit and the pseudo-localisation refresh disagreeing
+///   about which views belong to Scyther.
+///
 /// - Parameter object: The view, controller or element to test.
 /// - Returns: `true` when `object` is itself one of Scyther's own.
 @MainActor
-private func isScytherOwnedType(_ object: AnyObject) -> Bool {
+internal func isScytherOwnedType(_ object: AnyObject) -> Bool {
     object is ScytherPresentedUI
         || object is TopLevelViewsWrapper
         || object is TopLevelView

--- a/Sources/Scyther/Features/Localization/LanguageOverride.swift
+++ b/Sources/Scyther/Features/Localization/LanguageOverride.swift
@@ -324,6 +324,23 @@ public final class LanguageOverride: ObservableObject, @unchecked Sendable {
     /// hit `persistentDomain(forName:)` once per comparison.
     public var namingLocale: Locale { resolutionLocale }
 
+    /// The direction to pin Scyther's own interface to, or `nil` to leave it as the process
+    /// resolved it.
+    ///
+    /// `nil` whenever no override is set, and that `nil` is load-bearing. Scyther's menu is a
+    /// SwiftUI tree hosted inside the host app, so it inherits `\.layoutDirection` from the
+    /// process — which is exactly what pseudo-localisation's Right to Left mode changes, through
+    /// the launch defaults `AppleTextDirection` and `NSForceRightToLeftWritingDirection`. Pinning
+    /// the direction unconditionally to the device language's direction overrode that forcing, so
+    /// on a relaunch with the mode on the host app mirrored and Scyther's menu, alone on screen,
+    /// did not. Only a language the developer actually chose gets to override the process.
+    ///
+    /// - SeeAlso: ``layoutDirection(forLanguage:)``, which decides the direction itself.
+    internal var menuLayoutDirection: LayoutDirection? {
+        guard effectiveLocale != nil else { return nil }
+        return Self.layoutDirection(forLanguage: namingLocale.identifier)
+    }
+
     /// The direction Scyther's own interface should be laid out in, for a given language.
     ///
     /// ``MenuView`` installs this as `\.layoutDirection` alongside the `\.locale` it installs

--- a/Sources/Scyther/Features/Localization/LanguageOverride.swift
+++ b/Sources/Scyther/Features/Localization/LanguageOverride.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import Foundation
+import SwiftUI
 
 /// Forces the host app's language and resolves Scyther's own strings in that language.
 ///
@@ -45,6 +46,7 @@ import Foundation
 /// - ``devicePreferredLanguages(systemDefaults:)``
 ///
 /// ### Display
+/// - ``layoutDirection(forLanguage:)``
 /// - ``namingLocale``
 /// - ``availableLanguages``
 /// - ``displayName(for:in:)``
@@ -321,6 +323,32 @@ public final class LanguageOverride: ObservableObject, @unchecked Sendable {
     /// also keeps this cheap — ``availableLanguages`` sorts through it, and recomputing it would
     /// hit `persistentDomain(forName:)` once per comparison.
     public var namingLocale: Locale { resolutionLocale }
+
+    /// The direction Scyther's own interface should be laid out in, for a given language.
+    ///
+    /// ``MenuView`` installs this as `\.layoutDirection` alongside the `\.locale` it installs
+    /// from ``namingLocale``, so an Arabic or Hebrew override lays Scyther's menu out right to
+    /// left in the same session it is chosen, rather than only after a relaunch. The menu's copy
+    /// switches language immediately, and a right-to-left language whose layout did not follow it
+    /// would be a half-translated screen of a different kind.
+    ///
+    /// Static and taking an identifier rather than reading ``namingLocale`` itself, so the mapping
+    /// can be tested without an override instance and asserted for languages this app may never
+    /// be run in.
+    ///
+    /// - Note: This used to take a second parameter, for pseudo-localisation's forced
+    ///   right-to-left mode, which won over the language whenever it was on. That mode no longer
+    ///   changes anything mid-session — see ``PseudoLocalizationLayout`` — so the language is once
+    ///   again the only input, and the parameter would have been dead weight.
+    ///
+    /// - Parameter identifier: A BCP 47 language identifier, typically
+    ///   `namingLocale.identifier`.
+    /// - Returns: The direction to install as `\.layoutDirection`.
+    internal static func layoutDirection(forLanguage identifier: String) -> LayoutDirection {
+        Locale.Language(identifier: identifier).characterDirection == .rightToLeft
+            ? .rightToLeft
+            : .leftToRight
+    }
 
     /// The localisations the host app declares, excluding `Base`, sorted by their name in
     /// ``namingLocale`` — so the list re-sorts to match whatever language is in effect.

--- a/Sources/Scyther/Features/Localization/LanguageViewModel.swift
+++ b/Sources/Scyther/Features/Localization/LanguageViewModel.swift
@@ -125,10 +125,4 @@ final class LanguageViewModel: ViewModel {
         override.reset()
     }
 
-    /// Terminates the process so the host app relaunches in the chosen language.
-    ///
-    /// Only called from the destructive action of the relaunch alert.
-    func quitApp() {
-        exit(0)
-    }
 }

--- a/Sources/Scyther/Features/Menu/MenuView.swift
+++ b/Sources/Scyther/Features/Menu/MenuView.swift
@@ -40,14 +40,6 @@ public struct MenuView: View {
     /// on the Language page rather than waiting for the next launch.
     @ObservedObject private var languageOverride = LanguageOverride.shared
 
-    /// Whether pseudo-localisation is currently forcing right-to-left layout.
-    ///
-    /// Held as state and refreshed from ``PseudoLocalization/ModesChangedNotification`` rather
-    /// than read inline, because the menu is on screen while the switch is flicked: SwiftUI has no
-    /// reason to re-evaluate this body unless something it observes changes, so an inline read
-    /// would go on returning the value from when the menu was opened.
-    @State private var forcesRightToLeft: Bool = PseudoLocalization.instance.rightToLeft
-
     public init() {}
 
     /// Whether the menu is showing search results instead of its sections.
@@ -85,12 +77,8 @@ public struct MenuView: View {
         .navigationTitle("Scyther") // scyther:unlocalised product name
         .interactiveDismissDisabled()
         .environment(\.locale, languageOverride.namingLocale)
-        .onReceive(NotificationCenter.default.publisher(for: PseudoLocalization.ModesChangedNotification)) { _ in
-            forcesRightToLeft = PseudoLocalization.instance.rightToLeft
-        }
-        .environment(\.layoutDirection, PseudoLocalizationLayout.layoutDirection(
-            forcingRightToLeft: forcesRightToLeft,
-            languageIdentifier: languageOverride.namingLocale.identifier
+        .environment(\.layoutDirection, LanguageOverride.layoutDirection(
+            forLanguage: languageOverride.namingLocale.identifier
         ))
     }
 

--- a/Sources/Scyther/Features/Menu/MenuView.swift
+++ b/Sources/Scyther/Features/Menu/MenuView.swift
@@ -77,9 +77,13 @@ public struct MenuView: View {
         .navigationTitle("Scyther") // scyther:unlocalised product name
         .interactiveDismissDisabled()
         .environment(\.locale, languageOverride.namingLocale)
-        .environment(\.layoutDirection, LanguageOverride.layoutDirection(
-            forLanguage: languageOverride.namingLocale.identifier
-        ))
+        .transformEnvironment(\.layoutDirection) { direction in
+            // Transformed rather than set, so that with no language override the menu inherits the
+            // process's own direction — which is what pseudo-localisation's Right to Left mode
+            // changes at launch. Setting it unconditionally mirrored the host app and left the
+            // menu unmirrored. See `LanguageOverride.menuLayoutDirection`.
+            if let overridden = languageOverride.menuLayoutDirection { direction = overridden }
+        }
     }
 
     /// The normal browsing content: device header, Pinned, and every menu section.

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalization.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalization.swift
@@ -17,8 +17,8 @@ import UIKit
 ///   plain ASCII was never localised.
 /// - ``lengthened`` pads strings to roughly 135%, the expansion German and Finnish bring, so
 ///   clipping and truncation appear before a translator's work does.
-/// - ``rightToLeft`` forces RTL layout in Scyther's own interface, which catches hard-coded
-///   leading/trailing assumptions in it.
+/// - ``rightToLeft`` forces RTL layout across the whole app from its next launch, which catches
+///   hard-coded leading/trailing assumptions.
 /// - ``showsKeys`` renders the catalog key instead of its translation.
 ///
 /// A fifth switch, ``showsBoundaries``, is a setting *about* those rather than a fifth peer of
@@ -43,10 +43,11 @@ import UIKit
 /// So on a UIKit or `NSLocalizedString`-based app the text modes apply broadly; on a SwiftUI app
 /// using `Text("…")` they apply to Scyther's own interface and nothing else.
 /// ``rightToLeft`` has a different shape rather than a different limit. It changes no text, so it
-/// does not care how the host loads its copy at all: Scyther's own interface mirrors immediately,
-/// in both directions, and the host app mirrors on its **next launch** — UIKit and SwiftUI alike,
-/// since the mechanism is the pair of defaults keys iOS resolves at launch rather than anything
-/// applied to a view. See ``PseudoLocalizationLayout``.
+/// does not care how the host loads its copy at all — and it is a **next-launch** setting on every
+/// surface, Scyther's own menu included, because the mechanism is a pair of defaults keys iOS
+/// resolves while the process starts rather than anything applied to a view. Nothing changes in the
+/// session where the switch moves, in either direction, which is why the toggle raises a relaunch
+/// alert. See ``PseudoLocalizationLayout``.
 ///
 /// ```swift
 /// PseudoLocalization.instance.accented = true
@@ -74,9 +75,6 @@ import UIKit
 /// - ``resolvedModes(stored:isAppStore:)``
 /// - ``canAffectHostApp(isTestCase:isAppStore:)``
 ///
-/// ### Notifications
-/// - ``ModesChangedNotification``
-///
 /// ### UserDefaults Keys
 /// - ``AccentedDefaultsKey``
 /// - ``LengthenedDefaultsKey``
@@ -86,21 +84,6 @@ import UIKit
 @MainActor
 internal final class PseudoLocalization: @unchecked Sendable {
     // MARK: - Static Data (nonisolated for cross-thread access)
-
-    /// Posted on the main actor whenever the switches change, so SwiftUI views that are already on
-    /// screen can re-render.
-    ///
-    /// Needed only by ``PseudoLocalizationMode/rightToLeft``, and only because SwiftUI takes its
-    /// layout direction from the environment: ``MenuView`` installs that value, and without a
-    /// signal it would go on installing the old one until something else happened to invalidate
-    /// it — which, for a menu the developer is looking at while flicking the switch, is never. The
-    /// text modes need nothing like this, because every string is re-resolved through
-    /// ``localized(_:comment:)`` on the next render anyway.
-    ///
-    /// A notification rather than `ObservableObject`, matching ``InterfaceToolkit``'s existing
-    /// change notifications, so this type stays a plain settings singleton readable from any
-    /// thread rather than acquiring a publisher and an isolation story to go with it.
-    nonisolated static let ModesChangedNotification = NSNotification.Name("Scyther.PseudoLocalization.ModesChanged")
 
     /// UserDefaults key for storing whether accented glyphs are substituted.
     nonisolated static let AccentedDefaultsKey: String = "Scyther_pseudo_localization_accented"
@@ -305,8 +288,8 @@ internal final class PseudoLocalization: @unchecked Sendable {
 
     // MARK: - Effects
 
-    /// Brings the host-app hook, the host app's launch-time layout direction, and the views
-    /// watching for a change, into line with the switches.
+    /// Brings the host-app hook and the host app's launch-time layout direction into line with the
+    /// switches.
     ///
     /// Called from every setter rather than from the settings screen so the effects can never
     /// drift from what is persisted — including on the path that matters most, ``reset()``, whose
@@ -322,7 +305,13 @@ internal final class PseudoLocalization: @unchecked Sendable {
     }
 
     /// Puts the host-app hook and the host app's forced layout direction into the state the
-    /// *current* settings call for, and tells the views on screen that the modes have moved.
+    /// *current* settings call for.
+    ///
+    /// Nothing is announced to views on screen any more, and nothing needs to be. This used to
+    /// post a notification so ``MenuView`` could re-install its layout direction the moment
+    /// right-to-left was switched — the last mid-session effect this feature had, and the source
+    /// of the corruption ``PseudoLocalizationLayout`` records. The text modes never needed it:
+    /// every string is re-resolved through ``localized(_:comment:)`` on the next render anyway.
     ///
     /// The mode set is read here, on the main actor, rather than snapshotted by ``synchronise()``
     /// before it hops. That is the whole point of the split. The hops are unstructured `Task`s and
@@ -353,7 +342,6 @@ internal final class PseudoLocalization: @unchecked Sendable {
             isTestCase: isTestCase,
             isAppStore: isAppStore
         )
-        NotificationCenter.default.post(name: Self.ModesChangedNotification, object: nil)
     }
 
     /// Re-applies the persisted state at launch, so a session picks up where the last one left off.

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalization.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalization.swift
@@ -17,7 +17,8 @@ import UIKit
 ///   plain ASCII was never localised.
 /// - ``lengthened`` pads strings to roughly 135%, the expansion German and Finnish bring, so
 ///   clipping and truncation appear before a translator's work does.
-/// - ``rightToLeft`` forces RTL layout, which catches hard-coded leading/trailing assumptions.
+/// - ``rightToLeft`` forces RTL layout in Scyther's own interface, which catches hard-coded
+///   leading/trailing assumptions in it.
 /// - ``showsKeys`` renders the catalog key instead of its translation.
 ///
 /// A fifth switch, ``showsBoundaries``, is a setting *about* those rather than a fifth peer of
@@ -41,10 +42,11 @@ import UIKit
 ///
 /// So on a UIKit or `NSLocalizedString`-based app the text modes apply broadly; on a SwiftUI app
 /// using `Text("…")` they apply to Scyther's own interface and nothing else.
-/// ``rightToLeft`` has a different limit rather than none. It changes no text, so it does not care
-/// how the host loads its copy — but it reaches Scyther's own interface immediately, the host app's
-/// *UIKit* views on the next launch, and the host app's *SwiftUI* views not at all. See
-/// ``PseudoLocalizationLayout`` for why, and for what an honest route to the third would cost.
+/// ``rightToLeft`` has a different shape rather than a different limit. It changes no text, so it
+/// does not care how the host loads its copy at all: Scyther's own interface mirrors immediately,
+/// in both directions, and the host app mirrors on its **next launch** — UIKit and SwiftUI alike,
+/// since the mechanism is the pair of defaults keys iOS resolves at launch rather than anything
+/// applied to a view. See ``PseudoLocalizationLayout``.
 ///
 /// ```swift
 /// PseudoLocalization.instance.accented = true
@@ -280,10 +282,14 @@ internal final class PseudoLocalization: @unchecked Sendable {
 
     /// Whether the effects that reach outside Scyther's own interface may be installed.
     ///
-    /// Both of them mutate global runtime state the host app shares — a swizzle on `NSBundle`, and
-    /// `UIView.appearance()` — so they carry a stricter guard than the string transform does.
-    /// Under XCTest there is no host app to pseudo-localise, and installing either would leak
-    /// across into unrelated tests in the same process.
+    /// Both of them mutate state the host app owns — a swizzle on `NSBundle`, and two keys in its
+    /// standard `UserDefaults` — so they carry a stricter guard than the string transform does.
+    /// Under XCTest there is no host app to pseudo-localise, and touching either would leak across
+    /// into unrelated tests in the same process.
+    ///
+    /// ``PseudoLocalizationLayout/applyToHostApp(rightToLeft:isTestCase:isAppStore:systemDefaults:)``
+    /// consults this before *setting* its keys and deliberately not before removing them; see there
+    /// for why an App Store build clearing a stale key is the safe direction to err in.
     ///
     /// A pure function of two booleans for the same reason ``AccessibilityAudit/canAuditKeyWindow(isTestCase:isAppStore:)``
     /// is: neither input can be faked in the test host, so the refusing branches are unreachable
@@ -299,22 +305,24 @@ internal final class PseudoLocalization: @unchecked Sendable {
 
     // MARK: - Effects
 
-    /// Brings the host-app hook and the forced layout direction into line with the switches.
+    /// Brings the host-app hook, the host app's launch-time layout direction, and the views
+    /// watching for a change, into line with the switches.
     ///
-    /// Called from every setter rather than from the settings screen so the two effects can never
+    /// Called from every setter rather than from the settings screen so the effects can never
     /// drift from what is persisted — including on the path that matters most, ``reset()``, whose
     /// whole job is to make an unreadable session readable again.
     ///
-    /// Hops to the main actor because both effects touch UIKit. The hop is why the setters can
-    /// stay `nonisolated`, which is what lets the toggles be driven from a `Binding` without the
-    /// view model having to await anything. It deliberately carries nothing across the hop; see
-    /// ``applyEffects(isTestCase:isAppStore:)`` for why that matters.
+    /// Hops to the main actor because installing the hook and posting to observing views both have
+    /// to happen there. The hop is why the setters can stay `nonisolated`, which is what lets the
+    /// toggles be driven from a `Binding` without the view model having to await anything. It
+    /// deliberately carries nothing across the hop; see ``applyEffects(isTestCase:isAppStore:)``
+    /// for why that matters.
     private nonisolated func synchronise() {
         Task { @MainActor in self.applyEffects() }
     }
 
-    /// Puts the host-app hook and the forced layout direction into the state the *current*
-    /// settings call for.
+    /// Puts the host-app hook and the host app's forced layout direction into the state the
+    /// *current* settings call for, and tells the views on screen that the modes have moved.
     ///
     /// The mode set is read here, on the main actor, rather than snapshotted by ``synchronise()``
     /// before it hops. That is the whole point of the split. The hops are unstructured `Task`s and
@@ -335,22 +343,25 @@ internal final class PseudoLocalization: @unchecked Sendable {
         isAppStore: Bool = AppEnvironment.isAppStore
     ) {
         let modes = activeModes
-        let allowed = Self.canAffectHostApp(isTestCase: isTestCase, isAppStore: isAppStore)
         PseudoLocalizationHostHook.shared.setEnabled(
             !modes.intersection(.textAffecting).isEmpty,
             isTestCase: isTestCase,
             isAppStore: isAppStore
         )
-        PseudoLocalizationLayout.apply(rightToLeft: modes.contains(.rightToLeft), allowed: allowed)
+        PseudoLocalizationLayout.applyToHostApp(
+            rightToLeft: modes.contains(.rightToLeft),
+            isTestCase: isTestCase,
+            isAppStore: isAppStore
+        )
         NotificationCenter.default.post(name: Self.ModesChangedNotification, object: nil)
     }
 
     /// Re-applies the persisted state at launch, so a session picks up where the last one left off.
     ///
-    /// Called from `Scyther.start(allowProductionBuilds:)`. Without it, a developer who left
-    /// right-to-left on would find it silently off after a relaunch, which is precisely when they
-    /// would be looking at it — several of the layout problems the mode exists to catch only
-    /// appear on a screen built from scratch.
+    /// Called from `Scyther.start(allowProductionBuilds:)`. Without it, a developer who left a text
+    /// mode on would find the host-app hook uninstalled after a relaunch while the switch still
+    /// read as on — the feature silently doing nothing, which is the failure that is hardest to
+    /// notice.
     internal static func setup() {
         instance.synchronise()
     }

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalization.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalization.swift
@@ -20,6 +20,10 @@ import UIKit
 /// - ``rightToLeft`` forces RTL layout, which catches hard-coded leading/trailing assumptions.
 /// - ``showsKeys`` renders the catalog key instead of its translation.
 ///
+/// A fifth switch, ``showsBoundaries``, is a setting *about* those rather than a fifth peer of
+/// them: it keeps the `[` and `]` around a lengthened string, transforms nothing on its own, and
+/// is the one switch that is **on** unless a developer has turned it off.
+///
 /// ## What this can and cannot reach
 ///
 /// Every string in Scyther's own interface goes through ``localized(_:comment:override:)``, so the
@@ -56,6 +60,7 @@ import UIKit
 /// - ``lengthened``
 /// - ``rightToLeft``
 /// - ``showsKeys``
+/// - ``showsBoundaries``
 /// - ``reset()``
 ///
 /// ### Effects
@@ -75,6 +80,7 @@ import UIKit
 /// - ``LengthenedDefaultsKey``
 /// - ``RightToLeftDefaultsKey``
 /// - ``ShowsKeysDefaultsKey``
+/// - ``ShowsBoundariesDefaultsKey``
 @MainActor
 internal final class PseudoLocalization: @unchecked Sendable {
     // MARK: - Static Data (nonisolated for cross-thread access)
@@ -106,7 +112,10 @@ internal final class PseudoLocalization: @unchecked Sendable {
     /// UserDefaults key for storing whether catalog keys are shown in place of translations.
     nonisolated static let ShowsKeysDefaultsKey: String = "Scyther_pseudo_localization_show_keys"
 
-    /// Where the four switches are persisted.
+    /// UserDefaults key for storing whether transformed strings keep their delimiters.
+    nonisolated static let ShowsBoundariesDefaultsKey: String = "Scyther_pseudo_localization_show_boundaries"
+
+    /// Where the switches are persisted.
     ///
     /// Injected rather than read from `UserDefaults.scyther` at each call site so a test can hand
     /// in a throwaway suite and assert on persistence without writing to — or having to clean up
@@ -179,16 +188,47 @@ internal final class PseudoLocalization: @unchecked Sendable {
         }
     }
 
+    /// Whether a lengthened string keeps the `[` and `]` marking where it starts and ends.
+    ///
+    /// The one switch here that reads as `true` with nothing stored, which is why it cannot use
+    /// `UserDefaults.bool(forKey:)` — that method answers absence with `false`, the opposite of
+    /// what is wanted for a setting that ships on. It is the same read
+    /// ``AccessibilityAudit/isEnabled(_:)`` does, for the same reason: an existing install where
+    /// nothing has been written must keep behaving exactly as it did before the switch existed.
+    ///
+    /// On rather than off because the brackets are the diagnostic. The padding dots already say a
+    /// string grew; only the closing bracket says whether the end of it was cut off, which is the
+    /// thing ``lengthened`` exists to reveal. The switch is for the developer who has seen enough
+    /// of them and wants the expansion without the punctuation.
+    ///
+    /// The value is persisted to `UserDefaults.scyther` and restored on app launch.
+    internal nonisolated var showsBoundaries: Bool {
+        get {
+            guard let stored = defaults.object(forKey: Self.ShowsBoundariesDefaultsKey) as? Bool else { return true }
+            return stored
+        }
+        set {
+            defaults.setValue(newValue, forKey: Self.ShowsBoundariesDefaultsKey)
+            synchronise()
+        }
+    }
+
     /// Switches every mode off and tears down the effects they installed.
     ///
     /// Exists as one call rather than four assignments so the settings screen's escape hatch — and
     /// anything recovering from a session left in an unreadable state — cannot half-succeed and
     /// leave, say, the host-app hook installed with no mode to justify it.
+    ///
+    /// ``showsBoundaries`` is restored to `true` rather than cleared to `false`, because "off" is
+    /// not its shipped state. This is the button that puts the page back the way it was found; a
+    /// developer who pressed it and then switched lengthening on again would otherwise get an
+    /// unbracketed sample and no reason to connect it to a button they pressed a minute ago.
     internal nonisolated func reset() {
         defaults.setValue(false, forKey: Self.AccentedDefaultsKey)
         defaults.setValue(false, forKey: Self.LengthenedDefaultsKey)
         defaults.setValue(false, forKey: Self.RightToLeftDefaultsKey)
         defaults.setValue(false, forKey: Self.ShowsKeysDefaultsKey)
+        defaults.setValue(true, forKey: Self.ShowsBoundariesDefaultsKey)
         synchronise()
     }
 
@@ -205,6 +245,7 @@ internal final class PseudoLocalization: @unchecked Sendable {
         if lengthened { modes.insert(.lengthened) }
         if rightToLeft { modes.insert(.rightToLeft) }
         if showsKeys { modes.insert(.showsKeys) }
+        if showsBoundaries { modes.insert(.showsBoundaries) }
         return modes
     }
 

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationLayout.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationLayout.swift
@@ -77,9 +77,9 @@ import UIKit
 /// way too, and usefully: a view set back to `.unspecified` lays out left-to-right even while its
 /// superview is still forced right-to-left, so only the views that were stamped have to be found.
 ///
-/// ``clearForcedDirection(in:)`` is the answer, and it is narrow in three ways at once. It runs on
-/// the way *off* only; it writes only `.unspecified`, and only to a view that currently reads
-/// `.forceRightToLeft`; and it never touches a view SwiftUI hosts.
+/// ``clearForcedDirection(in:)`` is the answer, and it is narrow in two ways that matter. It runs
+/// on the way *off* only, and the only value it ever writes is `.unspecified`, to a view of
+/// Scyther's that currently reads `.forceRightToLeft`. It never forces a direction onto anything.
 ///
 /// ## Why it does nothing on the way on
 ///
@@ -91,6 +91,11 @@ import UIKit
 /// — while every unit test still passed, because the attribute values were exactly what the tests
 /// asked for. An attribute being set is not evidence that the result is readable. Switching on is
 /// therefore left entirely to the environment half, which is where it always worked.
+///
+/// The same mismatch, from the other side, is what the off direction has to repair: a stamp left
+/// behind there forces right-to-left on a view whose contents SwiftUI has since laid out
+/// left-to-right, and UIKit mirrors the difference. Clearing the stamp removes one of the two
+/// signals; forcing one adds a second. Only the first is ever done here.
 ///
 /// Testing ``apply(rightToLeft:allowed:)`` itself is honest only up to a point, and the point is
 /// `UIView.appearance()`: it is process-wide state with no reliable way to read the applied value
@@ -232,20 +237,31 @@ internal enum PseudoLocalizationLayout {
     ///
     /// Switching **off** is the half that genuinely needed fixing, because the proxy cannot undo
     /// itself: it stamps `.forceRightToLeft` onto each view as the view joins a window and never
-    /// revisits it, so views built while the mode was on stay mirrored for the rest of the session.
-    /// The narrowest repair is to take the stamp back off, which is what this does — write
-    /// `.unspecified` to a view that currently reads `.forceRightToLeft`, and nothing else. A view
-    /// holding any other value was never stamped by this feature and is left exactly as it is.
+    /// revisits it, so views built while the mode was on keep forcing a direction the environment
+    /// has already left behind. The repair is to take the stamp back off, which is all this does —
+    /// write `.unspecified` to a view of Scyther's that currently reads `.forceRightToLeft`, and
+    /// nothing else. A view holding any other value was never stamped by this feature and is left
+    /// exactly as it is.
     ///
-    /// ## What it does not touch
+    /// ## Why it reaches inside the hosting view, and why that is safe
     ///
-    /// Anything SwiftUI hosts. The descent stops at the root view of a ``ScytherPresentedUI``
-    /// controller — the hosting view of every screen Scyther presents — and neither clears it nor
-    /// looks below it. The environment half already governs what SwiftUI draws there, and the
-    /// evidence that reaching into it is dangerous is the reversed text above. What is left for
-    /// this to correct is exactly the UIKit chrome *around* that view: the navigation controller
-    /// Scyther's menu is presented in, its navigation bar, and the overlays Scyther installs
-    /// straight into the app's key window.
+    /// Because that is where the damage was. Measured on a device across the two states: with the
+    /// mode **on**, the environment and the stamp agree that everything is right-to-left and the
+    /// menu is mirrored and perfectly readable. With the mode **off**, the environment has flipped
+    /// back to left-to-right while the collection view backing the `List` is still stamped
+    /// `.forceRightToLeft`, and UIKit mirrors content SwiftUI has already laid out the other way —
+    /// which is text drawn backwards, `Fonts` as `stnoF`. The reversal is the *mismatch*, not the
+    /// stamp on its own, which is why only the off direction was ever broken.
+    ///
+    /// So the stamps inside a hosting view are cleared like any others, and the rule that keeps
+    /// this safe is the narrow one: never *set* `.forceRightToLeft` on anything, in either
+    /// direction. Removing a forced direction leaves the view where a view built with the mode off
+    /// would have been, and restores the agreement between the two halves. Imposing one is what
+    /// made a hosting view mirror its own rendering, and nothing here does it.
+    ///
+    /// The chrome around the hosting view is cleared too — the navigation controller Scyther's
+    /// menu is presented in, its navigation bar, and the overlays Scyther installs straight into
+    /// the app's key window.
     ///
     /// The host app's views are read to find Scyther's and never written, in either direction. Its
     /// UIKit views still mirror on the next launch and un-mirror on the one after, through the
@@ -271,22 +287,15 @@ internal enum PseudoLocalizationLayout {
     /// Clears `view` if it qualifies, then examines its subviews.
     ///
     /// Every view is asked individually rather than a subtree being cleared wholesale once its
-    /// root qualifies. That is the difference between undoing a stamp and applying one: the walk
-    /// must be able to leave a view alone, and a subtree sweep cannot, since it would also write
-    /// to views that were never stamped and to the hosting view it is supposed to stop at.
+    /// root qualifies. That is the difference between undoing a stamp and applying one: this walk
+    /// must be able to leave a view exactly as it found it, and a subtree sweep cannot, because it
+    /// would also write to views the proxy never stamped.
     ///
     /// - Parameter view: The view to examine.
     private static func clearForcedDirection(below view: UIView) {
-        switch role(of: view) {
-        case .swiftUIHosted:
-            return
-        case .scytherChrome:
-            if view.semanticContentAttribute == .forceRightToLeft {
-                view.semanticContentAttribute = .unspecified
-                view.setNeedsLayout()
-            }
-        case .foreign:
-            break
+        if role(of: view).isScythers, view.semanticContentAttribute == .forceRightToLeft {
+            view.semanticContentAttribute = .unspecified
+            view.setNeedsLayout()
         }
         for subview in view.subviews {
             clearForcedDirection(below: subview)
@@ -295,25 +304,34 @@ internal enum PseudoLocalizationLayout {
 
     /// What a view is, as far as clearing a forced direction is concerned.
     ///
+    /// Three cases rather than a boolean because the two Scyther ones are recognised by different
+    /// evidence and are worth telling apart when reading a hierarchy — but they are cleared
+    /// identically, and deliberately so. A stamp inside a hosting view is the same stamp,
+    /// left by the same proxy, and it was the one doing the damage.
+    ///
     /// ## Topics
     ///
     /// ### Cases
     /// - ``swiftUIHosted``
     /// - ``scytherChrome``
     /// - ``foreign``
+    ///
+    /// ### Deciding
+    /// - ``isScythers``
     internal enum ViewRole {
-        /// A view SwiftUI hosts for Scyther, and everything below it.
+        /// A view SwiftUI hosts for Scyther: the hosting view of a presented screen, and
+        /// everything the proxy stamped inside it — the collection view backing a `List`, its
+        /// cells, and whatever else was created while the mode was on.
         ///
-        /// Never written to and never descended into. What SwiftUI draws inside a hosting view is
-        /// governed by the `\.layoutDirection` environment value ``MenuView`` and
-        /// ``PseudoLocalizationView`` install, and the one time this walk reached in and set an
-        /// attribute there the menu came back with its text reversed glyph by glyph.
+        /// Cleared, never forced. The distinction is the whole of what went wrong on this
+        /// feature: *setting* `.forceRightToLeft` on a hosted view while SwiftUI's environment
+        /// says left-to-right makes UIKit mirror content SwiftUI has already laid out, which
+        /// renders text backwards — `Fonts` as `stnoF`. *Removing* that stamp is the repair for
+        /// exactly that mismatch, which is why this walk only ever writes `.unspecified`.
         case swiftUIHosted
 
         /// Scyther's own UIKit chrome: its overlays, and the containers around a screen it
         /// presents.
-        ///
-        /// The only views a `.forceRightToLeft` stamp is Scyther's to remove.
         case scytherChrome
 
         /// A view belonging to the app being debugged.
@@ -321,68 +339,66 @@ internal enum PseudoLocalizationLayout {
         /// Read to find Scyther's own, never written to. Its direction is the appearance proxy's
         /// business and the next launch's.
         case foreign
+
+        /// Whether a `.forceRightToLeft` stamp on a view with this role is Scyther's to remove.
+        internal var isScythers: Bool { self != .foreign }
     }
 
     /// Which of the three a view is.
     ///
-    /// Asked once per view and answered from the *owning controller* rather than the view's class,
-    /// because Scyther's presented screens are SwiftUI: the view a screen hangs off is
-    /// `_UIHostingView`, a private type that names Scyther nowhere, so a class test could never
-    /// find it. The controller can be asked instead, and is.
+    /// Answered from the *responder chain* rather than from the view's class, because Scyther's
+    /// screens are SwiftUI: the view a screen hangs off is `_UIHostingView`, a private type that
+    /// names Scyther nowhere, and the views inside it are private types too. What can be asked is
+    /// which controller the view ultimately belongs to.
     ///
-    /// The order of the three tests is the whole rule:
+    /// The climb does not stop at the first controller it meets, and that matters. SwiftUI puts
+    /// container view controllers of its own inside a hosting controller — a `List` is backed by
+    /// one — so a cell's nearest controller is a private SwiftUI type that is neither Scyther's
+    /// nor contains anything of Scyther's. Stopping there classified every row of the menu as the
+    /// app's and left the stamps that were reversing their text in place. Climbing on reaches the
+    /// ``ScytherHostingController`` above it.
     ///
-    /// - A ``ScytherPresentedUI`` owner means SwiftUI is hosting this view for Scyther, and the
-    ///   answer is ``ViewRole/swiftUIHosted`` before anything else is considered.
+    /// The three tests, in the order they are asked:
+    ///
     /// - `isScytherOwnedType(_:)` — the same rule the accessibility audit uses, shared rather than
     ///   restated — recognises the overlays Scyther installs straight into the app's key window,
     ///   which have no controller at all and can only be known by class.
+    /// - A ``ScytherPresentedUI`` anywhere up the chain means SwiftUI is hosting this view for
+    ///   Scyther.
     /// - ``ScytherPresentation/containsScytherUI(_:)`` recognises the chrome around a presented
     ///   screen. `Scyther.showMenu(from:)` presents a stock `UINavigationController` whose child
     ///   is the ``ScytherHostingController``, so the navigation bar's owning controller is a UIKit
-    ///   container and only its children give it away. A navigation bar left mirrored above a
-    ///   correctly laid-out menu is the same bug reported again.
+    ///   container and only its children give it away.
+    ///
+    /// The climb stops when the chain leaves views and controllers — at a `UIWindowScene`, and
+    /// beyond it `UIApplication` and the app's delegate. Those belong to the app and may be named
+    /// anything at all, which is the same boundary ``AuditNode`` draws for the same reason.
     ///
     /// - Parameter view: The view to classify.
     /// - Returns: The view's role.
     internal static func role(of view: UIView) -> ViewRole {
-        let controller = owningController(of: view)
-        if controller is ScytherPresentedUI { return .swiftUIHosted }
         if isScytherOwnedType(view) { return .scytherChrome }
-        guard let controller, ScytherPresentation.containsScytherUI(controller) else { return .foreign }
-        return .scytherChrome
+        var responder: UIResponder? = view.next
+        var steps = 0
+        var chrome = false
+        while let current = responder, steps < maximumResponderSteps {
+            if let controller = current as? UIViewController {
+                if controller is ScytherPresentedUI { return .swiftUIHosted }
+                if ScytherPresentation.containsScytherUI(controller) { chrome = true }
+            } else if !(current is UIView) {
+                break
+            }
+            responder = current.next
+            steps += 1
+        }
+        return chrome ? .scytherChrome : .foreign
     }
 
-    /// How far ``owningController(of:)`` climbs before giving up.
+    /// How far ``role(of:)`` climbs before giving up.
     ///
     /// A responder chain is not cyclic, so this is belt-and-braces of the same kind
     /// ``ScytherPresentation`` and ``AuditNode`` already keep — and it costs one integer compare
     /// per link of a walk that runs once per view on a screen.
     private static let maximumResponderSteps = 100
-
-    /// The view controller a view belongs to, if any.
-    ///
-    /// Climbs the *responder* chain rather than `superview`, which is the whole trick:
-    /// `UIResponder.next` hands back a view's owning view controller when the view is that
-    /// controller's root view and its superview otherwise, so one loop crosses from the deepest
-    /// label in a SwiftUI list up to the controller hosting it. A `superview` walk would stop at
-    /// the hosting view and never reach the marker that identifies it as Scyther's.
-    ///
-    /// Stops as soon as the chain leaves views and controllers — at a `UIWindowScene`, and beyond
-    /// it `UIApplication` and the app's delegate — because those belong to the app.
-    ///
-    /// - Parameter view: The view to resolve an owner for.
-    /// - Returns: The owning controller, or `nil` when the chain runs out first.
-    private static func owningController(of view: UIView) -> UIViewController? {
-        var responder: UIResponder? = view.next
-        var steps = 0
-        while let current = responder, steps < maximumResponderSteps {
-            if let controller = current as? UIViewController { return controller }
-            guard current is UIView else { return nil }
-            responder = current.next
-            steps += 1
-        }
-        return nil
-    }
 }
 #endif

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationLayout.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationLayout.swift
@@ -25,7 +25,8 @@ import UIKit
 /// 1. `UIView.appearance()` applies to views created *after* it changes, so nothing already on
 ///    screen moves. That is inherent to the appearance proxy, and working around it would mean
 ///    tearing down and rebuilding the host app's view hierarchy, which a debug toolkit has no
-///    business doing.
+///    business doing. It is not the whole story for *Scyther's own* views, though, and the half
+///    that was missing is a defect this shipped with: see below.
 /// 2. SwiftUI does not consult the appearance proxy at all. Its direction comes from the
 ///    `\.layoutDirection` environment value — and ``MenuView`` *sets* that value explicitly, from
 ///    the language override, so Scyther's own interface was pinned left-to-right by Scyther's own
@@ -57,10 +58,36 @@ import UIKit
 /// mechanism and turned out to be wrong on a simulator. A fourth, resting on an undocumented
 /// defaults key, is not worth an accurate limit.
 ///
-/// Testing the UIKit half is honest only up to a point, and the point is `UIView.appearance()`: it
-/// is process-wide state with no reliable way to read the applied value back, and `ScytherTests`
-/// has no host app whose windows could be inspected. It is therefore driven only through
-/// ``attribute(rightToLeft:)``, which is pure and is tested.
+/// ## Why the appearance proxy can never undo itself
+///
+/// The UIKit half shipped with a defect that took a while to see, because it looks like the proxy
+/// is symmetrical and it is not. `UIView.appearance()` does not *govern* a view; it *stamps* one.
+/// The value is copied onto each view as it is added to a window, and it stays on that view for
+/// the rest of its life. Setting the proxy back therefore changes nothing that already exists:
+/// switching the mode off left every view built while it was on holding `.forceRightToLeft`, and a
+/// developer who switched right-to-left on, off, and navigated back to the menu found it still
+/// mirrored until the process was relaunched.
+///
+/// Measured on a simulator rather than reasoned about, since this feature has a history of the
+/// second: with the proxy set to `.forceRightToLeft`, a view added to a window reads back
+/// `.forceRightToLeft`, and still reads back `.forceRightToLeft` after the proxy is reset to
+/// `.unspecified` and the window is reset and laid out again. A `UINavigationBar` and a
+/// `UIHostingController`'s view behave the same way. Resetting the window is not enough either,
+/// because the stamp is on each view rather than inherited from an ancestor — which cuts the other
+/// way too, and usefully: a view set back to `.unspecified` lays out left-to-right even while its
+/// superview is still forced right-to-left, so only the views that were stamped have to be found.
+///
+/// ``applyToOwnedViews(rightToLeft:in:)`` is the answer, and it is deliberately narrow. Scyther
+/// resets the views *Scyther owns* — its menu, everything presented from it, and its overlays —
+/// because those it is entitled to reach into. The host app's views are left to the proxy and the
+/// next launch, exactly as documented, and the walk reads them only to find its own.
+///
+/// Testing ``apply(rightToLeft:allowed:)`` itself is honest only up to a point, and the point is
+/// `UIView.appearance()`: it is process-wide state with no reliable way to read the applied value
+/// back, and `ScytherTests` has no host app whose windows could be inspected. It is therefore
+/// driven only through ``attribute(rightToLeft:)`` and ``applyToOwnedViews(rightToLeft:in:)``,
+/// which are pure enough to be tested against a hierarchy built by hand — which is what the view
+/// walk is tested against.
 ///
 /// ## Topics
 ///
@@ -70,6 +97,8 @@ import UIKit
 ///
 /// ### Applying
 /// - ``apply(rightToLeft:allowed:)``
+/// - ``applyToOwnedViews(rightToLeft:in:)``
+/// - ``isScytherOwned(_:)``
 @MainActor
 internal enum PseudoLocalizationLayout {
     /// The layout direction Scyther's own SwiftUI interface should be laid out in.
@@ -125,6 +154,11 @@ internal enum PseudoLocalizationLayout {
     /// its environment, seeded when its hosting view was built, and nothing here reaches back into
     /// it.
     ///
+    /// It then hands off to ``applyToOwnedViews(rightToLeft:in:)`` for the views Scyther itself
+    /// owns, which the proxy cannot help with in either direction — it stamps a view once, as the
+    /// view joins a window, and never revisits it. Nothing about the host app changes because of
+    /// that step.
+    ///
     /// A relaunch makes the UIKit half complete but no more than that.
     /// ``PseudoLocalization/setup()`` sets the proxy from `Scyther.start(allowProductionBuilds:)`,
     /// before any of the app's views exist, so every *UIKit* view is built mirrored. A SwiftUI
@@ -153,13 +187,153 @@ internal enum PseudoLocalizationLayout {
         guard allowed, !AppEnvironment.isTestCase, !AppEnvironment.isAppStore else { return }
         let attribute = attribute(rightToLeft: rightToLeft)
         UIView.appearance().semanticContentAttribute = attribute
+        var windows: [UIWindow] = []
         for scene in UIApplication.shared.connectedScenes {
             guard let windowScene = scene as? UIWindowScene else { continue }
             for window in windowScene.windows {
                 window.semanticContentAttribute = attribute
                 window.setNeedsLayout()
+                windows.append(window)
             }
         }
+        applyToOwnedViews(rightToLeft: rightToLeft, in: windows)
+    }
+
+    /// Puts the views *Scyther* owns into the direction the mode now calls for, instead of waiting
+    /// for them to be built again.
+    ///
+    /// This is the half of the UIKit story the proxy cannot do, in either direction. Off is the
+    /// case that shipped broken — a mirrored menu that stayed mirrored for the rest of the session
+    /// — and on had the same weakness wearing better clothes: it happened to look right only
+    /// because a developer switching it on usually navigates somewhere afterwards, and the views
+    /// they arrive at are new. Both directions now go through here, so both behave the same and
+    /// neither depends on when a view happened to be created.
+    ///
+    /// The walk descends from `roots`, and the only views it *writes* to are Scyther's own: a
+    /// subtree recognised by ``isScytherOwned(_:)`` is stamped whole and not descended into again,
+    /// and everything else is passed over and its subviews examined instead. The host app's views
+    /// are read to find Scyther's and never written, which is the line this feature draws
+    /// everywhere else too: the app's UIKit views mirror through the appearance proxy on their next
+    /// launch, and its SwiftUI views not at all.
+    ///
+    /// Each stamped view is marked for layout and each owned root is laid out immediately, because
+    /// the point of the fix is that the screen the developer is looking at changes *now*. Without
+    /// the forced pass the attribute would sit correct-but-unrendered until something else
+    /// invalidated the layout, which on a menu nobody is scrolling is indefinitely.
+    ///
+    /// Cost is a full descent of the window's view tree with a responder climb per view, which is
+    /// far too much to do per frame and entirely fine here: it runs when a switch moves, and the
+    /// alternative — tracking every view Scyther creates — would be a registry to keep correct
+    /// forever in exchange for microseconds nobody is waiting on.
+    ///
+    /// Carries no production guard of its own, unlike ``apply(rightToLeft:allowed:)``: it writes
+    /// only to views Scyther owns, which on an App Store build do not exist, and its caller has
+    /// already refused. Not carrying one is also what makes it testable — the XCTest half of that
+    /// guard would otherwise make every test below assert that nothing happened.
+    ///
+    /// - Parameters:
+    ///   - rightToLeft: Whether right-to-left is being forced.
+    ///   - roots: The views to descend from. In production the app's windows; in a test, a
+    ///     hierarchy built by hand.
+    internal static func applyToOwnedViews(rightToLeft: Bool, in roots: [UIView]) {
+        let attribute = attribute(rightToLeft: rightToLeft)
+        for root in roots {
+            applyToOwnedSubtrees(of: root, attribute: attribute)
+        }
+    }
+
+    /// Finds Scyther's own subtrees below `view` and stamps them.
+    ///
+    /// Stops descending the moment it finds one, because everything inside a view of Scyther's is
+    /// Scyther's too and asking again per descendant would be the same answer bought at the price
+    /// of a responder climb each time.
+    ///
+    /// - Parameters:
+    ///   - view: The view to examine.
+    ///   - attribute: The attribute to stamp onto anything owned.
+    private static func applyToOwnedSubtrees(of view: UIView, attribute: UISemanticContentAttribute) {
+        if isScytherOwned(view) {
+            stamp(view, with: attribute)
+            view.layoutIfNeeded()
+            return
+        }
+        for subview in view.subviews {
+            applyToOwnedSubtrees(of: subview, attribute: attribute)
+        }
+    }
+
+    /// Sets `attribute` on `view` and everything below it.
+    ///
+    /// Every descendant, not just the root, because the stamp the appearance proxy leaves is on
+    /// each view individually rather than inherited: a subtree whose root alone was reset would
+    /// keep every mirrored label, button and image view it already had.
+    ///
+    /// - Parameters:
+    ///   - view: The root of the subtree to stamp.
+    ///   - attribute: The attribute to apply.
+    private static func stamp(_ view: UIView, with attribute: UISemanticContentAttribute) {
+        view.semanticContentAttribute = attribute
+        view.setNeedsLayout()
+        for subview in view.subviews {
+            stamp(subview, with: attribute)
+        }
+    }
+
+    /// Whether a view belongs to Scyther rather than to the app being debugged.
+    ///
+    /// Two questions, because Scyther's UI arrives on screen two ways. `isScytherOwnedType(_:)` —
+    /// the same rule the accessibility audit uses, deliberately shared rather than restated —
+    /// catches the overlays Scyther installs straight into the app's key window, which are its own
+    /// classes and have no view controller. The controller question catches everything Scyther
+    /// *presents*, whose views are SwiftUI's `_UIHostingView` and name Scyther nowhere; they are
+    /// recognised by the controller that owns them instead.
+    ///
+    /// Ownership is asked of the controller through ``ScytherPresentation/containsScytherUI(_:)``
+    /// rather than by testing it against ``ScytherPresentedUI`` directly, and that is what makes
+    /// the menu's navigation bar come with it: `Scyther.showMenu(from:)` presents a stock
+    /// `UINavigationController` whose child is the ``ScytherHostingController``, so the navigation
+    /// bar's owning controller is a UIKit container and only its children give it away. A
+    /// navigation bar left mirrored above an un-mirrored list would be a half-fix a developer
+    /// would report as the same bug.
+    ///
+    /// - Parameter view: The view to test.
+    /// - Returns: `true` when the view is Scyther's own.
+    internal static func isScytherOwned(_ view: UIView) -> Bool {
+        if isScytherOwnedType(view) { return true }
+        guard let controller = owningController(of: view) else { return false }
+        return ScytherPresentation.containsScytherUI(controller)
+    }
+
+    /// How far ``owningController(of:)`` climbs before giving up.
+    ///
+    /// A responder chain is not cyclic, so this is belt-and-braces of the same kind
+    /// ``ScytherPresentation`` and ``AuditNode`` already keep — and it costs one integer compare
+    /// per link of a walk that runs once per view on a screen.
+    private static let maximumResponderSteps = 100
+
+    /// The view controller a view belongs to, if any.
+    ///
+    /// Climbs the *responder* chain rather than `superview`, which is the whole trick:
+    /// `UIResponder.next` hands back a view's owning view controller when the view is that
+    /// controller's root view and its superview otherwise, so one loop crosses from the deepest
+    /// label in a SwiftUI list up to the controller hosting it. A `superview` walk would stop at
+    /// the hosting view and never reach the marker that identifies it as Scyther's.
+    ///
+    /// Stops as soon as the chain leaves views and controllers — at a `UIWindowScene`, and beyond
+    /// it `UIApplication` and the app's delegate — because those belong to the app.
+    ///
+    /// - Parameter view: The view to resolve an owner for.
+    /// - Returns: The owning controller, or `nil` when the chain runs out first.
+    private static func owningController(of view: UIView) -> UIViewController? {
+        var responder: UIResponder? = view.next
+        var steps = 0
+        while let current = responder, steps < maximumResponderSteps {
+            if let controller = current as? UIViewController { return controller }
+            guard current is UIView else { return nil }
+            responder = current.next
+            steps += 1
+        }
+        return nil
     }
 }
 #endif

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationLayout.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationLayout.swift
@@ -6,123 +6,75 @@
 //
 
 #if !os(macOS)
+import Foundation
 import SwiftUI
-import UIKit
 
-/// Forces the host app's layout direction, without switching it to an RTL language.
+/// Decides the layout direction Scyther's own interface is laid out in, without switching it to an
+/// RTL language.
 ///
 /// Separated from ``PseudoLocalization`` because right-to-left is not a string transformation at
-/// all: no character changes, and none of the string plumbing in this feature is involved. It is a
-/// UIKit semantic attribute, which is also why it is the one mode with no gap between Scyther's
-/// interface and the host app's — it does not care how the app loads its copy.
+/// all: no character changes, and none of the string plumbing in this feature is involved.
 ///
-/// ## Two halves, and only one of them is immediate
+/// Two halves, with two different timescales, and the split is the honest shape of the problem.
+/// ``layoutDirection(forcingRightToLeft:languageIdentifier:)`` decides the value ``MenuView`` and
+/// ``PseudoLocalizationView`` install as `\.layoutDirection`, which mirrors *Scyther's own
+/// interface* the instant the switch moves and un-mirrors it the instant it moves back.
+/// ``applyToHostApp(rightToLeft:isTestCase:isAppStore:systemDefaults:)`` writes the two defaults
+/// keys iOS reads at launch, which mirrors *the host app* — all of it, UIKit and SwiftUI alike —
+/// on its next launch.
 ///
-/// The first draft of this type had only the UIKit half, and switching the mode on visibly did
-/// nothing at all — not in the host app, not even in Scyther's own menu. Two reasons, both worth
-/// recording so the mistake is not repeated:
+/// ## What used to be here, and why it is gone
 ///
-/// 1. `UIView.appearance()` applies to views created *after* it changes, so nothing already on
-///    screen moves. That is inherent to the appearance proxy, and working around it would mean
-///    tearing down and rebuilding the host app's view hierarchy, which a debug toolkit has no
-///    business doing. It is not the whole story for *Scyther's own* views, though, and the half
-///    that was missing is a defect this shipped with: see below.
-/// 2. SwiftUI does not consult the appearance proxy at all. Its direction comes from the
-///    `\.layoutDirection` environment value — and ``MenuView`` *sets* that value explicitly, from
-///    the language override, so Scyther's own interface was pinned left-to-right by Scyther's own
-///    code no matter what the proxy said.
+/// A third mechanism used to set `UIView.appearance().semanticContentAttribute`. It is deleted,
+/// and the reasoning is worth keeping so it is not reintroduced.
 ///
-/// The mode therefore has two halves. ``layoutDirection(forcingRightToLeft:languageIdentifier:)``
-/// is the SwiftUI half: it decides the environment value ``MenuView`` and ``PseudoLocalizationView``
-/// install, which is what makes Scyther's own interface flip the instant the switch moves. It is
-/// pure, and it is tested. ``apply(rightToLeft:allowed:)`` is the UIKit half: it reaches the host
-/// app's UIKit views on the next launch, and its SwiftUI views not at all.
+/// The appearance proxy does not govern a view, it *stamps* one: the value is copied onto each
+/// view as the view joins a window and is never revisited, so setting the proxy back cannot undo a
+/// view that already exists. Everything built while the mode was on kept forcing right-to-left
+/// after the mode was switched off — including the views inside Scyther's own menu — and a
+/// leftover stamp does not merely mirror a layout. It *disagrees* with the SwiftUI environment
+/// around it, and UIKit answers a disagreement by mirroring content SwiftUI has already laid out
+/// the other way, which is text drawn backwards: `Fonts` rendered as `stnoF`.
 ///
-/// ## What would reach a SwiftUI host app, and what it would cost
+/// Three attempts were made to clean up after the stamp — reset the windows, reset the views
+/// Scyther owns, reset the views inside its hosting views — and every one left the menu unreadable
+/// on a device while every unit test passed, because an attribute holding the value a test asked
+/// for is not evidence that the screen is legible. The residue cannot be chased to zero either: a
+/// recycled cell that is off-screen when the switch moves carries its stamp back on with it.
 ///
-/// Nothing here can, and the reason is structural rather than a missing trick: a SwiftUI view's
-/// direction comes from `\.layoutDirection` in *its own* environment, which the host app owns.
-/// There is no public API for a library to modify another view tree's environment, and the
-/// appearance proxy — measured, twice — does not seed it.
+/// It also never reached a SwiftUI host app at all, so what it cost in corruption it did not even
+/// buy in coverage. Nothing is stamped any more, nothing needs unstamping, and the mismatch that
+/// reversed the glyphs cannot occur in either direction.
 ///
-/// One route does exist and is deliberately *not* taken. Xcode's own "Right to Left
-/// Pseudolanguage" scheme option works by launching the process with `-AppleTextDirection YES` and
-/// `-NSForceRightToLeftWritingDirection YES`, which are resolved at launch and do reach SwiftUI.
-/// Scyther could write those into the host's standard `UserDefaults` the same way
-/// ``LanguageOverride`` already writes `AppleLanguages`, and they would take effect on the next
-/// launch. The cost is why it is not built: it writes into the host app's own defaults domain for
-/// a second reason, it is undocumented as a defaults key rather than a launch argument, it cannot
-/// be undone within the session that set it, and — the decisive one — nothing in this repository
-/// can verify it, since `ScytherTests` has no host app and the example app would have to be driven
-/// by hand. This feature has already shipped three claims about reach that were reasoned from
-/// mechanism and turned out to be wrong on a simulator. A fourth, resting on an undocumented
-/// defaults key, is not worth an accurate limit.
+/// ## Why the defaults keys instead
 ///
-/// ## Why the appearance proxy can never undo itself
+/// Because they do the thing the proxy could not: they are resolved at launch, before any view
+/// exists, and they reach **both** frameworks. `AppleTextDirection` and
+/// `NSForceRightToLeftWritingDirection` are what Xcode's own **Edit Scheme → Run → Options → App
+/// Language → Right to Left Pseudolanguage** passes on the command line, and writing them into the
+/// host's standard `UserDefaults` is the same move ``LanguageOverride`` already makes with
+/// `AppleLanguages` — an established pattern in this package rather than a new liberty.
 ///
-/// The UIKit half shipped with a defect that took a while to see, because it looks like the proxy
-/// is symmetrical and it is not. `UIView.appearance()` does not *govern* a view; it *stamps* one.
-/// The value is copied onto each view as it is added to a window, and it stays on that view for
-/// the rest of its life. Setting the proxy back therefore changes nothing that already exists:
-/// switching the mode off left every view built while it was on holding `.forceRightToLeft`, and a
-/// developer who switched right-to-left on, off, and navigated back to the menu found it still
-/// mirrored until the process was relaunched.
-///
-/// Measured on a simulator rather than reasoned about, since this feature has a history of the
-/// second: with the proxy set to `.forceRightToLeft`, a view added to a window reads back
-/// `.forceRightToLeft`, and still reads back `.forceRightToLeft` after the proxy is reset to
-/// `.unspecified` and the window is reset and laid out again. A `UINavigationBar` and a
-/// `UIHostingController`'s view behave the same way. Resetting the window is not enough either,
-/// because the stamp is on each view rather than inherited from an ancestor — which cuts the other
-/// way too, and usefully: a view set back to `.unspecified` lays out left-to-right even while its
-/// superview is still forced right-to-left, so only the views that were stamped have to be found.
-///
-/// ``clearForcedDirection(in:)`` is the answer, and it is narrow in two ways that matter. It runs
-/// on the way *off* only, and the only value it ever writes is `.unspecified`, to a view of
-/// Scyther's that currently reads `.forceRightToLeft`. It never forces a direction onto anything.
-///
-/// ## Why it does nothing on the way on
-///
-/// Because forcing the attribute onto Scyther's own views broke the rendering, which is worth
-/// recording precisely. Switching the mode on already worked through the environment half, and
-/// adding the UIKit half to the same views gave them two signals saying the same thing. A hosting
-/// view told to force a direction mirrors what it *renders* rather than reordering what it lays
-/// out, so the menu came back with every label reversed glyph by glyph — `Fonts` drawn as `stnoF`
-/// — while every unit test still passed, because the attribute values were exactly what the tests
-/// asked for. An attribute being set is not evidence that the result is readable. Switching on is
-/// therefore left entirely to the environment half, which is where it always worked.
-///
-/// The same mismatch, from the other side, is what the off direction has to repair: a stamp left
-/// behind there forces right-to-left on a view whose contents SwiftUI has since laid out
-/// left-to-right, and UIKit mirrors the difference. Clearing the stamp removes one of the two
-/// signals; forcing one adds a second. Only the first is ever done here.
-///
-/// Testing ``apply(rightToLeft:allowed:)`` itself is honest only up to a point, and the point is
-/// `UIView.appearance()`: it is process-wide state with no reliable way to read the applied value
-/// back, and `ScytherTests` has no host app whose windows could be inspected. It is therefore
-/// driven only through ``attribute(rightToLeft:)`` and ``clearForcedDirection(in:)``, which are
-/// pure enough to be tested against a hierarchy built by hand. What those tests can prove is
-/// bounded, and this file has now been the proof: they can say which attribute a view carries;
-/// they cannot say what the screen looks like.
+/// The trade is timing, and it is stated on the toggle rather than buried here: Scyther's own UI
+/// changes now, the developer's app changes on its next launch. An asymmetry nobody explains is a
+/// bug report.
 ///
 /// ## Topics
 ///
 /// ### Deciding
 /// - ``layoutDirection(forcingRightToLeft:languageIdentifier:)``
-/// - ``attribute(rightToLeft:)``
 ///
-/// ### Applying
-/// - ``apply(rightToLeft:allowed:)``
-/// - ``clearForcedDirection(in:)``
-/// - ``role(of:)``
-/// - ``ViewRole``
-@MainActor
+/// ### Reaching the host app
+/// - ``applyToHostApp(rightToLeft:isTestCase:isAppStore:systemDefaults:)``
+/// - ``textDirectionDefaultsKey``
+/// - ``forceRightToLeftDefaultsKey``
 internal enum PseudoLocalizationLayout {
     /// The layout direction Scyther's own SwiftUI interface should be laid out in.
     ///
-    /// This is the half of the mode that works immediately, and it is the only half that can:
     /// SwiftUI takes its direction from the environment, so the value has to be *decided* where
     /// the environment is installed rather than *forced onto* a view that has already been built.
+    /// That is why this is the half that has been correct since the first version, while the one
+    /// that tried to force an attribute onto existing views never was.
     ///
     /// The forced mode wins over the language. That ordering is the point — a developer switching
     /// the mode on is asking to see the layout mirrored *without* changing language, and a
@@ -145,260 +97,77 @@ internal enum PseudoLocalizationLayout {
             : .leftToRight
     }
 
-    /// The semantic content attribute matching a switch position.
+    /// The standard-defaults key iOS reads at launch to decide the app's text direction.
     ///
-    /// `.unspecified` rather than `.forceLeftToRight` for the off case, so switching the mode off
-    /// hands the decision back to the user's actual language instead of pinning a genuinely
-    /// Arabic or Hebrew device to left-to-right — which would be a worse bug than the one the
-    /// mode exists to find.
-    ///
-    /// - Parameter rightToLeft: Whether right-to-left is being forced.
-    /// - Returns: The attribute to apply.
-    internal static func attribute(rightToLeft: Bool) -> UISemanticContentAttribute {
-        rightToLeft ? .forceRightToLeft : .unspecified
-    }
+    /// Undocumented as a defaults key — Xcode passes it as the launch argument
+    /// `-AppleTextDirection YES` — but it is read from the standard domain the same way
+    /// `AppleLanguages` is, which is what makes it reachable from inside the process rather than
+    /// only from a scheme.
+    internal static let textDirectionDefaultsKey = "AppleTextDirection"
 
-    /// Applies the layout direction to the appearance proxy and to the windows already on screen,
-    /// for the *host app*.
+    /// The standard-defaults key iOS reads at launch to force right-to-left writing.
     ///
-    /// Described in deliberately weaker terms than the SwiftUI half, because it is weaker, and the
-    /// first version of this feature shipped a toggle whose subtitle promised what only this half
-    /// could deliver — which, on the screens anyone actually looked at, was nothing.
+    /// Written alongside ``textDirectionDefaultsKey`` because Xcode's scheme option sets both, and
+    /// setting one without the other is a state the system is never asked for in practice.
+    internal static let forceRightToLeftDefaultsKey = "NSForceRightToLeftWritingDirection"
+
+    /// Mirrors the *host app* — UIKit and SwiftUI alike — from its next launch, or stops doing so.
     ///
-    /// What it does: sets the proxy, so UIKit views the host app creates from now on are laid out
-    /// mirrored, and sets the attribute on the existing windows, which flips UIKit content already
-    /// on screen. What it does not do: move a SwiftUI view. SwiftUI reads `\.layoutDirection` from
-    /// its environment, seeded when its hosting view was built, and nothing here reaches back into
-    /// it.
+    /// This is the half that makes the mode worth having. Pseudo-localisation exists to test the
+    /// developer's app, and a right-to-left mode that mirrored only Scyther's own menu would test
+    /// nothing anybody ships. What it costs is immediacy: the two keys are read once, while the
+    /// process is starting, so nothing about the running app moves when the switch does.
     ///
-    /// On the way *off* it then hands to ``clearForcedDirection(in:)``, which takes the proxy's
-    /// stamp back off the UIKit chrome Scyther owns — the proxy cannot do that itself, since it
-    /// stamps a view once as the view joins a window and never revisits it. There is no matching
-    /// step on the way on: forcing the attribute onto Scyther's own views is what made a hosting
-    /// view mirror its rendered text, and the environment half already flips Scyther's interface
-    /// the moment the switch moves. Nothing about the host app changes because of either.
+    /// ## Reversibility
     ///
-    /// A relaunch makes the UIKit half complete but no more than that.
-    /// ``PseudoLocalization/setup()`` sets the proxy from `Scyther.start(allowProductionBuilds:)`,
-    /// before any of the app's views exist, so every *UIKit* view is built mirrored. A SwiftUI
-    /// view is not, measured on a simulator after a relaunch with the switch left on: SwiftUI does
-    /// not consult the proxy at any point in its life, so being early does not help.
+    /// Switching off **removes** the keys rather than writing `false`, and that is deliberate
+    /// rather than tidy. A developer who tries this once must be able to get their app back, and a
+    /// key left behind holding `false` is a Scyther-shaped value sitting in their app's defaults
+    /// for good — the sort of thing that is found months later while debugging something else.
+    /// Removal restores the state the app was in before Scyther was ever asked, and it takes
+    /// effect on the next launch in exactly the way switching on does.
     ///
-    /// This is the one part of the mode whose behaviour has not been observed directly here, and
-    /// it should be read as such: the example app is SwiftUI, so what a relaunch does for a UIKit
-    /// host rests on documented appearance-proxy behaviour rather than on a screenshot. The
-    /// difference is why the surface table in the DocC article marks which rows were checked.
+    /// ``LanguageOverride/reset()`` removes `AppleLanguages` for the same reason.
     ///
-    /// Like ``PseudoLocalizationHostHook/setEnabled(_:isTestCase:isAppStore:)``, it carries the
-    /// production guard itself rather than trusting its caller, because the promise that Scyther
-    /// never forces a shipping app's layout direction is made about this function.
+    /// ## The guard, and the one place it lets a write through
     ///
-    /// The XCTest half of the guard has no injection seam, unlike the hook's. There is nothing a
-    /// test could usefully do with it: there is no host app whose windows could be flipped, and
-    /// `UIView.appearance()` is process-wide state a test has no reliable way to restore for the
-    /// tests that run after it.
+    /// Carried here rather than trusted to the caller, matching
+    /// ``PseudoLocalizationHostHook/setEnabled(_:isTestCase:isAppStore:)``: the promise that
+    /// Scyther never leaves a shipping app mirrored is made about this function, so this function
+    /// keeps it. Under XCTest there is no host app to mirror and writing to the standard domain
+    /// would leak into unrelated tests in the same process, so nothing happens at all.
+    ///
+    /// An App Store build refuses to *set* the keys and still *removes* them, which is not an
+    /// oversight. ``PseudoLocalization/resolvedModes(stored:isAppStore:)`` reports no modes on such
+    /// a build, so the only call that can arrive is the off case — and a switch left on in a
+    /// TestFlight build, carried into a store build through the same preferences file, is exactly
+    /// the situation where the keys need clearing rather than preserving. Refusing to remove them
+    /// would leave a real user's app mirrored with no way to reach the switch that did it.
     ///
     /// - Parameters:
-    ///   - rightToLeft: Whether to force right-to-left layout.
-    ///   - allowed: Whether the host app may be touched at all, per
-    ///     ``PseudoLocalization/canAffectHostApp(isTestCase:isAppStore:)``.
-    internal static func apply(rightToLeft: Bool, allowed: Bool = true) {
-        guard allowed, !AppEnvironment.isTestCase, !AppEnvironment.isAppStore else { return }
-        let attribute = attribute(rightToLeft: rightToLeft)
-        UIView.appearance().semanticContentAttribute = attribute
-        var windows: [UIWindow] = []
-        for scene in UIApplication.shared.connectedScenes {
-            guard let windowScene = scene as? UIWindowScene else { continue }
-            for window in windowScene.windows {
-                window.semanticContentAttribute = attribute
-                window.setNeedsLayout()
-                windows.append(window)
-            }
+    ///   - rightToLeft: Whether right-to-left is being forced.
+    ///   - isTestCase: Whether the process is running under XCTest, per ``AppEnvironment/isTestCase``.
+    ///   - isAppStore: Whether this is an App Store build, per ``AppEnvironment/isAppStore``.
+    ///   - systemDefaults: Where the keys are written. Defaults to `.standard`, which is the host
+    ///     app's own domain; injected so a test can assert on a throwaway suite instead.
+    internal static func applyToHostApp(
+        rightToLeft: Bool,
+        isTestCase: Bool = AppEnvironment.isTestCase,
+        isAppStore: Bool = AppEnvironment.isAppStore,
+        systemDefaults: UserDefaults = .standard
+    ) {
+        guard !isTestCase else { return }
+        guard rightToLeft else {
+            systemDefaults.removeObject(forKey: textDirectionDefaultsKey)
+            systemDefaults.removeObject(forKey: forceRightToLeftDefaultsKey)
+            return
         }
-        guard !rightToLeft else { return }
-        clearForcedDirection(in: windows)
+        guard PseudoLocalization.canAffectHostApp(
+            isTestCase: isTestCase,
+            isAppStore: isAppStore
+        ) else { return }
+        systemDefaults.set(true, forKey: textDirectionDefaultsKey)
+        systemDefaults.set(true, forKey: forceRightToLeftDefaultsKey)
     }
-
-    /// Clears the forced direction the appearance proxy stamped onto Scyther's own UIKit chrome
-    /// while the mode was on.
-    ///
-    /// ## Why only this direction, and only a clear
-    ///
-    /// The two directions are not symmetric, and an earlier attempt to make them symmetric was
-    /// worse than the bug it replaced. Switching the mode **on** already works, through the
-    /// `\.layoutDirection` environment value ``MenuView`` and ``PseudoLocalizationView`` install:
-    /// Scyther's interface mirrors the instant the switch moves and its text stays readable.
-    /// Forcing `.forceRightToLeft` onto Scyther's view tree as well added a second, contradictory
-    /// signal to the same views, and a hosting view told to force a direction mirrors what it
-    /// *renders* rather than reordering what it lays out: on a device the menu came back with
-    /// every label reversed glyph by glyph — `Fonts` as `stnoF` — which no assertion about an
-    /// attribute value can detect. So nothing here forces anything on. Switching on is left
-    /// entirely to the environment half.
-    ///
-    /// Switching **off** is the half that genuinely needed fixing, because the proxy cannot undo
-    /// itself: it stamps `.forceRightToLeft` onto each view as the view joins a window and never
-    /// revisits it, so views built while the mode was on keep forcing a direction the environment
-    /// has already left behind. The repair is to take the stamp back off, which is all this does —
-    /// write `.unspecified` to a view of Scyther's that currently reads `.forceRightToLeft`, and
-    /// nothing else. A view holding any other value was never stamped by this feature and is left
-    /// exactly as it is.
-    ///
-    /// ## Why it reaches inside the hosting view, and why that is safe
-    ///
-    /// Because that is where the damage was. Measured on a device across the two states: with the
-    /// mode **on**, the environment and the stamp agree that everything is right-to-left and the
-    /// menu is mirrored and perfectly readable. With the mode **off**, the environment has flipped
-    /// back to left-to-right while the collection view backing the `List` is still stamped
-    /// `.forceRightToLeft`, and UIKit mirrors content SwiftUI has already laid out the other way —
-    /// which is text drawn backwards, `Fonts` as `stnoF`. The reversal is the *mismatch*, not the
-    /// stamp on its own, which is why only the off direction was ever broken.
-    ///
-    /// So the stamps inside a hosting view are cleared like any others, and the rule that keeps
-    /// this safe is the narrow one: never *set* `.forceRightToLeft` on anything, in either
-    /// direction. Removing a forced direction leaves the view where a view built with the mode off
-    /// would have been, and restores the agreement between the two halves. Imposing one is what
-    /// made a hosting view mirror its own rendering, and nothing here does it.
-    ///
-    /// The chrome around the hosting view is cleared too — the navigation controller Scyther's
-    /// menu is presented in, its navigation bar, and the overlays Scyther installs straight into
-    /// the app's key window.
-    ///
-    /// The host app's views are read to find Scyther's and never written, in either direction. Its
-    /// UIKit views still mirror on the next launch and un-mirror on the one after, through the
-    /// proxy alone, and its SwiftUI views still never.
-    ///
-    /// Cost is a descent of the window's view tree with a responder climb per view. Far too much
-    /// per frame, entirely fine when a switch moves.
-    ///
-    /// Carries no production guard of its own, unlike ``apply(rightToLeft:allowed:)``: it writes
-    /// only to views Scyther owns, which on an App Store build do not exist, and its caller has
-    /// already refused. Not carrying one is also what makes it testable — the XCTest half of that
-    /// guard would otherwise make every test of it assert that nothing happened.
-    ///
-    /// - Parameter roots: The views to descend from. In production the app's windows; in a test, a
-    ///   hierarchy built by hand.
-    internal static func clearForcedDirection(in roots: [UIView]) {
-        for root in roots {
-            clearForcedDirection(below: root)
-            root.layoutIfNeeded()
-        }
-    }
-
-    /// Clears `view` if it qualifies, then examines its subviews.
-    ///
-    /// Every view is asked individually rather than a subtree being cleared wholesale once its
-    /// root qualifies. That is the difference between undoing a stamp and applying one: this walk
-    /// must be able to leave a view exactly as it found it, and a subtree sweep cannot, because it
-    /// would also write to views the proxy never stamped.
-    ///
-    /// - Parameter view: The view to examine.
-    private static func clearForcedDirection(below view: UIView) {
-        if role(of: view).isScythers, view.semanticContentAttribute == .forceRightToLeft {
-            view.semanticContentAttribute = .unspecified
-            view.setNeedsLayout()
-        }
-        for subview in view.subviews {
-            clearForcedDirection(below: subview)
-        }
-    }
-
-    /// What a view is, as far as clearing a forced direction is concerned.
-    ///
-    /// Three cases rather than a boolean because the two Scyther ones are recognised by different
-    /// evidence and are worth telling apart when reading a hierarchy — but they are cleared
-    /// identically, and deliberately so. A stamp inside a hosting view is the same stamp,
-    /// left by the same proxy, and it was the one doing the damage.
-    ///
-    /// ## Topics
-    ///
-    /// ### Cases
-    /// - ``swiftUIHosted``
-    /// - ``scytherChrome``
-    /// - ``foreign``
-    ///
-    /// ### Deciding
-    /// - ``isScythers``
-    internal enum ViewRole {
-        /// A view SwiftUI hosts for Scyther: the hosting view of a presented screen, and
-        /// everything the proxy stamped inside it — the collection view backing a `List`, its
-        /// cells, and whatever else was created while the mode was on.
-        ///
-        /// Cleared, never forced. The distinction is the whole of what went wrong on this
-        /// feature: *setting* `.forceRightToLeft` on a hosted view while SwiftUI's environment
-        /// says left-to-right makes UIKit mirror content SwiftUI has already laid out, which
-        /// renders text backwards — `Fonts` as `stnoF`. *Removing* that stamp is the repair for
-        /// exactly that mismatch, which is why this walk only ever writes `.unspecified`.
-        case swiftUIHosted
-
-        /// Scyther's own UIKit chrome: its overlays, and the containers around a screen it
-        /// presents.
-        case scytherChrome
-
-        /// A view belonging to the app being debugged.
-        ///
-        /// Read to find Scyther's own, never written to. Its direction is the appearance proxy's
-        /// business and the next launch's.
-        case foreign
-
-        /// Whether a `.forceRightToLeft` stamp on a view with this role is Scyther's to remove.
-        internal var isScythers: Bool { self != .foreign }
-    }
-
-    /// Which of the three a view is.
-    ///
-    /// Answered from the *responder chain* rather than from the view's class, because Scyther's
-    /// screens are SwiftUI: the view a screen hangs off is `_UIHostingView`, a private type that
-    /// names Scyther nowhere, and the views inside it are private types too. What can be asked is
-    /// which controller the view ultimately belongs to.
-    ///
-    /// The climb does not stop at the first controller it meets, and that matters. SwiftUI puts
-    /// container view controllers of its own inside a hosting controller — a `List` is backed by
-    /// one — so a cell's nearest controller is a private SwiftUI type that is neither Scyther's
-    /// nor contains anything of Scyther's. Stopping there classified every row of the menu as the
-    /// app's and left the stamps that were reversing their text in place. Climbing on reaches the
-    /// ``ScytherHostingController`` above it.
-    ///
-    /// The three tests, in the order they are asked:
-    ///
-    /// - `isScytherOwnedType(_:)` — the same rule the accessibility audit uses, shared rather than
-    ///   restated — recognises the overlays Scyther installs straight into the app's key window,
-    ///   which have no controller at all and can only be known by class.
-    /// - A ``ScytherPresentedUI`` anywhere up the chain means SwiftUI is hosting this view for
-    ///   Scyther.
-    /// - ``ScytherPresentation/containsScytherUI(_:)`` recognises the chrome around a presented
-    ///   screen. `Scyther.showMenu(from:)` presents a stock `UINavigationController` whose child
-    ///   is the ``ScytherHostingController``, so the navigation bar's owning controller is a UIKit
-    ///   container and only its children give it away.
-    ///
-    /// The climb stops when the chain leaves views and controllers — at a `UIWindowScene`, and
-    /// beyond it `UIApplication` and the app's delegate. Those belong to the app and may be named
-    /// anything at all, which is the same boundary ``AuditNode`` draws for the same reason.
-    ///
-    /// - Parameter view: The view to classify.
-    /// - Returns: The view's role.
-    internal static func role(of view: UIView) -> ViewRole {
-        if isScytherOwnedType(view) { return .scytherChrome }
-        var responder: UIResponder? = view.next
-        var steps = 0
-        var chrome = false
-        while let current = responder, steps < maximumResponderSteps {
-            if let controller = current as? UIViewController {
-                if controller is ScytherPresentedUI { return .swiftUIHosted }
-                if ScytherPresentation.containsScytherUI(controller) { chrome = true }
-            } else if !(current is UIView) {
-                break
-            }
-            responder = current.next
-            steps += 1
-        }
-        return chrome ? .scytherChrome : .foreign
-    }
-
-    /// How far ``role(of:)`` climbs before giving up.
-    ///
-    /// A responder chain is not cyclic, so this is belt-and-braces of the same kind
-    /// ``ScytherPresentation`` and ``AuditNode`` already keep — and it costs one integer compare
-    /// per link of a walk that runs once per view on a screen.
-    private static let maximumResponderSteps = 100
 }
 #endif

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationLayout.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationLayout.swift
@@ -7,96 +7,60 @@
 
 #if !os(macOS)
 import Foundation
-import SwiftUI
 
-/// Decides the layout direction Scyther's own interface is laid out in, without switching it to an
-/// RTL language.
+/// Forces the host app's layout direction, without switching it to an RTL language.
 ///
 /// Separated from ``PseudoLocalization`` because right-to-left is not a string transformation at
-/// all: no character changes, and none of the string plumbing in this feature is involved.
+/// all: no character changes, and none of the string plumbing in this feature is involved. What it
+/// is instead is a *launch* setting — two keys in the host app's standard `UserDefaults`, read by
+/// iOS while the process starts, reaching UIKit and SwiftUI alike.
 ///
-/// Two halves, with two different timescales, and the split is the honest shape of the problem.
-/// ``layoutDirection(forcingRightToLeft:languageIdentifier:)`` decides the value ``MenuView`` and
-/// ``PseudoLocalizationView`` install as `\.layoutDirection`, which mirrors *Scyther's own
-/// interface* the instant the switch moves and un-mirrors it the instant it moves back.
-/// ``applyToHostApp(rightToLeft:isTestCase:isAppStore:systemDefaults:)`` writes the two defaults
-/// keys iOS reads at launch, which mirrors *the host app* — all of it, UIKit and SwiftUI alike —
-/// on its next launch.
+/// ## Why nothing happens until a relaunch
 ///
-/// ## What used to be here, and why it is gone
+/// This mode has been rebuilt four times, and every version that changed something mid-session
+/// corrupted the screen in the same way. The record is short and worth keeping:
 ///
-/// A third mechanism used to set `UIView.appearance().semanticContentAttribute`. It is deleted,
-/// and the reasoning is worth keeping so it is not reintroduced.
+/// 1. `UIView.appearance().semanticContentAttribute` stamps a view once, as the view joins a
+///    window, and never revisits it — so switching the mode off could not undo the views already
+///    stamped, and it never reached a SwiftUI view at all.
+/// 2. Three attempts to clear those stamps afterwards each left Scyther's menu rendering its
+///    labels backwards — `Fonts` as `stnoF` — while every unit test passed, because an attribute
+///    holding the value a test asked for says nothing about whether the screen is legible.
+/// 3. Writing these two defaults keys fixed the reach but not the timing. They apply to UIKit's
+///    text rendering *live*, so switching on agreed with the SwiftUI environment value Scyther
+///    installed in its own views and looked right — while removing them does **not** un-apply
+///    live, so switching off left UIKit right-to-left under an environment that had flipped back,
+///    and the labels reversed again.
 ///
-/// The appearance proxy does not govern a view, it *stamps* one: the value is copied onto each
-/// view as the view joins a window and is never revisited, so setting the proxy back cannot undo a
-/// view that already exists. Everything built while the mode was on kept forcing right-to-left
-/// after the mode was switched off — including the views inside Scyther's own menu — and a
-/// leftover stamp does not merely mirror a layout. It *disagrees* with the SwiftUI environment
-/// around it, and UIKit answers a disagreement by mirroring content SwiftUI has already laid out
-/// the other way, which is text drawn backwards: `Fonts` rendered as `stnoF`.
+/// One thing is common to all three: a *disagreement*, inside one session, between something that
+/// changed immediately and something that did not. UIKit answers that disagreement by mirroring
+/// content that has already been laid out the other way, which is text drawn backwards.
 ///
-/// Three attempts were made to clean up after the stamp — reset the windows, reset the views
-/// Scyther owns, reset the views inside its hosting views — and every one left the menu unreadable
-/// on a device while every unit test passed, because an attribute holding the value a test asked
-/// for is not evidence that the screen is legible. The residue cannot be chased to zero either: a
-/// recycled cell that is off-screen when the switch moves carries its stamp back on with it.
+/// So nothing changes mid-session. The keys are written or removed when the switch moves, and no
+/// surface — the host app's, or Scyther's own menu and page — is asked to move with them. At the
+/// next launch every surface reads the same keys and agrees by construction, which was measured on
+/// a device in both directions: relaunched with the keys present the app is mirrored and readable,
+/// relaunched with them absent it is left-to-right and readable.
 ///
-/// It also never reached a SwiftUI host app at all, so what it cost in corruption it did not even
-/// buy in coverage. Nothing is stamped any more, nothing needs unstamping, and the mismatch that
-/// reversed the glyphs cannot occur in either direction.
+/// That is also exactly how Xcode's own **Edit Scheme → Run → Options → App Language → Right to
+/// Left Pseudolanguage** behaves, which is where these keys come from. A developer who already
+/// knows that option will find nothing surprising here.
 ///
-/// ## Why the defaults keys instead
+/// The cost is the immediate feedback, and it is worth paying. An unreadable debug menu is a worse
+/// failure than a relaunch, and every attempt to avoid the relaunch produced the same corruption
+/// by a different route.
 ///
-/// Because they do the thing the proxy could not: they are resolved at launch, before any view
-/// exists, and they reach **both** frameworks. `AppleTextDirection` and
-/// `NSForceRightToLeftWritingDirection` are what Xcode's own **Edit Scheme → Run → Options → App
-/// Language → Right to Left Pseudolanguage** passes on the command line, and writing them into the
-/// host's standard `UserDefaults` is the same move ``LanguageOverride`` already makes with
-/// `AppleLanguages` — an established pattern in this package rather than a new liberty.
-///
-/// The trade is timing, and it is stated on the toggle rather than buried here: Scyther's own UI
-/// changes now, the developer's app changes on its next launch. An asymmetry nobody explains is a
-/// bug report.
+/// The one thing Scyther's interface still does immediately is follow a *language* override's
+/// direction, which is a different input with no launch-time half to disagree with — see
+/// ``LanguageOverride/layoutDirection(forLanguage:)``.
 ///
 /// ## Topics
-///
-/// ### Deciding
-/// - ``layoutDirection(forcingRightToLeft:languageIdentifier:)``
 ///
 /// ### Reaching the host app
 /// - ``applyToHostApp(rightToLeft:isTestCase:isAppStore:systemDefaults:)``
 /// - ``textDirectionDefaultsKey``
 /// - ``forceRightToLeftDefaultsKey``
 internal enum PseudoLocalizationLayout {
-    /// The layout direction Scyther's own SwiftUI interface should be laid out in.
-    ///
-    /// SwiftUI takes its direction from the environment, so the value has to be *decided* where
-    /// the environment is installed rather than *forced onto* a view that has already been built.
-    /// That is why this is the half that has been correct since the first version, while the one
-    /// that tried to force an attribute onto existing views never was.
-    ///
-    /// The forced mode wins over the language. That ordering is the point — a developer switching
-    /// the mode on is asking to see the layout mirrored *without* changing language, and a
-    /// language-derived direction that quietly overruled them is exactly the bug this replaced.
-    /// With the mode off the language decides, as it did before, so an Arabic override still lays
-    /// the menu out right to left on its own.
-    ///
-    /// - Parameters:
-    ///   - forcingRightToLeft: Whether ``PseudoLocalizationMode/rightToLeft`` is switched on.
-    ///   - languageIdentifier: The identifier of the language Scyther is rendering in, from
-    ///     ``LanguageOverride/namingLocale``.
-    /// - Returns: The direction to install as `\.layoutDirection`.
-    internal static func layoutDirection(
-        forcingRightToLeft: Bool,
-        languageIdentifier: String
-    ) -> LayoutDirection {
-        if forcingRightToLeft { return .rightToLeft }
-        return Locale.Language(identifier: languageIdentifier).characterDirection == .rightToLeft
-            ? .rightToLeft
-            : .leftToRight
-    }
-
     /// The standard-defaults key iOS reads at launch to decide the app's text direction.
     ///
     /// Undocumented as a defaults key — Xcode passes it as the launch argument

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationLayout.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationLayout.swift
@@ -77,17 +77,28 @@ import UIKit
 /// way too, and usefully: a view set back to `.unspecified` lays out left-to-right even while its
 /// superview is still forced right-to-left, so only the views that were stamped have to be found.
 ///
-/// ``applyToOwnedViews(rightToLeft:in:)`` is the answer, and it is deliberately narrow. Scyther
-/// resets the views *Scyther owns* — its menu, everything presented from it, and its overlays —
-/// because those it is entitled to reach into. The host app's views are left to the proxy and the
-/// next launch, exactly as documented, and the walk reads them only to find its own.
+/// ``clearForcedDirection(in:)`` is the answer, and it is narrow in three ways at once. It runs on
+/// the way *off* only; it writes only `.unspecified`, and only to a view that currently reads
+/// `.forceRightToLeft`; and it never touches a view SwiftUI hosts.
+///
+/// ## Why it does nothing on the way on
+///
+/// Because forcing the attribute onto Scyther's own views broke the rendering, which is worth
+/// recording precisely. Switching the mode on already worked through the environment half, and
+/// adding the UIKit half to the same views gave them two signals saying the same thing. A hosting
+/// view told to force a direction mirrors what it *renders* rather than reordering what it lays
+/// out, so the menu came back with every label reversed glyph by glyph — `Fonts` drawn as `stnoF`
+/// — while every unit test still passed, because the attribute values were exactly what the tests
+/// asked for. An attribute being set is not evidence that the result is readable. Switching on is
+/// therefore left entirely to the environment half, which is where it always worked.
 ///
 /// Testing ``apply(rightToLeft:allowed:)`` itself is honest only up to a point, and the point is
 /// `UIView.appearance()`: it is process-wide state with no reliable way to read the applied value
 /// back, and `ScytherTests` has no host app whose windows could be inspected. It is therefore
-/// driven only through ``attribute(rightToLeft:)`` and ``applyToOwnedViews(rightToLeft:in:)``,
-/// which are pure enough to be tested against a hierarchy built by hand — which is what the view
-/// walk is tested against.
+/// driven only through ``attribute(rightToLeft:)`` and ``clearForcedDirection(in:)``, which are
+/// pure enough to be tested against a hierarchy built by hand. What those tests can prove is
+/// bounded, and this file has now been the proof: they can say which attribute a view carries;
+/// they cannot say what the screen looks like.
 ///
 /// ## Topics
 ///
@@ -97,8 +108,9 @@ import UIKit
 ///
 /// ### Applying
 /// - ``apply(rightToLeft:allowed:)``
-/// - ``applyToOwnedViews(rightToLeft:in:)``
-/// - ``isScytherOwned(_:)``
+/// - ``clearForcedDirection(in:)``
+/// - ``role(of:)``
+/// - ``ViewRole``
 @MainActor
 internal enum PseudoLocalizationLayout {
     /// The layout direction Scyther's own SwiftUI interface should be laid out in.
@@ -154,10 +166,12 @@ internal enum PseudoLocalizationLayout {
     /// its environment, seeded when its hosting view was built, and nothing here reaches back into
     /// it.
     ///
-    /// It then hands off to ``applyToOwnedViews(rightToLeft:in:)`` for the views Scyther itself
-    /// owns, which the proxy cannot help with in either direction — it stamps a view once, as the
-    /// view joins a window, and never revisits it. Nothing about the host app changes because of
-    /// that step.
+    /// On the way *off* it then hands to ``clearForcedDirection(in:)``, which takes the proxy's
+    /// stamp back off the UIKit chrome Scyther owns — the proxy cannot do that itself, since it
+    /// stamps a view once as the view joins a window and never revisits it. There is no matching
+    /// step on the way on: forcing the attribute onto Scyther's own views is what made a hosting
+    /// view mirror its rendered text, and the environment half already flips Scyther's interface
+    /// the moment the switch moves. Nothing about the host app changes because of either.
     ///
     /// A relaunch makes the UIKit half complete but no more than that.
     /// ``PseudoLocalization/setup()`` sets the proxy from `Scyther.start(allowProductionBuilds:)`,
@@ -196,112 +210,147 @@ internal enum PseudoLocalizationLayout {
                 windows.append(window)
             }
         }
-        applyToOwnedViews(rightToLeft: rightToLeft, in: windows)
+        guard !rightToLeft else { return }
+        clearForcedDirection(in: windows)
     }
 
-    /// Puts the views *Scyther* owns into the direction the mode now calls for, instead of waiting
-    /// for them to be built again.
+    /// Clears the forced direction the appearance proxy stamped onto Scyther's own UIKit chrome
+    /// while the mode was on.
     ///
-    /// This is the half of the UIKit story the proxy cannot do, in either direction. Off is the
-    /// case that shipped broken — a mirrored menu that stayed mirrored for the rest of the session
-    /// — and on had the same weakness wearing better clothes: it happened to look right only
-    /// because a developer switching it on usually navigates somewhere afterwards, and the views
-    /// they arrive at are new. Both directions now go through here, so both behave the same and
-    /// neither depends on when a view happened to be created.
+    /// ## Why only this direction, and only a clear
     ///
-    /// The walk descends from `roots`, and the only views it *writes* to are Scyther's own: a
-    /// subtree recognised by ``isScytherOwned(_:)`` is stamped whole and not descended into again,
-    /// and everything else is passed over and its subviews examined instead. The host app's views
-    /// are read to find Scyther's and never written, which is the line this feature draws
-    /// everywhere else too: the app's UIKit views mirror through the appearance proxy on their next
-    /// launch, and its SwiftUI views not at all.
+    /// The two directions are not symmetric, and an earlier attempt to make them symmetric was
+    /// worse than the bug it replaced. Switching the mode **on** already works, through the
+    /// `\.layoutDirection` environment value ``MenuView`` and ``PseudoLocalizationView`` install:
+    /// Scyther's interface mirrors the instant the switch moves and its text stays readable.
+    /// Forcing `.forceRightToLeft` onto Scyther's view tree as well added a second, contradictory
+    /// signal to the same views, and a hosting view told to force a direction mirrors what it
+    /// *renders* rather than reordering what it lays out: on a device the menu came back with
+    /// every label reversed glyph by glyph — `Fonts` as `stnoF` — which no assertion about an
+    /// attribute value can detect. So nothing here forces anything on. Switching on is left
+    /// entirely to the environment half.
     ///
-    /// Each stamped view is marked for layout and each owned root is laid out immediately, because
-    /// the point of the fix is that the screen the developer is looking at changes *now*. Without
-    /// the forced pass the attribute would sit correct-but-unrendered until something else
-    /// invalidated the layout, which on a menu nobody is scrolling is indefinitely.
+    /// Switching **off** is the half that genuinely needed fixing, because the proxy cannot undo
+    /// itself: it stamps `.forceRightToLeft` onto each view as the view joins a window and never
+    /// revisits it, so views built while the mode was on stay mirrored for the rest of the session.
+    /// The narrowest repair is to take the stamp back off, which is what this does — write
+    /// `.unspecified` to a view that currently reads `.forceRightToLeft`, and nothing else. A view
+    /// holding any other value was never stamped by this feature and is left exactly as it is.
     ///
-    /// Cost is a full descent of the window's view tree with a responder climb per view, which is
-    /// far too much to do per frame and entirely fine here: it runs when a switch moves, and the
-    /// alternative — tracking every view Scyther creates — would be a registry to keep correct
-    /// forever in exchange for microseconds nobody is waiting on.
+    /// ## What it does not touch
+    ///
+    /// Anything SwiftUI hosts. The descent stops at the root view of a ``ScytherPresentedUI``
+    /// controller — the hosting view of every screen Scyther presents — and neither clears it nor
+    /// looks below it. The environment half already governs what SwiftUI draws there, and the
+    /// evidence that reaching into it is dangerous is the reversed text above. What is left for
+    /// this to correct is exactly the UIKit chrome *around* that view: the navigation controller
+    /// Scyther's menu is presented in, its navigation bar, and the overlays Scyther installs
+    /// straight into the app's key window.
+    ///
+    /// The host app's views are read to find Scyther's and never written, in either direction. Its
+    /// UIKit views still mirror on the next launch and un-mirror on the one after, through the
+    /// proxy alone, and its SwiftUI views still never.
+    ///
+    /// Cost is a descent of the window's view tree with a responder climb per view. Far too much
+    /// per frame, entirely fine when a switch moves.
     ///
     /// Carries no production guard of its own, unlike ``apply(rightToLeft:allowed:)``: it writes
     /// only to views Scyther owns, which on an App Store build do not exist, and its caller has
     /// already refused. Not carrying one is also what makes it testable — the XCTest half of that
-    /// guard would otherwise make every test below assert that nothing happened.
+    /// guard would otherwise make every test of it assert that nothing happened.
     ///
-    /// - Parameters:
-    ///   - rightToLeft: Whether right-to-left is being forced.
-    ///   - roots: The views to descend from. In production the app's windows; in a test, a
-    ///     hierarchy built by hand.
-    internal static func applyToOwnedViews(rightToLeft: Bool, in roots: [UIView]) {
-        let attribute = attribute(rightToLeft: rightToLeft)
+    /// - Parameter roots: The views to descend from. In production the app's windows; in a test, a
+    ///   hierarchy built by hand.
+    internal static func clearForcedDirection(in roots: [UIView]) {
         for root in roots {
-            applyToOwnedSubtrees(of: root, attribute: attribute)
+            clearForcedDirection(below: root)
+            root.layoutIfNeeded()
         }
     }
 
-    /// Finds Scyther's own subtrees below `view` and stamps them.
+    /// Clears `view` if it qualifies, then examines its subviews.
     ///
-    /// Stops descending the moment it finds one, because everything inside a view of Scyther's is
-    /// Scyther's too and asking again per descendant would be the same answer bought at the price
-    /// of a responder climb each time.
+    /// Every view is asked individually rather than a subtree being cleared wholesale once its
+    /// root qualifies. That is the difference between undoing a stamp and applying one: the walk
+    /// must be able to leave a view alone, and a subtree sweep cannot, since it would also write
+    /// to views that were never stamped and to the hosting view it is supposed to stop at.
     ///
-    /// - Parameters:
-    ///   - view: The view to examine.
-    ///   - attribute: The attribute to stamp onto anything owned.
-    private static func applyToOwnedSubtrees(of view: UIView, attribute: UISemanticContentAttribute) {
-        if isScytherOwned(view) {
-            stamp(view, with: attribute)
-            view.layoutIfNeeded()
+    /// - Parameter view: The view to examine.
+    private static func clearForcedDirection(below view: UIView) {
+        switch role(of: view) {
+        case .swiftUIHosted:
             return
+        case .scytherChrome:
+            if view.semanticContentAttribute == .forceRightToLeft {
+                view.semanticContentAttribute = .unspecified
+                view.setNeedsLayout()
+            }
+        case .foreign:
+            break
         }
         for subview in view.subviews {
-            applyToOwnedSubtrees(of: subview, attribute: attribute)
+            clearForcedDirection(below: subview)
         }
     }
 
-    /// Sets `attribute` on `view` and everything below it.
+    /// What a view is, as far as clearing a forced direction is concerned.
     ///
-    /// Every descendant, not just the root, because the stamp the appearance proxy leaves is on
-    /// each view individually rather than inherited: a subtree whose root alone was reset would
-    /// keep every mirrored label, button and image view it already had.
+    /// ## Topics
     ///
-    /// - Parameters:
-    ///   - view: The root of the subtree to stamp.
-    ///   - attribute: The attribute to apply.
-    private static func stamp(_ view: UIView, with attribute: UISemanticContentAttribute) {
-        view.semanticContentAttribute = attribute
-        view.setNeedsLayout()
-        for subview in view.subviews {
-            stamp(subview, with: attribute)
-        }
+    /// ### Cases
+    /// - ``swiftUIHosted``
+    /// - ``scytherChrome``
+    /// - ``foreign``
+    internal enum ViewRole {
+        /// A view SwiftUI hosts for Scyther, and everything below it.
+        ///
+        /// Never written to and never descended into. What SwiftUI draws inside a hosting view is
+        /// governed by the `\.layoutDirection` environment value ``MenuView`` and
+        /// ``PseudoLocalizationView`` install, and the one time this walk reached in and set an
+        /// attribute there the menu came back with its text reversed glyph by glyph.
+        case swiftUIHosted
+
+        /// Scyther's own UIKit chrome: its overlays, and the containers around a screen it
+        /// presents.
+        ///
+        /// The only views a `.forceRightToLeft` stamp is Scyther's to remove.
+        case scytherChrome
+
+        /// A view belonging to the app being debugged.
+        ///
+        /// Read to find Scyther's own, never written to. Its direction is the appearance proxy's
+        /// business and the next launch's.
+        case foreign
     }
 
-    /// Whether a view belongs to Scyther rather than to the app being debugged.
+    /// Which of the three a view is.
     ///
-    /// Two questions, because Scyther's UI arrives on screen two ways. `isScytherOwnedType(_:)` —
-    /// the same rule the accessibility audit uses, deliberately shared rather than restated —
-    /// catches the overlays Scyther installs straight into the app's key window, which are its own
-    /// classes and have no view controller. The controller question catches everything Scyther
-    /// *presents*, whose views are SwiftUI's `_UIHostingView` and name Scyther nowhere; they are
-    /// recognised by the controller that owns them instead.
+    /// Asked once per view and answered from the *owning controller* rather than the view's class,
+    /// because Scyther's presented screens are SwiftUI: the view a screen hangs off is
+    /// `_UIHostingView`, a private type that names Scyther nowhere, so a class test could never
+    /// find it. The controller can be asked instead, and is.
     ///
-    /// Ownership is asked of the controller through ``ScytherPresentation/containsScytherUI(_:)``
-    /// rather than by testing it against ``ScytherPresentedUI`` directly, and that is what makes
-    /// the menu's navigation bar come with it: `Scyther.showMenu(from:)` presents a stock
-    /// `UINavigationController` whose child is the ``ScytherHostingController``, so the navigation
-    /// bar's owning controller is a UIKit container and only its children give it away. A
-    /// navigation bar left mirrored above an un-mirrored list would be a half-fix a developer
-    /// would report as the same bug.
+    /// The order of the three tests is the whole rule:
     ///
-    /// - Parameter view: The view to test.
-    /// - Returns: `true` when the view is Scyther's own.
-    internal static func isScytherOwned(_ view: UIView) -> Bool {
-        if isScytherOwnedType(view) { return true }
-        guard let controller = owningController(of: view) else { return false }
-        return ScytherPresentation.containsScytherUI(controller)
+    /// - A ``ScytherPresentedUI`` owner means SwiftUI is hosting this view for Scyther, and the
+    ///   answer is ``ViewRole/swiftUIHosted`` before anything else is considered.
+    /// - `isScytherOwnedType(_:)` — the same rule the accessibility audit uses, shared rather than
+    ///   restated — recognises the overlays Scyther installs straight into the app's key window,
+    ///   which have no controller at all and can only be known by class.
+    /// - ``ScytherPresentation/containsScytherUI(_:)`` recognises the chrome around a presented
+    ///   screen. `Scyther.showMenu(from:)` presents a stock `UINavigationController` whose child
+    ///   is the ``ScytherHostingController``, so the navigation bar's owning controller is a UIKit
+    ///   container and only its children give it away. A navigation bar left mirrored above a
+    ///   correctly laid-out menu is the same bug reported again.
+    ///
+    /// - Parameter view: The view to classify.
+    /// - Returns: The view's role.
+    internal static func role(of view: UIView) -> ViewRole {
+        let controller = owningController(of: view)
+        if controller is ScytherPresentedUI { return .swiftUIHosted }
+        if isScytherOwnedType(view) { return .scytherChrome }
+        guard let controller, ScytherPresentation.containsScytherUI(controller) else { return .foreign }
+        return .scytherChrome
     }
 
     /// How far ``owningController(of:)`` climbs before giving up.

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationMode.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationMode.swift
@@ -9,8 +9,8 @@ import Foundation
 
 /// The pseudo-localisation behaviours currently switched on, as one value.
 ///
-/// Modelled as an `OptionSet` rather than four loose `Bool`s because every consumer cares about
-/// the *combination*: ``PseudoLocalizationTransform`` needs to know the order to apply them in,
+/// Modelled as an `OptionSet` rather than a handful of loose `Bool`s because every consumer cares
+/// about the *combination*: ``PseudoLocalizationTransform`` needs to know the order to apply them in,
 /// ``PseudoLocalization`` needs to know whether *any* text mode is on before it installs a hook
 /// into the host app, and ``localized(_:comment:override:)`` needs a single cheap emptiness check
 /// on the hot path where every string in Scyther's UI is resolved.
@@ -25,6 +25,9 @@ import Foundation
 /// - ``lengthened``
 /// - ``rightToLeft``
 /// - ``showsKeys``
+///
+/// ### Presentation
+/// - ``showsBoundaries``
 ///
 /// ### Grouping
 /// - ``textAffecting``
@@ -73,11 +76,32 @@ struct PseudoLocalizationMode: OptionSet, Sendable, Hashable {
     /// fastest way to spot a key that resolved to the wrong entry entirely.
     static let showsKeys = PseudoLocalizationMode(rawValue: 1 << 3)
 
+    /// Keeps the `[` and `]` that mark where a transformed string starts and ends.
+    ///
+    /// The odd one out, and deliberately so: it transforms nothing by itself and switches nothing
+    /// on. It is a setting *about* the other modes — the only delimiters pseudo-localisation
+    /// produces are the ones ``lengthened`` puts around a padded string, and this decides whether
+    /// they are drawn. With no text mode on it therefore does nothing at all, which
+    /// ``PseudoLocalizationTransform/apply(to:key:modes:)`` gets for free from the guard it
+    /// already had.
+    ///
+    /// Not part of ``textAffecting`` for the same reason ``rightToLeft`` is not: that set decides
+    /// whether the hook into the host app's string loading is worth installing, and a mode that
+    /// only changes how another mode renders must never install it on its own.
+    ///
+    /// It is also the one mode that is on unless a developer has turned it off. The brackets are
+    /// the diagnostic rather than decoration — the padding dots say a string grew, but only the
+    /// closing bracket says whether the end of it was cut off — so the default keeps them and the
+    /// switch exists for the developer who has seen enough of them.
+    static let showsBoundaries = PseudoLocalizationMode(rawValue: 1 << 4)
+
     /// The modes that change the characters of a string, as opposed to the direction it is laid
     /// out in.
     ///
     /// The distinction is load-bearing: the hook into the host app's string loading is worth
-    /// installing only when one of these is on, and ``PseudoLocalizationMode/rightToLeft`` alone
-    /// must not install it.
+    /// installing only when one of these is on, and neither ``PseudoLocalizationMode/rightToLeft``
+    /// nor ``PseudoLocalizationMode/showsBoundaries`` alone must install it — the first changes a
+    /// layout attribute rather than a string, and the second only decides how one of these three
+    /// renders.
     static let textAffecting: PseudoLocalizationMode = [.accented, .lengthened, .showsKeys]
 }

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationMode.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationMode.swift
@@ -63,10 +63,10 @@ struct PseudoLocalizationMode: OptionSet, Sendable, Hashable {
     /// mirrored. Unlike the other three this changes no text at all, so it is deliberately not
     /// part of ``textAffecting``.
     ///
-    /// Its reach is also unlike the other three, and narrower than it first appears: Scyther's own
-    /// interface immediately, the host app's UIKit views on the next launch, and the host app's
-    /// SwiftUI views never. ``PseudoLocalizationLayout`` explains why and what the alternative
-    /// would cost.
+    /// Its reach is also unlike the other three, and narrower than it first appears: it mirrors
+    /// **Scyther's own interface only**, immediately, in both directions, and does not affect the
+    /// host app at all. ``PseudoLocalizationLayout`` explains why reaching further was tried and
+    /// deleted, and what a developer should use instead.
     static let rightToLeft = PseudoLocalizationMode(rawValue: 1 << 2)
 
     /// Renders the catalog key in place of its translation.

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationMode.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationMode.swift
@@ -63,10 +63,10 @@ struct PseudoLocalizationMode: OptionSet, Sendable, Hashable {
     /// mirrored. Unlike the other three this changes no text at all, so it is deliberately not
     /// part of ``textAffecting``.
     ///
-    /// Its reach is also unlike the other three, and narrower than it first appears: it mirrors
-    /// **Scyther's own interface only**, immediately, in both directions, and does not affect the
-    /// host app at all. ``PseudoLocalizationLayout`` explains why reaching further was tried and
-    /// deleted, and what a developer should use instead.
+    /// Its timing is also unlike the other three: it takes effect on the app's **next launch**,
+    /// across the whole process — the host app and Scyther's own menu alike — and nothing changes
+    /// in the session where the switch moves. ``PseudoLocalizationLayout`` explains why every
+    /// attempt at making it immediate corrupted the screen instead.
     static let rightToLeft = PseudoLocalizationMode(rawValue: 1 << 2)
 
     /// Renders the catalog key in place of its translation.

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationTransform.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationTransform.swift
@@ -21,7 +21,7 @@ import Foundation
 ///
 /// ### Individual transformations
 /// - ``accentuate(_:)``
-/// - ``lengthen(_:)``
+/// - ``lengthen(_:showingBoundaries:)``
 ///
 /// ### Tuning
 /// - ``expansionFactor``
@@ -46,14 +46,18 @@ enum PseudoLocalizationTransform {
     /// read as real words and make it hard to tell padding from copy at a glance.
     static let paddingCharacter: Character = "·"
 
-    /// Marks the start of a lengthened string.
+    /// Marks the start of a lengthened string, when
+    /// ``PseudoLocalizationMode/showsBoundaries`` is on.
     static let openingDelimiter: Character = "["
 
-    /// Marks the end of a lengthened string.
+    /// Marks the end of a lengthened string, when ``PseudoLocalizationMode/showsBoundaries`` is on.
     ///
     /// The delimiters are the actual diagnostic: a missing closing bracket means the label was
     /// truncated, which is far easier to spot in a screenshot than judging whether some accented
-    /// text looks a few characters short.
+    /// text looks a few characters short. That is why they are on by default — and why they are a
+    /// switch rather than a certainty, since a developer who has read a hundred bracketed labels
+    /// and only wants to see the expansion should not have to give up lengthening to stop seeing
+    /// them.
     static let closingDelimiter: Character = "]"
 
     // MARK: - Applying
@@ -72,6 +76,11 @@ enum PseudoLocalizationTransform {
     ///   read past.
     /// - ``PseudoLocalizationMode/rightToLeft`` is ignored here entirely: it is a layout
     ///   attribute applied by ``PseudoLocalizationLayout``, not a property of any string.
+    /// - ``PseudoLocalizationMode/showsBoundaries`` switches nothing on. It reaches only
+    ///   ``lengthen(_:showingBoundaries:)``, because the brackets that mode governs are the only
+    ///   delimiters anything here produces, and the guard on the first line means it cannot do
+    ///   anything at all unless a text mode is already on. That is the whole of its behaviour:
+    ///   with every text mode off, the string comes back untouched whichever way it is set.
     ///
     /// A string carrying plural configuration is returned untouched whatever the modes say — see
     /// ``carriesPluralConfiguration(_:)``. That refusal cannot live in ``accentuate(_:)`` alone,
@@ -91,7 +100,9 @@ enum PseudoLocalizationTransform {
 
         var result = value
         if modes.contains(.accented) { result = accentuate(result) }
-        if modes.contains(.lengthened) { result = lengthen(result) }
+        if modes.contains(.lengthened) {
+            result = lengthen(result, showingBoundaries: modes.contains(.showsBoundaries))
+        }
         return result
     }
 
@@ -362,7 +373,8 @@ enum PseudoLocalizationTransform {
 
     // MARK: - Lengthening
 
-    /// Pads a string to roughly ``expansionFactor`` of its length, bracketed at both ends.
+    /// Pads a string to roughly ``expansionFactor`` of its length, bracketed at both ends unless
+    /// the developer has switched the brackets off.
     ///
     /// The brackets are counted towards the target rather than added on top of it, so the result
     /// really is about 135% and not 135% plus two. They cost the padding two characters, which
@@ -371,19 +383,28 @@ enum PseudoLocalizationTransform {
     /// bracket that fits is worth more than an exact ratio, because it is the bracket, not the
     /// length, that tells the developer whether the label was clipped.
     ///
+    /// Without them the two characters go back to the padding rather than being lost, so both
+    /// forms expand a string by the same amount and a layout that survives one survives the other.
+    /// What is given up is the diagnostic: a padded label with no closing bracket is a label that
+    /// grew, and there is no longer any way to tell from it whether the end was cut off. That is
+    /// the trade the switch exists to offer, and the reason it ships on.
+    ///
     /// An empty string is returned untouched. Bracketing nothing would turn every blank
     /// accessibility value and every empty placeholder into a visible `[]`, which reads as a
     /// rendering bug rather than as a measurement.
     ///
-    /// - Parameter value: The string to pad.
-    /// - Returns: The padded, bracketed string.
-    static func lengthen(_ value: String) -> String {
+    /// - Parameters:
+    ///   - value: The string to pad.
+    ///   - showingBoundaries: Whether to mark the ends with ``openingDelimiter`` and
+    ///     ``closingDelimiter``.
+    /// - Returns: The padded string.
+    static func lengthen(_ value: String, showingBoundaries: Bool = true) -> String {
         guard !value.isEmpty else { return value }
         let target = Int((Double(value.count) * expansionFactor).rounded())
-        let padding = max(0, target - value.count - 2)
-        return String(openingDelimiter)
-            + value
-            + String(repeating: String(paddingCharacter), count: padding)
-            + String(closingDelimiter)
+        let delimiters = showingBoundaries ? 2 : 0
+        let padding = max(0, target - value.count - delimiters)
+        let body = value + String(repeating: String(paddingCharacter), count: padding)
+        guard showingBoundaries else { return body }
+        return String(openingDelimiter) + body + String(closingDelimiter)
     }
 }

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationView.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationView.swift
@@ -12,6 +12,11 @@ import SwiftUI
 /// Four stock `Toggle`s in one `Section`, a fifth in a section of its own, a live sample of the
 /// transformation, and a button that switches everything off.
 ///
+/// Right to Left raises the same **Relaunch required** alert ``LanguageView`` raises, reusing its
+/// title, its buttons and its ``ViewModel/quitApp()`` route so the two settings that only apply at
+/// launch behave identically. Only the message differs: the language page can say Scyther's menu
+/// has already switched, and this one cannot, because nothing changes here until a relaunch.
+///
 /// The fifth is separated deliberately. ``PseudoLocalizationMode/showsBoundaries`` is not a peer of
 /// the other four — it switches nothing on, it changes how one of them renders, and it is the only
 /// one that ships on — so listing it as a fifth equal would invite a developer to flick it looking
@@ -24,12 +29,10 @@ import SwiftUI
 /// exists so the page can still show what the modes do while remaining the one place they do not
 /// apply.
 ///
-/// The exemption covers *text* only. This page installs the forced layout direction on itself, the
-/// same way ``MenuView`` does, so it mirrors along with the rest of Scyther — deliberately, since
-/// plain English reads perfectly well mirrored and insulating this one screen would misrepresent
-/// what the mode does. Installing it here as well as on ``MenuView`` is not redundant: it is what
-/// makes the page the developer is looking at flip at the moment the switch moves, rather than
-/// whenever SwiftUI next happens to hand it a fresh environment.
+/// The exemption covers *text* only. Right to Left is a next-launch setting on every surface, so
+/// this page does not flip while the switch is being flicked — and after a relaunch with the mode
+/// on it is mirrored along with the rest of the app, deliberately, since plain English reads
+/// perfectly well mirrored and insulating one screen would misrepresent what the mode does.
 struct PseudoLocalizationView: View {
     /// The view model mirroring ``PseudoLocalization``'s switches.
     @StateObject private var viewModel = PseudoLocalizationViewModel()
@@ -52,7 +55,7 @@ struct PseudoLocalizationView: View {
                 Toggle(isOn: $viewModel.rightToLeft) {
                     label(
                         localizedChrome("Right to Left"),
-                        subtitle: localizedChrome("Mirrors Scyther's interface now, and your whole app — UIKit and SwiftUI — on its next launch. Switching it off restores your app on the launch after that.")
+                        subtitle: localizedChrome("Mirrors the whole app on its next launch, to find hard-coded leading and trailing edges.")
                     )
                 }
                 Toggle(isOn: $viewModel.showsKeys) {
@@ -103,10 +106,14 @@ struct PseudoLocalizationView: View {
             }
         }
         .navigationTitle(localizedChrome("Pseudo-localisation"))
-        .environment(\.layoutDirection, PseudoLocalizationLayout.layoutDirection(
-            forcingRightToLeft: viewModel.rightToLeft,
-            languageIdentifier: LanguageOverride.shared.namingLocale.identifier
-        ))
+        .alert(localizedChrome("Relaunch required"), isPresented: $viewModel.showingRelaunchAlert) {
+            Button(localizedChrome("Later"), role: .cancel) {}
+            Button(localizedChrome("Quit App"), role: .destructive) {
+                viewModel.quitApp()
+            }
+        } message: {
+            Text(localizedChrome("Right to Left applies the next time the app launches — your app and Scyther's menu, UIKit and SwiftUI alike. Switching it off restores everything on the launch after that."))
+        }
         .onFirstAppear {
             await viewModel.onFirstAppear()
         }

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationView.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationView.swift
@@ -52,7 +52,7 @@ struct PseudoLocalizationView: View {
                 Toggle(isOn: $viewModel.rightToLeft) {
                     label(
                         localizedChrome("Right to Left"),
-                        subtitle: localizedChrome("Mirrors Scyther's interface now, and your app's UIKit views on its next launch. Your app's SwiftUI views are unaffected: Scyther cannot reach their environment.")
+                        subtitle: localizedChrome("Mirrors Scyther's interface now, and your whole app — UIKit and SwiftUI — on its next launch. Switching it off restores your app on the launch after that.")
                     )
                 }
                 Toggle(isOn: $viewModel.showsKeys) {

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationView.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationView.swift
@@ -9,8 +9,13 @@ import SwiftUI
 
 /// The settings page for pseudo-localisation.
 ///
-/// Four stock `Toggle`s in one `Section`, a live sample of the transformation, and a button that
-/// switches everything off.
+/// Four stock `Toggle`s in one `Section`, a fifth in a section of its own, a live sample of the
+/// transformation, and a button that switches everything off.
+///
+/// The fifth is separated deliberately. ``PseudoLocalizationMode/showsBoundaries`` is not a peer of
+/// the other four — it switches nothing on, it changes how one of them renders, and it is the only
+/// one that ships on — so listing it as a fifth equal would invite a developer to flick it looking
+/// for an effect and find none.
 ///
 /// Every string on this page is resolved through ``localizedChrome(_:comment:override:)`` rather
 /// than ``localized(_:comment:override:)``. That is not a stylistic choice: with "Show keys" and
@@ -63,6 +68,17 @@ struct PseudoLocalizationView: View {
             }
 
             Section {
+                Toggle(isOn: $viewModel.showsBoundaries) {
+                    label(
+                        localizedChrome("Show Boundaries"),
+                        subtitle: localizedChrome("Marks where each string starts and ends, so you can see when one has been cut off. Only shows up when another text mode is on.")
+                    )
+                }
+            } header: {
+                Text(localizedChrome("Boundaries"))
+            }
+
+            Section {
                 Text(viewModel.sampleText)
             } header: {
                 Text(localizedChrome("Sample"))
@@ -99,8 +115,8 @@ struct PseudoLocalizationView: View {
     /// A two-line switch label: title above, explanation below.
     ///
     /// Matches the rest of the menu's two-line rows rather than pushing the explanation into a
-    /// section footer, because each of the four modes needs its own explanation and four footers
-    /// would separate every switch from the sentence describing it.
+    /// section footer, because every switch on this page needs its own explanation and a footer
+    /// each would separate them from the sentences describing them.
     ///
     /// - Parameters:
     ///   - title: The mode's name.

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationViewModel.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationViewModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 /// View model backing the pseudo-localisation settings page.
 ///
-/// Mirrors the four switches on ``PseudoLocalization`` into `@Published` properties so SwiftUI can
+/// Mirrors the switches on ``PseudoLocalization`` into `@Published` properties so SwiftUI can
 /// bind to them, and writes every change straight back through `didSet` — the pattern
 /// ``GridOverlayViewModel`` uses, for the same reason: the singleton, not the view model, is the
 /// source of truth, and a mode has to take effect the instant it is switched on rather than when
@@ -41,6 +41,9 @@ import SwiftUI
 /// - ``lengthened``
 /// - ``rightToLeft``
 /// - ``showsKeys``
+///
+/// ### Presentation
+/// - ``showsBoundaries``
 ///
 /// ### Sample
 /// - ``sampleSource``
@@ -81,6 +84,18 @@ class PseudoLocalizationViewModel: ViewModel {
         }
     }
 
+    /// Whether a lengthened string keeps the brackets marking where it starts and ends.
+    ///
+    /// Seeded to `true` rather than `false` like the others, so the first render of the page — the
+    /// one drawn before ``loadSettings()`` has run — already shows the switch in the position it
+    /// ships in, rather than flicking on a moment later in front of the developer.
+    @Published var showsBoundaries: Bool = true {
+        didSet {
+            guard !isLoading else { return }
+            PseudoLocalization.instance.showsBoundaries = showsBoundaries
+        }
+    }
+
     /// Suppresses the `didSet` write-back while the published properties are being seeded.
     ///
     /// Without it, ``loadSettings()`` assigning the persisted value back into each property would
@@ -111,6 +126,7 @@ class PseudoLocalizationViewModel: ViewModel {
         if accented { modes.insert(.accented) }
         if lengthened { modes.insert(.lengthened) }
         if showsKeys { modes.insert(.showsKeys) }
+        if showsBoundaries { modes.insert(.showsBoundaries) }
         return PseudoLocalizationTransform.apply(
             to: sampleSource,
             key: "Save changes to your profile",
@@ -132,14 +148,19 @@ class PseudoLocalizationViewModel: ViewModel {
         lengthened = PseudoLocalization.instance.lengthened
         rightToLeft = PseudoLocalization.instance.rightToLeft
         showsKeys = PseudoLocalization.instance.showsKeys
+        showsBoundaries = PseudoLocalization.instance.showsBoundaries
         isLoading = false
     }
 
     /// Switches every mode off, in the singleton and in the UI.
     ///
-    /// Goes through ``PseudoLocalization/reset()`` rather than assigning `false` to the four
-    /// published properties, so the effects are torn down in one pass instead of four, and so a
-    /// mode added later cannot be left behind by a screen that forgot to clear it.
+    /// Goes through ``PseudoLocalization/reset()`` rather than assigning `false` to the published
+    /// properties, so the effects are torn down in one pass instead of one per mode, and so a mode
+    /// added later cannot be left behind by a screen that forgot to clear it.
+    ///
+    /// ``showsBoundaries`` goes back to `true` here, not `false`, because it mirrors what
+    /// ``PseudoLocalization/reset()`` has just written: the button restores the shipped state, and
+    /// the shipped state for the brackets is on.
     @MainActor
     func turnEverythingOff() {
         PseudoLocalization.instance.reset()
@@ -148,6 +169,7 @@ class PseudoLocalizationViewModel: ViewModel {
         lengthened = false
         rightToLeft = false
         showsKeys = false
+        showsBoundaries = true
         isLoading = false
     }
 }

--- a/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationViewModel.swift
+++ b/Sources/Scyther/Features/PseudoLocalization/PseudoLocalizationViewModel.swift
@@ -51,6 +51,7 @@ import SwiftUI
 ///
 /// ### Actions
 /// - ``turnEverythingOff()``
+/// - ``showingRelaunchAlert``
 class PseudoLocalizationViewModel: ViewModel {
     /// Whether letters are replaced with accented look-alikes.
     @Published var accented: Bool = false {
@@ -68,13 +69,26 @@ class PseudoLocalizationViewModel: ViewModel {
         }
     }
 
-    /// Whether the interface is forced into right-to-left layout.
+    /// Whether the app is forced into right-to-left layout on its next launch.
     @Published var rightToLeft: Bool = false {
         didSet {
             guard !isLoading else { return }
             PseudoLocalization.instance.rightToLeft = rightToLeft
+            showingRelaunchAlert = true
         }
     }
+
+    /// Whether the "Relaunch required" alert is presented.
+    ///
+    /// The same alert ``LanguageViewModel`` raises, for the same reason: a setting that iOS reads
+    /// once, while the process is starting, cannot show its effect in the session that changes it.
+    ///
+    /// Raised in **both** directions, unlike the language page's, which only raises it when a
+    /// language is chosen. Switching right-to-left off is just as invisible as switching it on —
+    /// the two keys are removed immediately and the running process goes on laying itself out the
+    /// way it launched — and a developer who switches it off and sees nothing happen has exactly
+    /// the confusion the alert exists to prevent.
+    @Published var showingRelaunchAlert: Bool = false
 
     /// Whether catalog keys are rendered in place of their translations.
     @Published var showsKeys: Bool = false {
@@ -161,8 +175,14 @@ class PseudoLocalizationViewModel: ViewModel {
     /// ``showsBoundaries`` goes back to `true` here, not `false`, because it mirrors what
     /// ``PseudoLocalization/reset()`` has just written: the button restores the shipped state, and
     /// the shipped state for the brackets is on.
+    ///
+    /// Raises the relaunch alert when right-to-left was on, since this is the other way to switch
+    /// it off — and the way most likely to be reached by someone trying to put things back. The
+    /// keys are already gone by then; what has not happened, and cannot until a relaunch, is the
+    /// app laying itself out left to right again.
     @MainActor
     func turnEverythingOff() {
+        let wasMirrored = rightToLeft
         PseudoLocalization.instance.reset()
         isLoading = true
         accented = false
@@ -171,5 +191,6 @@ class PseudoLocalizationViewModel: ViewModel {
         showsKeys = false
         showsBoundaries = true
         isLoading = false
+        if wasMirrored { showingRelaunchAlert = true }
     }
 }

--- a/Sources/Scyther/Resources/Localizable.xcstrings
+++ b/Sources/Scyther/Resources/Localizable.xcstrings
@@ -32507,79 +32507,79 @@
         }
       }
     },
-    "Mirrors Scyther's interface now, and your whole app — UIKit and SwiftUI — on its next launch. Switching it off restores your app on the launch after that.": {
+    "Mirrors the whole app on its next launch, to find hard-coded leading and trailing edges.": {
       "comment": "Subtitle for the Right to Left switch",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "يعكس واجهة Scyther فورًا، وتطبيقك بالكامل — UIKit وSwiftUI معًا — عند التشغيل التالي. وإيقافه يعيد تطبيقك إلى حالته عند التشغيل الذي يليه."
+            "value": "يعكس التطبيق بالكامل عند التشغيل التالي، لاكتشاف الحواف اليمنى واليسرى المكتوبة بشكل ثابت."
           }
         },
         "de": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Spiegelt Scythers Oberfläche sofort und deine gesamte App – UIKit wie SwiftUI – beim nächsten Start. Ausschalten stellt deine App beim übernächsten Start wieder her."
+            "value": "Spiegelt die gesamte App beim nächsten Start, um fest verdrahtete linke und rechte Kanten zu finden."
           }
         },
         "es": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Refleja la interfaz de Scyther al instante y toda tu app —UIKit y SwiftUI— en el próximo inicio. Desactivarlo la restaura en el inicio siguiente."
+            "value": "Refleja toda la app en el próximo inicio, para detectar bordes izquierdo y derecho fijados en el código."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Reflète l’interface de Scyther immédiatement, et toute votre app — UIKit comme SwiftUI — au prochain lancement. La désactiver rétablit votre app au lancement suivant."
+            "value": "Reflète toute l’app au prochain lancement, pour repérer les bords gauche et droit codés en dur."
           }
         },
         "it": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Riflette subito l’interfaccia di Scyther e tutta la tua app — UIKit e SwiftUI — al prossimo avvio. Disattivandolo, la tua app torna normale all’avvio successivo."
+            "value": "Riflette tutta l’app al prossimo avvio, per trovare bordi sinistro e destro scritti a mano."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Scyther のインターフェイスはすぐに、アプリ全体（UIKit と SwiftUI の両方）は次回起動時にミラーリングされます。オフにすると、その次の起動でアプリは元に戻ります。"
+            "value": "次回起動時にアプリ全体をミラーリングし、左右の端を直書きしている箇所を見つけます。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Scyther의 인터페이스는 즉시, 앱 전체(UIKit과 SwiftUI 모두)는 다음 실행 때 미러링됩니다. 끄면 그다음 실행에서 앱이 원래대로 돌아갑니다."
+            "value": "다음 실행 때 앱 전체를 미러링해 하드코딩된 좌우 가장자리를 찾습니다."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Spiegelt Scythers interface meteen en je hele app — UIKit én SwiftUI — bij de volgende start. Uitzetten herstelt je app bij de start daarna."
+            "value": "Spiegelt de hele app bij de volgende start, om hardgecodeerde linker- en rechterranden te vinden."
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Espelha a interface do Scyther na hora e todo o seu app — UIKit e SwiftUI — na próxima inicialização. Desativar restaura o app na inicialização seguinte."
+            "value": "Espelha o app inteiro na próxima inicialização, para achar bordas esquerda e direita fixas no código."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Зеркалит интерфейс Scyther сразу, а всё ваше приложение — и UIKit, и SwiftUI — при следующем запуске. Выключение возвращает приложение при следующем после этого запуске."
+            "value": "Зеркалит всё приложение при следующем запуске, чтобы найти жёстко заданные левый и правый края."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "立即镜像 Scyther 的界面，并在下次启动时镜像你的整个 App（UIKit 与 SwiftUI 均可）。关闭后，App 会在再下次启动时恢复。"
+            "value": "在下次启动时镜像整个 App，用于发现硬编码的左右边距。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "立即鏡像 Scyther 的介面，並在下次啟動時鏡像你的整個 App（UIKit 與 SwiftUI 皆可）。關閉後，App 會在再下次啟動時恢復。"
+            "value": "在下次啟動時鏡像整個 App，用於發現硬編碼的左右邊界。"
           }
         }
       }
@@ -48462,6 +48462,83 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "從右到左"
+          }
+        }
+      }
+    },
+    "Right to Left applies the next time the app launches — your app and Scyther's menu, UIKit and SwiftUI alike. Switching it off restores everything on the launch after that.": {
+      "comment": "Message in the Relaunch required alert raised by the Right to Left switch",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "يُطبَّق وضع «من اليمين إلى اليسار» عند التشغيل التالي للتطبيق — تطبيقك وقائمة Scyther معًا، في UIKit وSwiftUI. وإيقافه يعيد كل شيء عند التشغيل الذي يليه."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rechts-nach-links gilt ab dem nächsten Start der App – deine App wie auch Scythers Menü, UIKit wie SwiftUI. Ausschalten stellt beim übernächsten Start alles wieder her."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "De derecha a izquierda se aplica en el próximo inicio de la app: tu app y el menú de Scyther, tanto UIKit como SwiftUI. Desactivarlo lo restaura todo en el inicio siguiente."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Le mode Droite à gauche s’applique au prochain lancement de l’app — votre app comme le menu de Scyther, UIKit comme SwiftUI. Le désactiver rétablit tout au lancement suivant."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Da destra a sinistra si applica al prossimo avvio dell’app — la tua app e il menu di Scyther, sia UIKit sia SwiftUI. Disattivandolo, tutto torna normale all’avvio successivo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "右から左は次回のアプリ起動時に適用されます。あなたのアプリも Scyther のメニューも、UIKit と SwiftUI の両方が対象です。オフにすると、その次の起動ですべて元に戻ります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "오른쪽에서 왼쪽 설정은 앱을 다음에 실행할 때 적용됩니다. 사용자의 앱과 Scyther 메뉴 모두, UIKit과 SwiftUI 모두에 적용됩니다. 끄면 그다음 실행에서 모두 원래대로 돌아갑니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Rechts-naar-links geldt vanaf de volgende start van de app — je app én Scythers menu, UIKit én SwiftUI. Uitzetten herstelt alles bij de start daarna."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Da direita para a esquerda passa a valer na próxima inicialização do app — o seu app e o menu do Scyther, em UIKit e SwiftUI. Desativar restaura tudo na inicialização seguinte."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Режим «справа налево» применится при следующем запуске приложения — и к вашему приложению, и к меню Scyther, в UIKit и SwiftUI. Выключение вернёт всё при следующем после этого запуске."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "从右到左将在 App 下次启动时生效——你的 App 和 Scyther 菜单都包括在内，UIKit 与 SwiftUI 均可。关闭后，一切会在再下次启动时恢复。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "從右到左將在 App 下次啟動時生效——你的 App 與 Scyther 選單都包括在內，UIKit 與 SwiftUI 皆可。關閉後，一切會在再下次啟動時恢復。"
           }
         }
       }

--- a/Sources/Scyther/Resources/Localizable.xcstrings
+++ b/Sources/Scyther/Resources/Localizable.xcstrings
@@ -32507,79 +32507,79 @@
         }
       }
     },
-    "Mirrors Scyther's interface now, and your app's UIKit views on its next launch. Your app's SwiftUI views are unaffected: Scyther cannot reach their environment.": {
-      "comment": "Subtitle under the Right to Left switch, stating exactly which surfaces mirror and when",
+    "Mirrors Scyther's interface now, and your whole app — UIKit and SwiftUI — on its next launch. Switching it off restores your app on the launch after that.": {
+      "comment": "Subtitle for the Right to Left switch",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "يعكس واجهة Scyther الآن، ويعكس عروض UIKit في تطبيقك عند التشغيل التالي. أما عروض SwiftUI في تطبيقك فلا تتأثر: إذ لا يمكن لـ Scyther الوصول إلى بيئتها."
+            "value": "يعكس واجهة Scyther فورًا، وتطبيقك بالكامل — UIKit وSwiftUI معًا — عند التشغيل التالي. وإيقافه يعيد تطبيقك إلى حالته عند التشغيل الذي يليه."
           }
         },
         "de": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Spiegelt Scythers Oberfläche sofort und die UIKit-Views deiner App beim nächsten Start. Die SwiftUI-Views deiner App bleiben unberührt: Scyther kommt an ihre Environment nicht heran."
+            "value": "Spiegelt Scythers Oberfläche sofort und deine gesamte App – UIKit wie SwiftUI – beim nächsten Start. Ausschalten stellt deine App beim übernächsten Start wieder her."
           }
         },
         "es": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Refleja la interfaz de Scyther ahora, y las vistas UIKit de tu app en el próximo arranque. Las vistas SwiftUI de tu app no se ven afectadas: Scyther no puede acceder a su entorno."
+            "value": "Refleja la interfaz de Scyther al instante y toda tu app —UIKit y SwiftUI— en el próximo inicio. Desactivarlo la restaura en el inicio siguiente."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Met en miroir l’interface de Scyther maintenant, et les vues UIKit de votre app au prochain lancement. Les vues SwiftUI de votre app ne sont pas affectées : Scyther ne peut pas atteindre leur environnement."
+            "value": "Reflète l’interface de Scyther immédiatement, et toute votre app — UIKit comme SwiftUI — au prochain lancement. La désactiver rétablit votre app au lancement suivant."
           }
         },
         "it": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Rispecchia subito l’interfaccia di Scyther, e le view UIKit della tua app al prossimo avvio. Le view SwiftUI della tua app non sono interessate: Scyther non può raggiungere il loro environment."
+            "value": "Riflette subito l’interfaccia di Scyther e tutta la tua app — UIKit e SwiftUI — al prossimo avvio. Disattivandolo, la tua app torna normale all’avvio successivo."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "ScytherのUIは今すぐ、AppのUIKitビューは次回起動時にミラーリングされます。AppのSwiftUIビューは対象外です。Scytherはそのenvironmentに介入できません。"
+            "value": "Scyther のインターフェイスはすぐに、アプリ全体（UIKit と SwiftUI の両方）は次回起動時にミラーリングされます。オフにすると、その次の起動でアプリは元に戻ります。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Scyther 인터페이스는 지금, 앱의 UIKit 뷰는 다음 실행 시 좌우 반전됩니다. 앱의 SwiftUI 뷰는 영향을 받지 않습니다. Scyther가 그 environment에 접근할 수 없기 때문입니다."
+            "value": "Scyther의 인터페이스는 즉시, 앱 전체(UIKit과 SwiftUI 모두)는 다음 실행 때 미러링됩니다. 끄면 그다음 실행에서 앱이 원래대로 돌아갑니다."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Spiegelt Scythers interface nu, en de UIKit-views van je app bij de volgende start. De SwiftUI-views van je app blijven ongemoeid: Scyther kan hun environment niet bereiken."
+            "value": "Spiegelt Scythers interface meteen en je hele app — UIKit én SwiftUI — bij de volgende start. Uitzetten herstelt je app bij de start daarna."
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Espelha a interface do Scyther agora, e as views UIKit do seu app na próxima abertura. As views SwiftUI do seu app não são afetadas: o Scyther não alcança o environment delas."
+            "value": "Espelha a interface do Scyther na hora e todo o seu app — UIKit e SwiftUI — na próxima inicialização. Desativar restaura o app na inicialização seguinte."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "Отражает интерфейс Scyther сразу, а UIKit-представления вашего приложения — при следующем запуске. SwiftUI-представления не затрагиваются: Scyther не может добраться до их environment."
+            "value": "Зеркалит интерфейс Scyther сразу, а всё ваше приложение — и UIKit, и SwiftUI — при следующем запуске. Выключение возвращает приложение при следующем после этого запуске."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "立即镜像 Scyther 界面，你的 App 的 UIKit 视图在下次启动时生效。你的 App 的 SwiftUI 视图不受影响：Scyther 无法访问它们的 environment。"
+            "value": "立即镜像 Scyther 的界面，并在下次启动时镜像你的整个 App（UIKit 与 SwiftUI 均可）。关闭后，App 会在再下次启动时恢复。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "立即鏡像 Scyther 介面，你的 App 的 UIKit 視圖於下次啟動時生效。你的 App 的 SwiftUI 視圖不受影響：Scyther 無法存取它們的 environment。"
+            "value": "立即鏡像 Scyther 的介面，並在下次啟動時鏡像你的整個 App（UIKit 與 SwiftUI 皆可）。關閉後，App 會在再下次啟動時恢復。"
           }
         }
       }

--- a/Sources/Scyther/Resources/Localizable.xcstrings
+++ b/Sources/Scyther/Resources/Localizable.xcstrings
@@ -10599,6 +10599,83 @@
         }
       }
     },
+    "Boundaries": {
+      "comment": "Section header above the switch that keeps the brackets around a lengthened string",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "الحدود"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Begrenzungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Delimitadores"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Délimiteurs"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Delimitatori"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "区切り"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "경계"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Begrenzingen"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Delimitadores"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Границы"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "边界标记"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "邊界標記"
+          }
+        }
+      }
+    },
     "Boxes missing labels and touch targets over the running app. Contrast is measured when you open this report, because it costs a snapshot of the whole screen.": {
       "comment": "Footer under the settings section of the accessibility audit report screen, explaining that the live overlay runs only the two checks that need no pixels and that contrast is measured when the report is opened",
       "localizations": {
@@ -31583,6 +31660,83 @@
         }
       }
     },
+    "Marks where each string starts and ends, so you can see when one has been cut off. Only shows up when another text mode is on.": {
+      "comment": "Subtitle for the Show Boundaries switch",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "يحدّد بداية كل نص ونهايته، لتلاحظ ما إذا كان قد اقتُطع. لا يظهر إلا عند تفعيل وضع نصي آخر."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Markiert Anfang und Ende jeder Zeichenkette, damit sichtbar wird, wenn eine abgeschnitten wurde. Erscheint nur, wenn ein anderer Textmodus aktiv ist."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Marca dónde empieza y termina cada cadena, para que veas cuándo se ha cortado alguna. Solo aparece cuando hay otro modo de texto activado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Marque le début et la fin de chaque chaîne, pour repérer celles qui sont tronquées. N’apparaît que si un autre mode de texte est activé."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Segna dove inizia e finisce ogni stringa, così vedi quando ne viene troncata una. Compare solo quando è attiva un’altra modalità di testo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "各文字列の始まりと終わりを示し、途中で切れているかどうかを確認できます。ほかのテキストモードがオンのときのみ表示されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "각 문자열의 시작과 끝을 표시해 잘린 문자열을 확인할 수 있습니다. 다른 텍스트 모드가 켜져 있을 때만 나타납니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Markeert waar elke tekst begint en eindigt, zodat je ziet wanneer er een is afgekapt. Verschijnt alleen als een andere tekstmodus aanstaat."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Marca onde cada texto começa e termina, para você ver quando algum foi cortado. Só aparece quando outro modo de texto está ativado."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Отмечает начало и конец каждой строки, чтобы было видно, когда строка обрезана. Появляется только при включённом другом текстовом режиме."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "标出每条字符串的开头和结尾，便于发现被截断的文本。仅在开启其他文本模式时显示。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "標出每條字串的開頭和結尾，便於發現被截斷的文字。僅在開啟其他文字模式時顯示。"
+          }
+        }
+      }
+    },
     "Marseille, France": {
       "comment": "Location preset name",
       "localizations": {
@@ -32662,7 +32816,7 @@
       }
     },
     "Modes": {
-      "comment": "Section header above the four pseudo-localisation switches",
+      "comment": "Section header above the pseudo-localisation mode switches",
       "localizations": {
         "ar": {
           "stringUnit": {
@@ -51850,6 +52004,83 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "分享"
+          }
+        }
+      }
+    },
+    "Show Boundaries": {
+      "comment": "Switch label for keeping the brackets that mark where a transformed string starts and ends",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "إظهار الحدود"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Begrenzungen anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostrar delimitadores"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Afficher les délimiteurs"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostra delimitatori"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "区切りを表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "경계 표시"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Begrenzingen tonen"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Mostrar delimitadores"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Показывать границы"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "显示边界标记"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "顯示邊界標記"
           }
         }
       }

--- a/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
+++ b/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
@@ -83,13 +83,17 @@ strength of how the mechanism *ought* to behave. The rows marked "no" rest on do
 appearance-proxy behaviour and have not been observed here: the example app is SwiftUI, so there is
 no UIKit host in this repository to look at.
 
-Switching the mode off restores Scyther's own interface just as immediately, and that took a fix
-rather than falling out of the mechanism: `UIView.appearance()` stamps its value onto each view as
-the view joins a window and never revisits it, so putting the proxy back changes nothing that
-already exists. The first version of this mode therefore left the menu mirrored for the rest of the
-session. ``PseudoLocalizationLayout/applyToOwnedViews(rightToLeft:in:)`` resets the views Scyther
-owns — and only those — in both directions. Nothing above changes for the host app: its UIKit views
-un-mirror on the next launch exactly as they mirror on one.
+Switching the mode off needed a fix of its own, because the appearance proxy cannot undo itself: it
+stamps its value onto each view as the view joins a window and never revisits it, so putting the
+proxy back changes nothing that already exists, and the first version of this mode left the menu
+mirrored for the rest of the session. ``PseudoLocalizationLayout/clearForcedDirection(in:)`` takes
+that stamp back off Scyther's own UIKit chrome — the container its menu is presented in, and its
+overlays — and writes nothing else, in that direction only. What SwiftUI hosts is deliberately out
+of its reach: mirroring Scyther's interface, both ways, is the environment value ``MenuView`` and
+``PseudoLocalizationView`` install, and forcing the UIKit attribute onto a hosting view as well
+makes it mirror the text it *renders* — measured on a device as a menu whose every label read
+backwards. Nothing above changes for the host app: its UIKit views un-mirror on the next launch
+exactly as they mirror on one.
 
 The reason for the split is ``PseudoLocalizationLayout``'s two halves. SwiftUI reads
 `\.layoutDirection` from **its own** environment, which the host app owns; `UIView.appearance()`

--- a/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
+++ b/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
@@ -75,6 +75,14 @@ strength of how the mechanism *ought* to behave. The rows marked "no" rest on do
 appearance-proxy behaviour and have not been observed here: the example app is SwiftUI, so there is
 no UIKit host in this repository to look at.
 
+Switching the mode off restores Scyther's own interface just as immediately, and that took a fix
+rather than falling out of the mechanism: `UIView.appearance()` stamps its value onto each view as
+the view joins a window and never revisits it, so putting the proxy back changes nothing that
+already exists. The first version of this mode therefore left the menu mirrored for the rest of the
+session. ``PseudoLocalizationLayout/applyToOwnedViews(rightToLeft:in:)`` resets the views Scyther
+owns — and only those — in both directions. Nothing above changes for the host app: its UIKit views
+un-mirror on the next launch exactly as they mirror on one.
+
 The reason for the split is ``PseudoLocalizationLayout``'s two halves. SwiftUI reads
 `\.layoutDirection` from **its own** environment, which the host app owns; `UIView.appearance()`
 governs UIKit views created after it changes and does not seed that environment at any point.

--- a/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
+++ b/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
@@ -66,52 +66,51 @@ pseudo-localisation looks like, and Scyther's menu is a real, fully localised Sw
 at it on — but it is a demonstration, not a test of your screens. On a UIKit or
 `NSLocalizedString`-based app it is a test of your screens.
 
-Right to Left is a different mechanism, and it has a different limit rather than none. It changes
-no text, so it does not care how your copy is loaded — but a layout direction cannot simply be
-forced onto views that already exist. What flips, and when:
+Right to Left is a different mechanism, and it runs on two timescales rather than one. It changes
+no text, so it does not care how your copy is loaded — but a layout direction cannot be forced onto
+views that already exist, so what Scyther owns flips now and what the host app owns flips at its
+next launch. What flips, and when:
 
 | Surface | When it mirrors | Checked on a simulator |
 | --- | --- | --- |
 | The Pseudo-localisation page | Immediately | yes |
 | The rest of the Scyther menu, and every page reached from it | Immediately | yes |
-| The host app's UIKit views created after the switch | On navigating to them | no |
-| The host app's UIKit views generally | On the next launch | no |
-| **The host app's SwiftUI views** | **Never** | yes — confirmed not to |
+| The host app's UIKit views | On the next launch | not yet |
+| The host app's SwiftUI views | On the next launch | not yet |
 
-The third column is there because this mode's reach has now been claimed wrongly three times on the
-strength of how the mechanism *ought* to behave. The rows marked "no" rest on documented
-appearance-proxy behaviour and have not been observed here: the example app is SwiftUI, so there is
-no UIKit host in this repository to look at.
+Switching the mode off unwinds in the same shape: Scyther's own interface immediately, the host app
+on its next launch.
 
-Switching the mode off needed a fix of its own, because the appearance proxy cannot undo itself: it
-stamps its value onto each view as the view joins a window and never revisits it, so putting the
-proxy back changes nothing that already exists, and the first version of this mode left the menu
-mirrored for the rest of the session. ``PseudoLocalizationLayout/clearForcedDirection(in:)`` takes
-that stamp back off Scyther's own views, in that direction only, and the one value it ever writes
-is `.unspecified`.
+The third column is there because this mode's reach has been claimed wrongly three times on the
+strength of how a mechanism *ought* to behave, and each time a device disagreed. The rows marked
+"not yet" rest on the two defaults keys below being the same ones Xcode's scheme option passes;
+they have not been observed here.
 
-Never `.forceRightToLeft`, and that restraint is the whole of what keeps it safe. Mirroring
-Scyther's interface is the environment value ``MenuView`` and ``PseudoLocalizationView`` install;
-forcing the UIKit attribute as well gives a view two signals, and a hosting view told to force a
-direction mirrors the text it *renders* rather than reordering what it lays out. Measured on a
-device: with the mode on, environment and stamp agree and the menu is mirrored and readable; with
-the mode off, a leftover stamp disagrees with the environment and the rows come back as `stnoF` and
-`stnenopmoC ecafretnI`. Removing the stamp settles the disagreement; adding one causes it. Nothing
-above changes for the host app: its UIKit views un-mirror on the next launch exactly as they mirror
-on one.
+An earlier version of this mode reached the host app through `UIView.appearance()` instead, and
+that is worth recording so it is not tried again. The appearance proxy stamps a view once, as the
+view joins a window, and never revisits it, so switching the mode off could not undo the views it
+had already stamped. Worse, a leftover stamp does not merely mirror a layout: it disagrees with the
+SwiftUI environment around it, and UIKit answers by mirroring content SwiftUI has already laid out
+the other way, which draws text backwards — `Fonts` as `stnoF`, measured on a device across three
+attempts to clean up after it. It also never reached a SwiftUI host app at all. The defaults keys
+do what it was reaching for, at the only moment it can be done properly, and nothing is stamped any
+more.
 
-The reason for the split is ``PseudoLocalizationLayout``'s two halves. SwiftUI reads
-`\.layoutDirection` from **its own** environment, which the host app owns; `UIView.appearance()`
-governs UIKit views created after it changes and does not seed that environment at any point.
-Scyther's interface mirrors instantly because Scyther installs that environment value itself, in
-``MenuView`` and ``PseudoLocalizationView``, and can therefore change it — which is also why the
-first version of this mode appeared to do nothing at all: ``MenuView`` was pinning the direction to
-the language and overruling the appearance proxy every time. Being early does not rescue the host
-app either; a relaunch mirrors its UIKit views and leaves its SwiftUI views exactly as they were.
+The reason for the split is ``PseudoLocalizationLayout``'s two halves. Scyther's interface mirrors
+instantly because Scyther installs `\.layoutDirection` itself, in ``MenuView`` and
+``PseudoLocalizationView``, and can therefore change it — which is also why the first version of
+this mode appeared to do nothing at all: ``MenuView`` was pinning the direction to the language and
+overruling everything else. The host app mirrors at launch because
+``PseudoLocalizationLayout/applyToHostApp(rightToLeft:isTestCase:isAppStore:systemDefaults:)``
+writes `AppleTextDirection` and `NSForceRightToLeftWritingDirection` into its standard
+`UserDefaults`: the two keys Xcode's own **Right to Left Pseudolanguage** scheme option passes on
+the command line, resolved before any view exists, reaching UIKit and SwiftUI alike. Writing into
+the host's defaults domain is the same move ``LanguageOverride`` already makes with
+`AppleLanguages`.
 
-There is a route to a SwiftUI host app, described in ``PseudoLocalizationLayout`` and deliberately
-not taken — Xcode's own scheme option does the same job properly, without Scyther writing an
-undocumented key into the host's defaults.
+Switching off removes both keys rather than writing `false`, so the app returns to the state it was
+in before Scyther was asked. See that function for why an App Store build refuses to set the keys
+and still clears them.
 
 The toggle's own subtitle carries all of this, not just these docs. A developer looking at a switch
 that says "forces right-to-left layout" and seeing nothing move has been told something false, and
@@ -159,19 +158,22 @@ The Pseudo-localisation page, and its row in the menu, are therefore the one par
 instead. The page carries a **Sample** row so it can still show what the modes do while remaining
 the one place they do not apply, and a **Turn Everything Off** button.
 
-The exemption covers text only. Right to Left is a process-wide UIKit attribute, so this page flips
-along with everything else; that is deliberate, because the text stays perfectly legible mirrored
-and insulating one screen from the layout mode would misrepresent what the mode does.
+The exemption covers text only. Right to Left mirrors the whole of Scyther's interface, so this
+page flips along with everything else; that is deliberate, because the text stays perfectly legible
+mirrored and insulating one screen from the layout mode would misrepresent what the mode does.
 
 The exemption is deliberately narrow. Exempting the whole menu would be safer still and would also
 mean there was nothing to see.
 
 ## Known limits
 
-- Right to Left never reaches the host app's SwiftUI views, and reaches its UIKit views only as
-  they are recreated or after a relaunch. Scyther's own interface is the only surface it mirrors
-  immediately. See the table above; the toggle says so too. For a SwiftUI app, Xcode's **Edit
-  Scheme → Run → Options → App Language → Right to Left Pseudolanguage** is the tool that works.
+- Right to Left reaches the host app only at launch, in both directions. Scyther's own interface is
+  the only surface it mirrors immediately, and the toggle says so. Xcode's **Edit Scheme → Run →
+  Options → App Language → Right to Left Pseudolanguage** does the same thing from the scheme, and
+  is the better tool when a relaunch is happening anyway.
+- Right to Left writes two keys into the host app's standard `UserDefaults` and removes them when
+  switched off. Nothing else in the app's own defaults domain is touched, and nothing at all is
+  written on an App Store build or under XCTest.
 - Strings the app has already resolved and cached are not revisited. A label rendered before the
   mode was switched on keeps its old text until something re-renders it.
 - Show Keys recovers the catalog key by reflecting on `String.LocalizationValue`, whose layout is

--- a/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
+++ b/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
@@ -114,6 +114,11 @@ that any mid-session effect ends up disagreeing with something and reversing tex
 value is still installed from the *language* override, which has no launch-time half to disagree
 with: see ``LanguageOverride/layoutDirection(forLanguage:)``.
 
+It is installed with `transformEnvironment`, and only when a language override is actually set —
+``LanguageOverride/menuLayoutDirection`` returns `nil` otherwise. Pinning it unconditionally to the
+device language's direction beat the launch keys, so a relaunch with the mode on mirrored the host
+app and left Scyther's menu, alone on screen, unmirrored. Seen on device.
+
 The toggle's own subtitle carries all of this, not just these docs. A developer looking at a switch
 that says "forces right-to-left layout" and seeing nothing move has been told something false, and
 no amount of accurate prose elsewhere repairs that.

--- a/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
+++ b/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
@@ -15,7 +15,7 @@ edge that ends up on the wrong side in Arabic, a string somebody forgot to put t
 rendering the app with copy that *behaves* like a translation without *being* one.
 
 **UI/UX → Pseudo-localisation** offers four modes, each a switch, each off by default, and all
-freely combinable:
+freely combinable — plus a fifth switch that is a setting about them rather than a mode of its own:
 
 | Mode | What it does | What it finds |
 | --- | --- | --- |
@@ -27,6 +27,14 @@ freely combinable:
 The bracketing in Lengthened is the point of it: a label that has lost its closing `]` was
 truncated, which is far easier to see in a screenshot than judging whether some accented text
 looks a few characters short.
+
+That is also why **Show Boundaries** — the fifth switch, and the only one that ships **on** —
+exists at all. The padding dots say a string grew; only the closing bracket says whether the end of
+it was cut off. Switching it off keeps the expansion and drops the delimiters, giving their two
+characters back to the padding so both forms grow a string by the same amount. It transforms
+nothing itself, so with every text mode off it does nothing whichever way it is set, and it reads
+as on when nothing has been stored for it — an install that predates it keeps the brackets it has
+always had. See ``PseudoLocalizationMode/showsBoundaries``.
 
 ## What it can reach, and what it cannot
 
@@ -108,7 +116,12 @@ spend an afternoon chasing in their own code, and a diagnostic tool that manufac
 worse than no tool.
 
 - Every mode is off by default and persisted under `Scyther_pseudo_localization_*` in
-  `UserDefaults.scyther`.
+  `UserDefaults.scyther`. ``PseudoLocalization/showsBoundaries`` is the one switch that reads as on
+  with nothing stored, and ``PseudoLocalization/reset()`` restores it to on rather than clearing
+  it, because that is its shipped state.
+- Show Boundaries changes how another mode renders and nothing else. It is deliberately absent from
+  ``PseudoLocalizationMode/textAffecting``, so it can never install the hook into the host app's
+  string loading on its own.
 - The swizzle is installed only while a text mode is on, and removed the moment the last one is
   switched off. An app that never opens the page never has its string loading touched.
 - Only `Bundle.main` is transformed, and within it only the default `Localizable` table. UIKit's

--- a/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
+++ b/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
@@ -87,13 +87,18 @@ Switching the mode off needed a fix of its own, because the appearance proxy can
 stamps its value onto each view as the view joins a window and never revisits it, so putting the
 proxy back changes nothing that already exists, and the first version of this mode left the menu
 mirrored for the rest of the session. ``PseudoLocalizationLayout/clearForcedDirection(in:)`` takes
-that stamp back off Scyther's own UIKit chrome — the container its menu is presented in, and its
-overlays — and writes nothing else, in that direction only. What SwiftUI hosts is deliberately out
-of its reach: mirroring Scyther's interface, both ways, is the environment value ``MenuView`` and
-``PseudoLocalizationView`` install, and forcing the UIKit attribute onto a hosting view as well
-makes it mirror the text it *renders* — measured on a device as a menu whose every label read
-backwards. Nothing above changes for the host app: its UIKit views un-mirror on the next launch
-exactly as they mirror on one.
+that stamp back off Scyther's own views, in that direction only, and the one value it ever writes
+is `.unspecified`.
+
+Never `.forceRightToLeft`, and that restraint is the whole of what keeps it safe. Mirroring
+Scyther's interface is the environment value ``MenuView`` and ``PseudoLocalizationView`` install;
+forcing the UIKit attribute as well gives a view two signals, and a hosting view told to force a
+direction mirrors the text it *renders* rather than reordering what it lays out. Measured on a
+device: with the mode on, environment and stamp agree and the menu is mirrored and readable; with
+the mode off, a leftover stamp disagrees with the environment and the rows come back as `stnoF` and
+`stnenopmoC ecafretnI`. Removing the stamp settles the disagreement; adding one causes it. Nothing
+above changes for the host app: its UIKit views un-mirror on the next launch exactly as they mirror
+on one.
 
 The reason for the split is ``PseudoLocalizationLayout``'s two halves. SwiftUI reads
 `\.layoutDirection` from **its own** environment, which the host app owns; `UIView.appearance()`

--- a/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
+++ b/Sources/Scyther/Scyther.docc/PseudoLocalisation.md
@@ -66,25 +66,24 @@ pseudo-localisation looks like, and Scyther's menu is a real, fully localised Sw
 at it on — but it is a demonstration, not a test of your screens. On a UIKit or
 `NSLocalizedString`-based app it is a test of your screens.
 
-Right to Left is a different mechanism, and it runs on two timescales rather than one. It changes
-no text, so it does not care how your copy is loaded — but a layout direction cannot be forced onto
-views that already exist, so what Scyther owns flips now and what the host app owns flips at its
-next launch. What flips, and when:
+Right to Left is a different mechanism, and it is a **next-launch setting on every surface**. It
+changes no text, so it does not care how your copy is loaded — and nothing changes in the session
+where the switch is flicked:
 
-| Surface | When it mirrors | Checked on a simulator |
+| Surface | When it mirrors | Checked on a device |
 | --- | --- | --- |
-| The Pseudo-localisation page | Immediately | yes |
-| The rest of the Scyther menu, and every page reached from it | Immediately | yes |
-| The host app's UIKit views | On the next launch | not yet |
-| The host app's SwiftUI views | On the next launch | not yet |
+| The host app's UIKit views | On the next launch | yes |
+| The host app's SwiftUI views | On the next launch | yes |
+| The Scyther menu, and every page reached from it | On the next launch | yes |
 
-Switching the mode off unwinds in the same shape: Scyther's own interface immediately, the host app
-on its next launch.
+Switching the mode off unwinds the same way, on the launch after it is switched off.
 
-The third column is there because this mode's reach has been claimed wrongly three times on the
-strength of how a mechanism *ought* to behave, and each time a device disagreed. The rows marked
-"not yet" rest on the two defaults keys below being the same ones Xcode's scheme option passes;
-they have not been observed here.
+The third column is there because this mode's reach was claimed wrongly three times on the strength
+of how a mechanism *ought* to behave, and each time a device disagreed. These rows were checked the
+only way that settles it: relaunched with the keys present, and relaunched with them absent.
+
+Because nothing takes effect until then, the toggle raises the same **Relaunch required** alert
+``LanguageView`` raises, with **Later** and **Quit App**.
 
 An earlier version of this mode reached the host app through `UIView.appearance()` instead, and
 that is worth recording so it is not tried again. The appearance proxy stamps a view once, as the
@@ -96,21 +95,24 @@ attempts to clean up after it. It also never reached a SwiftUI host app at all. 
 do what it was reaching for, at the only moment it can be done properly, and nothing is stamped any
 more.
 
-The reason for the split is ``PseudoLocalizationLayout``'s two halves. Scyther's interface mirrors
-instantly because Scyther installs `\.layoutDirection` itself, in ``MenuView`` and
-``PseudoLocalizationView``, and can therefore change it — which is also why the first version of
-this mode appeared to do nothing at all: ``MenuView`` was pinning the direction to the language and
-overruling everything else. The host app mirrors at launch because
+The mechanism is one thing rather than two, which is the point.
 ``PseudoLocalizationLayout/applyToHostApp(rightToLeft:isTestCase:isAppStore:systemDefaults:)``
-writes `AppleTextDirection` and `NSForceRightToLeftWritingDirection` into its standard
+writes `AppleTextDirection` and `NSForceRightToLeftWritingDirection` into the host app's standard
 `UserDefaults`: the two keys Xcode's own **Right to Left Pseudolanguage** scheme option passes on
-the command line, resolved before any view exists, reaching UIKit and SwiftUI alike. Writing into
-the host's defaults domain is the same move ``LanguageOverride`` already makes with
-`AppleLanguages`.
+the command line, resolved before any view exists, reaching UIKit and SwiftUI alike — Scyther's own
+menu among them, since it is in the same process. Writing into the host's defaults domain is the
+same move ``LanguageOverride`` already makes with `AppleLanguages`.
 
 Switching off removes both keys rather than writing `false`, so the app returns to the state it was
 in before Scyther was asked. See that function for why an App Store build refuses to set the keys
 and still clears them.
+
+Scyther's interface no longer mirrors the moment the switch moves. It used to, through
+`\.layoutDirection` installed in ``MenuView`` and ``PseudoLocalizationView``, and that was the last
+mid-session effect this mode had — see ``PseudoLocalizationLayout`` for the four rounds of evidence
+that any mid-session effect ends up disagreeing with something and reversing text. The environment
+value is still installed from the *language* override, which has no launch-time half to disagree
+with: see ``LanguageOverride/layoutDirection(forLanguage:)``.
 
 The toggle's own subtitle carries all of this, not just these docs. A developer looking at a switch
 that says "forces right-to-left layout" and seeing nothing move has been told something false, and
@@ -158,8 +160,8 @@ The Pseudo-localisation page, and its row in the menu, are therefore the one par
 instead. The page carries a **Sample** row so it can still show what the modes do while remaining
 the one place they do not apply, and a **Turn Everything Off** button.
 
-The exemption covers text only. Right to Left mirrors the whole of Scyther's interface, so this
-page flips along with everything else; that is deliberate, because the text stays perfectly legible
+The exemption covers text only. After a relaunch with Right to Left on, this page is mirrored along
+with everything else in the process; that is deliberate, because the text stays perfectly legible
 mirrored and insulating one screen from the layout mode would misrepresent what the mode does.
 
 The exemption is deliberately narrow. Exempting the whole menu would be safer still and would also
@@ -167,10 +169,10 @@ mean there was nothing to see.
 
 ## Known limits
 
-- Right to Left reaches the host app only at launch, in both directions. Scyther's own interface is
-  the only surface it mirrors immediately, and the toggle says so. Xcode's **Edit Scheme → Run →
-  Options → App Language → Right to Left Pseudolanguage** does the same thing from the scheme, and
-  is the better tool when a relaunch is happening anyway.
+- Right to Left takes effect only at launch, in both directions and on every surface including
+  Scyther's own menu. The toggle raises a **Relaunch required** alert rather than leaving that to
+  be discovered. Xcode's **Edit Scheme → Run → Options → App Language → Right to Left
+  Pseudolanguage** does the same thing from the scheme.
 - Right to Left writes two keys into the host app's standard `UserDefaults` and removes them when
   switched off. Nothing else in the app's own defaults domain is touched, and nothing at all is
   written on an App Store build or under XCTest.

--- a/Sources/Scyther/Shared/SwiftUI/ViewModel.swift
+++ b/Sources/Scyther/Shared/SwiftUI/ViewModel.swift
@@ -192,4 +192,19 @@ class ViewModel: ObservableObject {
     func onSubsequentAppear() async {
 
     }
+
+    /// Terminates the process, so the host app comes back with a setting that only applies at
+    /// launch.
+    ///
+    /// The odd one out here — an action rather than a lifecycle hook — and it lives on the base
+    /// class because two pages need exactly the same one. ``LanguageViewModel`` needs it for
+    /// `AppLanguages`, and ``PseudoLocalizationViewModel`` for the two text-direction keys; both
+    /// raise a "Relaunch required" alert whose destructive button calls this. A second copy of
+    /// `exit(0)` would be a second thing to find, and the two features would drift.
+    ///
+    /// Only ever called from the destructive action of such an alert, after the developer has been
+    /// told what it does. Nothing calls it on their behalf.
+    func quitApp() {
+        exit(0)
+    }
 }

--- a/Tests/ScytherTests/Features/LanguageOverrideTests.swift
+++ b/Tests/ScytherTests/Features/LanguageOverrideTests.swift
@@ -4,6 +4,7 @@
 //
 
 @testable import Scyther
+import SwiftUI
 import XCTest
 
 final class LanguageOverrideTests: XCTestCase {
@@ -158,5 +159,26 @@ final class LanguageOverrideTests: XCTestCase {
         XCTAssertEqual(override.nativeDisplayName(for: "fr"), "français")
         let simplified = override.displayName(for: "zh-Hans", in: Locale(identifier: "en"))
         XCTAssertTrue(simplified.contains("Chinese") && simplified.contains("Simplified"), simplified)
+    }
+
+    // MARK: - Layout direction
+
+    /// The menu's copy switches language immediately, so its layout has to follow in the same
+    /// session or the screen is half-translated in a different way.
+    func testAnArabicOverrideLaysScythersInterfaceOutRightToLeft() {
+        XCTAssertEqual(LanguageOverride.layoutDirection(forLanguage: "ar"), .rightToLeft)
+    }
+
+    func testAHebrewOverrideLaysScythersInterfaceOutRightToLeft() {
+        XCTAssertEqual(LanguageOverride.layoutDirection(forLanguage: "he"), .rightToLeft)
+    }
+
+    func testAnEnglishOverrideStaysLeftToRight() {
+        XCTAssertEqual(LanguageOverride.layoutDirection(forLanguage: "en"), .leftToRight)
+    }
+
+    func testARegionalIdentifierIsResolvedByItsLanguage() {
+        XCTAssertEqual(LanguageOverride.layoutDirection(forLanguage: "ar-EG"), .rightToLeft)
+        XCTAssertEqual(LanguageOverride.layoutDirection(forLanguage: "pt-BR"), .leftToRight)
     }
 }

--- a/Tests/ScytherTests/Features/LanguageOverrideTests.swift
+++ b/Tests/ScytherTests/Features/LanguageOverrideTests.swift
@@ -181,4 +181,24 @@ final class LanguageOverrideTests: XCTestCase {
         XCTAssertEqual(LanguageOverride.layoutDirection(forLanguage: "ar-EG"), .rightToLeft)
         XCTAssertEqual(LanguageOverride.layoutDirection(forLanguage: "pt-BR"), .leftToRight)
     }
+
+    /// With no override set, Scyther must not pin its own layout direction at all.
+    ///
+    /// Pinning it to the device language's direction overrides the process-wide right-to-left
+    /// forcing that pseudo-localisation's Right to Left mode installs, so the host app mirrors
+    /// on relaunch and Scyther's menu, alone on screen, does not. Seen on device.
+    func testNoOverrideLeavesTheLayoutDirectionAloneSoForcedRightToLeftReachesTheMenu() {
+        let override = makeOverride()
+        XCTAssertNil(override.preferredLanguage)
+        XCTAssertNil(override.menuLayoutDirection)
+    }
+
+    func testAnOverrideStillPinsTheMenuToItsOwnLanguagesDirection() {
+        let override = makeOverride()
+        override.setPreferredLanguage("ar")
+        XCTAssertEqual(override.menuLayoutDirection, .rightToLeft)
+
+        override.setPreferredLanguage("en")
+        XCTAssertEqual(override.menuLayoutDirection, .leftToRight)
+    }
 }

--- a/Tests/ScytherTests/Features/PseudoLocalizationHookTests.swift
+++ b/Tests/ScytherTests/Features/PseudoLocalizationHookTests.swift
@@ -36,6 +36,7 @@ final class PseudoLocalizationHookTests: XCTestCase {
             PseudoLocalization.LengthenedDefaultsKey: PseudoLocalization.instance.lengthened,
             PseudoLocalization.RightToLeftDefaultsKey: PseudoLocalization.instance.rightToLeft,
             PseudoLocalization.ShowsKeysDefaultsKey: PseudoLocalization.instance.showsKeys,
+            PseudoLocalization.ShowsBoundariesDefaultsKey: PseudoLocalization.instance.showsBoundaries,
         ]
     }
 

--- a/Tests/ScytherTests/Features/PseudoLocalizationLayoutTests.swift
+++ b/Tests/ScytherTests/Features/PseudoLocalizationLayoutTests.swift
@@ -1,0 +1,182 @@
+//
+//  PseudoLocalizationLayoutTests.swift
+//  ScytherTests
+//
+//  Created by Brandon Stillitano on 7/9/2026.
+//
+
+#if !os(macOS)
+@testable import Scyther
+import SwiftUI
+import UIKit
+import XCTest
+
+/// Covers the half of ``PseudoLocalizationLayout`` that resets the views Scyther owns.
+///
+/// The appearance proxy cannot be tested here — it is process-wide state with no reliable way to
+/// read the applied value back — but the walk that undoes its work can be, because it takes the
+/// views it should visit rather than going looking for windows. Every hierarchy below is real
+/// `UIView`s under a real `UIViewController`, so the responder chain the ownership rule climbs is
+/// the one UIKit builds rather than a stand-in for it.
+@MainActor
+final class PseudoLocalizationLayoutTests: XCTestCase {
+
+    /// Stands in for a ``ScytherHostingController``: the marker is what ownership is decided by,
+    /// and a plain controller carrying it exercises the same rule without needing SwiftUI to build
+    /// a hosting view first.
+    private final class OwnedController: UIViewController, ScytherPresentedUI { }
+
+    /// The attribute a view stamped by the appearance proxy while the mode was on would be left
+    /// holding once the mode is switched off — the state the fix exists to clear.
+    private let stale: UISemanticContentAttribute = .forceRightToLeft
+
+    /// A value neither switch position ever produces, so a view that still holds it was genuinely
+    /// left alone rather than coincidentally reset to the value "off" happens to use.
+    private let untouched: UISemanticContentAttribute = .forceLeftToRight
+
+    // MARK: - Helpers
+
+    /// A controller whose root view holds two nested subviews, all three stamped with `attribute`.
+    private func hierarchy(
+        _ controller: UIViewController,
+        stampedWith attribute: UISemanticContentAttribute
+    ) -> (root: UIView, child: UIView, grandchild: UIView) {
+        let child = UIView()
+        let grandchild = UIView()
+        child.addSubview(grandchild)
+        controller.view.addSubview(child)
+        for view in [controller.view!, child, grandchild] {
+            view.semanticContentAttribute = attribute
+        }
+        return (controller.view, child, grandchild)
+    }
+
+    // MARK: - Ownership
+
+    func testAViewOwnedByAScytherControllerIsScythers() {
+        let controller = OwnedController()
+        let views = hierarchy(controller, stampedWith: .unspecified)
+        XCTAssertTrue(PseudoLocalizationLayout.isScytherOwned(views.root))
+        XCTAssertTrue(PseudoLocalizationLayout.isScytherOwned(views.grandchild))
+    }
+
+    func testAViewOwnedByTheAppIsNotScythers() {
+        let controller = UIViewController()
+        let views = hierarchy(controller, stampedWith: .unspecified)
+        XCTAssertFalse(PseudoLocalizationLayout.isScytherOwned(views.root))
+        XCTAssertFalse(PseudoLocalizationLayout.isScytherOwned(views.grandchild))
+    }
+
+    func testAContainerHostingAScytherControllerIsScythers() {
+        let container = UIViewController()
+        let scyther = OwnedController()
+        container.addChild(scyther)
+        container.view.addSubview(scyther.view)
+        XCTAssertTrue(PseudoLocalizationLayout.isScytherOwned(container.view))
+    }
+
+    func testScythersOwnOverlayViewsAreScythers() {
+        XCTAssertTrue(PseudoLocalizationLayout.isScytherOwned(TopLevelViewsWrapper()))
+        XCTAssertTrue(PseudoLocalizationLayout.isScytherOwned(TopLevelView()))
+    }
+
+    // MARK: - Switching on
+
+    func testSwitchingOnForcesRightToLeftOnEveryViewScytherOwns() {
+        let controller = OwnedController()
+        let views = hierarchy(controller, stampedWith: .unspecified)
+        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: true, in: [views.root])
+        XCTAssertEqual(views.root.semanticContentAttribute, .forceRightToLeft)
+        XCTAssertEqual(views.child.semanticContentAttribute, .forceRightToLeft)
+        XCTAssertEqual(views.grandchild.semanticContentAttribute, .forceRightToLeft)
+    }
+
+    // MARK: - Switching off
+
+    func testSwitchingOffClearsEveryViewScytherOwns() {
+        let controller = OwnedController()
+        let views = hierarchy(controller, stampedWith: stale)
+        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: false, in: [views.root])
+        XCTAssertEqual(views.root.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(views.child.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(views.grandchild.semanticContentAttribute, .unspecified)
+    }
+
+    /// The defect as reported: on, then off, and the menu is still mirrored.
+    func testSwitchingOnThenOffLeavesNothingOfScythersMirrored() {
+        let controller = OwnedController()
+        let views = hierarchy(controller, stampedWith: .unspecified)
+        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: true, in: [views.root])
+        for view in [views.root, views.child, views.grandchild] {
+            XCTAssertEqual(view.semanticContentAttribute, .forceRightToLeft)
+            XCTAssertEqual(view.effectiveUserInterfaceLayoutDirection, .rightToLeft)
+        }
+        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: false, in: [views.root])
+        for view in [views.root, views.child, views.grandchild] {
+            XCTAssertEqual(view.semanticContentAttribute, .unspecified)
+            XCTAssertEqual(view.effectiveUserInterfaceLayoutDirection, .leftToRight)
+        }
+    }
+
+    // MARK: - Descending from a window
+
+    func testTheWalkFindsScythersViewsBelowViewsThatAreNot() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        let app = UIViewController()
+        let appViews = hierarchy(app, stampedWith: untouched)
+        window.rootViewController = app
+        let scyther = OwnedController()
+        let scytherViews = hierarchy(scyther, stampedWith: stale)
+        window.addSubview(scyther.view)
+
+        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: false, in: [window])
+
+        XCTAssertEqual(scytherViews.root.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(scytherViews.child.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(scytherViews.grandchild.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(appViews.root.semanticContentAttribute, untouched)
+        XCTAssertEqual(appViews.child.semanticContentAttribute, untouched)
+        XCTAssertEqual(appViews.grandchild.semanticContentAttribute, untouched)
+    }
+
+    func testTheWalkReachesAContainersOwnViewsAndNotTheAppsAroundIt() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        let app = UIViewController()
+        let appViews = hierarchy(app, stampedWith: untouched)
+        window.rootViewController = app
+
+        let container = UIViewController()
+        let bar = UIView()
+        container.view.addSubview(bar)
+        let scyther = OwnedController()
+        container.addChild(scyther)
+        container.view.addSubview(scyther.view)
+        for view in [container.view!, bar, scyther.view!] {
+            view.semanticContentAttribute = stale
+        }
+        window.addSubview(container.view)
+
+        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: false, in: [window])
+
+        XCTAssertEqual(bar.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(container.view.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(scyther.view.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(appViews.root.semanticContentAttribute, untouched)
+    }
+
+    // MARK: - The host app
+
+    func testTheWalkLeavesTheHostAppsViewsAloneInBothDirections() {
+        let controller = UIViewController()
+        let views = hierarchy(controller, stampedWith: untouched)
+        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: true, in: [views.root])
+        XCTAssertEqual(views.root.semanticContentAttribute, untouched)
+        XCTAssertEqual(views.child.semanticContentAttribute, untouched)
+        XCTAssertEqual(views.grandchild.semanticContentAttribute, untouched)
+        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: false, in: [views.root])
+        XCTAssertEqual(views.root.semanticContentAttribute, untouched)
+        XCTAssertEqual(views.child.semanticContentAttribute, untouched)
+        XCTAssertEqual(views.grandchild.semanticContentAttribute, untouched)
+    }
+}
+#endif

--- a/Tests/ScytherTests/Features/PseudoLocalizationLayoutTests.swift
+++ b/Tests/ScytherTests/Features/PseudoLocalizationLayoutTests.swift
@@ -24,8 +24,13 @@ import XCTest
 /// said more than it could. They can say which attribute a view carries afterwards. They cannot
 /// say what the screen looks like: an earlier fix forced `.forceRightToLeft` onto Scyther's own
 /// views, passed every assertion here, and rendered the menu's text reversed glyph by glyph on a
-/// device. Hence ``testNothingSwiftUIHostsIsEverWrittenTo``, which is the assertion that would
-/// have caught it.
+/// device.
+///
+/// The property that actually matters is therefore pinned directly rather than approximated. It is
+/// not "hosted views are never written to" — that restriction was tried, and it left the reversed
+/// text in place, since the stamps doing the damage were inside the hosting view. It is
+/// ``testNothingIsEverForcedRightToLeft``: whatever this walk touches, it only ever *removes* a
+/// forced direction.
 @MainActor
 final class PseudoLocalizationLayoutTests: XCTestCase {
 
@@ -130,19 +135,77 @@ final class PseudoLocalizationLayoutTests: XCTestCase {
         XCTAssertEqual(views.grandchild.semanticContentAttribute, foreignValue)
     }
 
-    /// The assertion the earlier fix would have failed: the walk must not write to a view SwiftUI
-    /// hosts, even one the appearance proxy stamped, because forcing a direction on a hosting view
-    /// mirrors the text it renders.
-    func testNothingSwiftUIHostsIsEverWrittenTo() {
+    /// The property that matters, and the one an attribute-by-attribute assertion kept missing:
+    /// this walk only ever *removes* a forced direction. Forcing one is what made a hosting view
+    /// mirror the text it renders, and nothing here may do it — to Scyther's views, to the app's,
+    /// or to a view SwiftUI hosts.
+    func testNothingIsEverForcedRightToLeft() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        let app = UIViewController()
+        let appViews = hierarchy(app, setTo: .unspecified)
+        window.rootViewController = app
+
+        let container = UIViewController()
+        let chrome = hierarchy(container, setTo: foreignValue)
         let hosting = HostingController()
-        let views = hierarchy(hosting, setTo: stamped)
-        PseudoLocalizationLayout.clearForcedDirection(in: [views.root])
-        XCTAssertEqual(views.root.semanticContentAttribute, stamped)
-        XCTAssertEqual(views.child.semanticContentAttribute, stamped)
-        XCTAssertEqual(views.grandchild.semanticContentAttribute, stamped)
+        container.addChild(hosting)
+        container.view.addSubview(hosting.view)
+        let hosted = hierarchy(hosting, setTo: .unspecified)
+        window.addSubview(container.view)
+
+        PseudoLocalizationLayout.clearForcedDirection(in: [window])
+        PseudoLocalizationLayout.clearForcedDirection(in: [window])
+
+        let everything = [window, appViews.root, appViews.child, appViews.grandchild,
+                          chrome.root, chrome.child, chrome.grandchild,
+                          hosted.root, hosted.child, hosted.grandchild]
+        for view in everything {
+            XCTAssertNotEqual(view.semanticContentAttribute, .forceRightToLeft)
+        }
     }
 
-    func testTheWalkStopsAtAHostingViewWhileClearingTheChromeAroundIt() {
+    /// The check this round of the bug needed: a view stamped while the mode was on has to come
+    /// back to `.unspecified` when it is switched off, and it makes no difference that the view
+    /// sits inside a hosting view. That is where the reversed rows were.
+    func testAStampedViewInsideAHostingViewIsCleared() {
+        let hosting = HostingController()
+        let collection = UIView()
+        let cell = UIView()
+        let label = UIView()
+        cell.addSubview(label)
+        collection.addSubview(cell)
+        hosting.view.addSubview(collection)
+        for view in [hosting.view!, collection, cell, label] {
+            view.semanticContentAttribute = stamped
+        }
+
+        PseudoLocalizationLayout.clearForcedDirection(in: [hosting.view])
+
+        XCTAssertEqual(hosting.view.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(collection.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(cell.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(label.semanticContentAttribute, .unspecified)
+    }
+
+    /// SwiftUI puts container view controllers of its own inside a hosting controller, so a cell's
+    /// *nearest* controller is a private SwiftUI type that neither is nor contains anything of
+    /// Scyther's. A classifier that stopped at the first controller called every row of the menu
+    /// the app's and left the stamps in place.
+    func testAViewUnderASwiftUIContainerControllerIsStillScythers() {
+        let hosting = HostingController()
+        let inner = UIViewController()
+        hosting.addChild(inner)
+        hosting.view.addSubview(inner.view)
+        let cell = UIView()
+        inner.view.addSubview(cell)
+        cell.semanticContentAttribute = stamped
+
+        XCTAssertEqual(PseudoLocalizationLayout.role(of: cell), .swiftUIHosted)
+        PseudoLocalizationLayout.clearForcedDirection(in: [hosting.view])
+        XCTAssertEqual(cell.semanticContentAttribute, .unspecified)
+    }
+
+    func testTheWalkClearsTheChromeAroundAHostingViewAndTheHostingViewItself() {
         let container = UIViewController()
         let bar = UIView()
         container.view.addSubview(bar)
@@ -159,8 +222,8 @@ final class PseudoLocalizationLayoutTests: XCTestCase {
 
         XCTAssertEqual(container.view.semanticContentAttribute, .unspecified)
         XCTAssertEqual(bar.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(hosting.view.semanticContentAttribute, stamped)
-        XCTAssertEqual(hosted.semanticContentAttribute, stamped)
+        XCTAssertEqual(hosting.view.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(hosted.semanticContentAttribute, .unspecified)
     }
 
     // MARK: - Descending from a window

--- a/Tests/ScytherTests/Features/PseudoLocalizationLayoutTests.swift
+++ b/Tests/ScytherTests/Features/PseudoLocalizationLayoutTests.swift
@@ -7,268 +7,130 @@
 
 #if !os(macOS)
 @testable import Scyther
-import SwiftUI
-import UIKit
 import XCTest
 
-/// Covers the half of ``PseudoLocalizationLayout`` that takes the appearance proxy's stamp back
-/// off Scyther's own UIKit chrome.
+/// Covers the half of ``PseudoLocalizationLayout`` that reaches the host app.
 ///
-/// The appearance proxy cannot be tested here — it is process-wide state with no reliable way to
-/// read the applied value back — but the walk that undoes its work can be, because it takes the
-/// views it should visit rather than going looking for windows. Every hierarchy below is real
-/// `UIView`s under a real `UIViewController`, so the responder chain the classifier climbs is the
-/// one UIKit builds rather than a stand-in for it.
+/// Testable in a way its predecessor never was, and that is the point of the mechanism as much as
+/// its reach: forcing a layout direction meant writing an attribute onto live views, which a test
+/// could only inspect and never judge — three fixes passed every assertion while the menu was
+/// unreadable on a device. Writing two defaults keys is a fact a throwaway suite can hold, so what
+/// the tests below assert and what the developer's app will do at launch are the same statement.
 ///
-/// What these tests can and cannot say is worth stating, because a previous version of this file
-/// said more than it could. They can say which attribute a view carries afterwards. They cannot
-/// say what the screen looks like: an earlier fix forced `.forceRightToLeft` onto Scyther's own
-/// views, passed every assertion here, and rendered the menu's text reversed glyph by glyph on a
-/// device.
-///
-/// The property that actually matters is therefore pinned directly rather than approximated. It is
-/// not "hosted views are never written to" — that restriction was tried, and it left the reversed
-/// text in place, since the stamps doing the damage were inside the hosting view. It is
-/// ``testNothingIsEverForcedRightToLeft``: whatever this walk touches, it only ever *removes* a
-/// forced direction.
+/// The suite is a throwaway one on purpose. The production path writes to `UserDefaults.standard`,
+/// which in this process is the *test host's* domain, and a test that mirrored the test runner
+/// would be a memorable way to find out that the guard works.
 @MainActor
 final class PseudoLocalizationLayoutTests: XCTestCase {
 
-    /// Stands in for a ``ScytherHostingController``: the marker is what the classifier decides on,
-    /// and a plain controller carrying it exercises the same rule without needing SwiftUI to build
-    /// a hosting view first.
-    private final class HostingController: UIViewController, ScytherPresentedUI { }
+    private var defaults: UserDefaults!
+    private var suiteName: String!
 
-    /// The attribute the appearance proxy leaves on a view built while the mode was on, and the
-    /// only value the walk is allowed to overwrite.
-    private let stamped: UISemanticContentAttribute = .forceRightToLeft
+    private let textDirection = PseudoLocalizationLayout.textDirectionDefaultsKey
+    private let forceRightToLeft = PseudoLocalizationLayout.forceRightToLeftDefaultsKey
 
-    /// A value the walk must never produce or overwrite, so a view still holding it was genuinely
-    /// left alone rather than coincidentally reset to the value a clear happens to write.
-    private let foreignValue: UISemanticContentAttribute = .forceLeftToRight
-
-    // MARK: - Helpers
-
-    /// A controller whose root view holds two nested subviews, all three set to `attribute`.
-    @discardableResult
-    private func hierarchy(
-        _ controller: UIViewController,
-        setTo attribute: UISemanticContentAttribute
-    ) -> (root: UIView, child: UIView, grandchild: UIView) {
-        let child = UIView()
-        let grandchild = UIView()
-        child.addSubview(grandchild)
-        controller.view.addSubview(child)
-        for view in [controller.view!, child, grandchild] {
-            view.semanticContentAttribute = attribute
-        }
-        return (controller.view, child, grandchild)
+    override func setUp() {
+        super.setUp()
+        suiteName = "PseudoLocalizationLayoutTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
     }
 
-    // MARK: - Roles
-
-    func testAViewSwiftUIHostsForScytherIsRecognisedAsSuch() {
-        let controller = HostingController()
-        let views = hierarchy(controller, setTo: .unspecified)
-        XCTAssertEqual(PseudoLocalizationLayout.role(of: views.root), .swiftUIHosted)
-        XCTAssertEqual(PseudoLocalizationLayout.role(of: views.grandchild), .swiftUIHosted)
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
     }
 
-    func testTheChromeAroundAPresentedScytherScreenIsRecognisedAsScythers() {
-        let container = UIViewController()
-        let bar = UIView()
-        container.view.addSubview(bar)
-        let hosting = HostingController()
-        container.addChild(hosting)
-        container.view.addSubview(hosting.view)
-        XCTAssertEqual(PseudoLocalizationLayout.role(of: container.view), .scytherChrome)
-        XCTAssertEqual(PseudoLocalizationLayout.role(of: bar), .scytherChrome)
+    /// Puts the keys in the state a session that switched the mode on would have left them.
+    private func stubSwitchedOn() {
+        defaults.set(true, forKey: textDirection)
+        defaults.set(true, forKey: forceRightToLeft)
     }
 
-    func testScythersOwnOverlayViewsAreRecognisedAsScythers() {
-        XCTAssertEqual(PseudoLocalizationLayout.role(of: TopLevelViewsWrapper()), .scytherChrome)
-        XCTAssertEqual(PseudoLocalizationLayout.role(of: TopLevelView()), .scytherChrome)
+    /// Runs the host-app half as a build where Scyther is allowed to run would.
+    private func apply(rightToLeft: Bool, isTestCase: Bool = false, isAppStore: Bool = false) {
+        PseudoLocalizationLayout.applyToHostApp(
+            rightToLeft: rightToLeft,
+            isTestCase: isTestCase,
+            isAppStore: isAppStore,
+            systemDefaults: defaults
+        )
     }
 
-    func testAViewOwnedByTheAppIsForeign() {
-        let controller = UIViewController()
-        let views = hierarchy(controller, setTo: .unspecified)
-        XCTAssertEqual(PseudoLocalizationLayout.role(of: views.root), .foreign)
-        XCTAssertEqual(PseudoLocalizationLayout.role(of: views.grandchild), .foreign)
+    // MARK: - Switching on
+
+    func testSwitchingOnWritesBothKeysIOSReadsAtLaunch() {
+        apply(rightToLeft: true)
+        XCTAssertEqual(defaults.object(forKey: textDirection) as? Bool, true)
+        XCTAssertEqual(defaults.object(forKey: forceRightToLeft) as? Bool, true)
     }
 
-    // MARK: - Clearing
-
-    func testClearingTakesTheStampOffScythersChrome() {
-        let container = UIViewController()
-        let views = hierarchy(container, setTo: stamped)
-        let hosting = HostingController()
-        container.addChild(hosting)
-        PseudoLocalizationLayout.clearForcedDirection(in: [views.root])
-        XCTAssertEqual(views.root.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(views.child.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(views.grandchild.semanticContentAttribute, .unspecified)
+    /// The keys are the ones Xcode's own Right to Left Pseudolanguage scheme option passes, which
+    /// is what makes this reach SwiftUI as well as UIKit. Getting a name wrong would fail silently
+    /// on a device and look exactly like the feature not working.
+    func testTheKeysAreTheOnesTheSystemReads() {
+        XCTAssertEqual(PseudoLocalizationLayout.textDirectionDefaultsKey, "AppleTextDirection")
+        XCTAssertEqual(
+            PseudoLocalizationLayout.forceRightToLeftDefaultsKey,
+            "NSForceRightToLeftWritingDirection"
+        )
     }
 
-    /// `.unspecified` rather than `.forceLeftToRight`, so a genuinely Arabic device is handed back
-    /// to its own language rather than pinned the other way.
-    func testClearingWritesUnspecifiedRatherThanForcingTheOtherDirection() {
-        let container = UIViewController()
-        let views = hierarchy(container, setTo: stamped)
-        let hosting = HostingController()
-        container.addChild(hosting)
-        PseudoLocalizationLayout.clearForcedDirection(in: [views.root])
-        XCTAssertNotEqual(views.root.semanticContentAttribute, .forceLeftToRight)
-        XCTAssertEqual(views.root.effectiveUserInterfaceLayoutDirection, .leftToRight)
+    // MARK: - Switching off
+
+    /// Removed rather than set to `false`: a developer who tries this once has to be able to get
+    /// their app back, without a Scyther-shaped value left in their defaults for good.
+    func testSwitchingOffRemovesBothKeysRatherThanWritingFalse() {
+        stubSwitchedOn()
+        apply(rightToLeft: false)
+        XCTAssertNil(defaults.object(forKey: textDirection))
+        XCTAssertNil(defaults.object(forKey: forceRightToLeft))
     }
 
-    /// The walk exists to undo one specific stamp, so a view holding anything else was never this
-    /// feature's to touch.
-    func testClearingLeavesAViewHoldingAnyOtherValueAlone() {
-        let container = UIViewController()
-        let views = hierarchy(container, setTo: foreignValue)
-        let hosting = HostingController()
-        container.addChild(hosting)
-        PseudoLocalizationLayout.clearForcedDirection(in: [views.root])
-        XCTAssertEqual(views.root.semanticContentAttribute, foreignValue)
-        XCTAssertEqual(views.child.semanticContentAttribute, foreignValue)
-        XCTAssertEqual(views.grandchild.semanticContentAttribute, foreignValue)
+    func testSwitchingOffWithNothingStoredLeavesNothingBehind() {
+        apply(rightToLeft: false)
+        XCTAssertNil(defaults.object(forKey: textDirection))
+        XCTAssertNil(defaults.object(forKey: forceRightToLeft))
     }
 
-    /// The property that matters, and the one an attribute-by-attribute assertion kept missing:
-    /// this walk only ever *removes* a forced direction. Forcing one is what made a hosting view
-    /// mirror the text it renders, and nothing here may do it — to Scyther's views, to the app's,
-    /// or to a view SwiftUI hosts.
-    func testNothingIsEverForcedRightToLeft() {
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
-        let app = UIViewController()
-        let appViews = hierarchy(app, setTo: .unspecified)
-        window.rootViewController = app
-
-        let container = UIViewController()
-        let chrome = hierarchy(container, setTo: foreignValue)
-        let hosting = HostingController()
-        container.addChild(hosting)
-        container.view.addSubview(hosting.view)
-        let hosted = hierarchy(hosting, setTo: .unspecified)
-        window.addSubview(container.view)
-
-        PseudoLocalizationLayout.clearForcedDirection(in: [window])
-        PseudoLocalizationLayout.clearForcedDirection(in: [window])
-
-        let everything = [window, appViews.root, appViews.child, appViews.grandchild,
-                          chrome.root, chrome.child, chrome.grandchild,
-                          hosted.root, hosted.child, hosted.grandchild]
-        for view in everything {
-            XCTAssertNotEqual(view.semanticContentAttribute, .forceRightToLeft)
-        }
+    func testOnThenOffLeavesTheDefaultsAsTheyWereFound() {
+        apply(rightToLeft: true)
+        apply(rightToLeft: false)
+        XCTAssertNil(defaults.object(forKey: textDirection))
+        XCTAssertNil(defaults.object(forKey: forceRightToLeft))
     }
 
-    /// The check this round of the bug needed: a view stamped while the mode was on has to come
-    /// back to `.unspecified` when it is switched off, and it makes no difference that the view
-    /// sits inside a hosting view. That is where the reversed rows were.
-    func testAStampedViewInsideAHostingViewIsCleared() {
-        let hosting = HostingController()
-        let collection = UIView()
-        let cell = UIView()
-        let label = UIView()
-        cell.addSubview(label)
-        collection.addSubview(cell)
-        hosting.view.addSubview(collection)
-        for view in [hosting.view!, collection, cell, label] {
-            view.semanticContentAttribute = stamped
-        }
+    // MARK: - The guard
 
-        PseudoLocalizationLayout.clearForcedDirection(in: [hosting.view])
-
-        XCTAssertEqual(hosting.view.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(collection.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(cell.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(label.semanticContentAttribute, .unspecified)
+    func testNothingIsWrittenUnderXCTest() {
+        apply(rightToLeft: true, isTestCase: true)
+        XCTAssertNil(defaults.object(forKey: textDirection))
+        XCTAssertNil(defaults.object(forKey: forceRightToLeft))
     }
 
-    /// SwiftUI puts container view controllers of its own inside a hosting controller, so a cell's
-    /// *nearest* controller is a private SwiftUI type that neither is nor contains anything of
-    /// Scyther's. A classifier that stopped at the first controller called every row of the menu
-    /// the app's and left the stamps in place.
-    func testAViewUnderASwiftUIContainerControllerIsStillScythers() {
-        let hosting = HostingController()
-        let inner = UIViewController()
-        hosting.addChild(inner)
-        hosting.view.addSubview(inner.view)
-        let cell = UIView()
-        inner.view.addSubview(cell)
-        cell.semanticContentAttribute = stamped
-
-        XCTAssertEqual(PseudoLocalizationLayout.role(of: cell), .swiftUIHosted)
-        PseudoLocalizationLayout.clearForcedDirection(in: [hosting.view])
-        XCTAssertEqual(cell.semanticContentAttribute, .unspecified)
+    /// Under XCTest the off path must not write *or* remove: the standard domain in this process
+    /// belongs to the test host, and a test suite has no business editing it in either direction.
+    func testNothingIsRemovedUnderXCTest() {
+        stubSwitchedOn()
+        apply(rightToLeft: false, isTestCase: true)
+        XCTAssertEqual(defaults.object(forKey: textDirection) as? Bool, true)
+        XCTAssertEqual(defaults.object(forKey: forceRightToLeft) as? Bool, true)
     }
 
-    func testTheWalkClearsTheChromeAroundAHostingViewAndTheHostingViewItself() {
-        let container = UIViewController()
-        let bar = UIView()
-        container.view.addSubview(bar)
-        let hosting = HostingController()
-        container.addChild(hosting)
-        container.view.addSubview(hosting.view)
-        let hosted = UIView()
-        hosting.view.addSubview(hosted)
-        for view in [container.view!, bar, hosting.view!, hosted] {
-            view.semanticContentAttribute = stamped
-        }
-
-        PseudoLocalizationLayout.clearForcedDirection(in: [container.view])
-
-        XCTAssertEqual(container.view.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(bar.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(hosting.view.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(hosted.semanticContentAttribute, .unspecified)
+    func testAnAppStoreBuildNeverMirrorsTheHostApp() {
+        apply(rightToLeft: true, isAppStore: true)
+        XCTAssertNil(defaults.object(forKey: textDirection))
+        XCTAssertNil(defaults.object(forKey: forceRightToLeft))
     }
 
-    // MARK: - Descending from a window
-
-    func testTheWalkFindsScythersChromeBelowViewsThatAreNot() {
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
-        let app = UIViewController()
-        let appViews = hierarchy(app, setTo: stamped)
-        window.rootViewController = app
-
-        let container = UIViewController()
-        let scytherViews = hierarchy(container, setTo: stamped)
-        let hosting = HostingController()
-        container.addChild(hosting)
-        window.addSubview(container.view)
-
-        PseudoLocalizationLayout.clearForcedDirection(in: [window])
-
-        XCTAssertEqual(scytherViews.root.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(scytherViews.child.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(scytherViews.grandchild.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(appViews.root.semanticContentAttribute, stamped)
-        XCTAssertEqual(appViews.child.semanticContentAttribute, stamped)
-        XCTAssertEqual(appViews.grandchild.semanticContentAttribute, stamped)
-    }
-
-    /// The host app's UIKit views un-mirror on their next launch through the appearance proxy, the
-    /// same way they mirror on one. Nothing here may bring that forward.
-    func testTheWalkNeverWritesToTheHostAppsViews() {
-        let controller = UIViewController()
-        let views = hierarchy(controller, setTo: stamped)
-        PseudoLocalizationLayout.clearForcedDirection(in: [views.root])
-        XCTAssertEqual(views.root.semanticContentAttribute, stamped)
-        XCTAssertEqual(views.child.semanticContentAttribute, stamped)
-        XCTAssertEqual(views.grandchild.semanticContentAttribute, stamped)
-    }
-
-    func testClearingAnAlreadyClearHierarchyChangesNothing() {
-        let container = UIViewController()
-        let views = hierarchy(container, setTo: .unspecified)
-        let hosting = HostingController()
-        container.addChild(hosting)
-        PseudoLocalizationLayout.clearForcedDirection(in: [views.root])
-        XCTAssertEqual(views.root.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(views.grandchild.semanticContentAttribute, .unspecified)
+    /// The asymmetry is the safe direction to err in: a switch left on in a TestFlight build and
+    /// carried into a store build through the same preferences file must be cleared, not preserved.
+    func testAnAppStoreBuildStillClearsAStaleKey() {
+        stubSwitchedOn()
+        apply(rightToLeft: false, isAppStore: true)
+        XCTAssertNil(defaults.object(forKey: textDirection))
+        XCTAssertNil(defaults.object(forKey: forceRightToLeft))
     }
 }
 #endif

--- a/Tests/ScytherTests/Features/PseudoLocalizationLayoutTests.swift
+++ b/Tests/ScytherTests/Features/PseudoLocalizationLayoutTests.swift
@@ -11,35 +11,44 @@ import SwiftUI
 import UIKit
 import XCTest
 
-/// Covers the half of ``PseudoLocalizationLayout`` that resets the views Scyther owns.
+/// Covers the half of ``PseudoLocalizationLayout`` that takes the appearance proxy's stamp back
+/// off Scyther's own UIKit chrome.
 ///
 /// The appearance proxy cannot be tested here — it is process-wide state with no reliable way to
 /// read the applied value back — but the walk that undoes its work can be, because it takes the
 /// views it should visit rather than going looking for windows. Every hierarchy below is real
-/// `UIView`s under a real `UIViewController`, so the responder chain the ownership rule climbs is
-/// the one UIKit builds rather than a stand-in for it.
+/// `UIView`s under a real `UIViewController`, so the responder chain the classifier climbs is the
+/// one UIKit builds rather than a stand-in for it.
+///
+/// What these tests can and cannot say is worth stating, because a previous version of this file
+/// said more than it could. They can say which attribute a view carries afterwards. They cannot
+/// say what the screen looks like: an earlier fix forced `.forceRightToLeft` onto Scyther's own
+/// views, passed every assertion here, and rendered the menu's text reversed glyph by glyph on a
+/// device. Hence ``testNothingSwiftUIHostsIsEverWrittenTo``, which is the assertion that would
+/// have caught it.
 @MainActor
 final class PseudoLocalizationLayoutTests: XCTestCase {
 
-    /// Stands in for a ``ScytherHostingController``: the marker is what ownership is decided by,
+    /// Stands in for a ``ScytherHostingController``: the marker is what the classifier decides on,
     /// and a plain controller carrying it exercises the same rule without needing SwiftUI to build
     /// a hosting view first.
-    private final class OwnedController: UIViewController, ScytherPresentedUI { }
+    private final class HostingController: UIViewController, ScytherPresentedUI { }
 
-    /// The attribute a view stamped by the appearance proxy while the mode was on would be left
-    /// holding once the mode is switched off — the state the fix exists to clear.
-    private let stale: UISemanticContentAttribute = .forceRightToLeft
+    /// The attribute the appearance proxy leaves on a view built while the mode was on, and the
+    /// only value the walk is allowed to overwrite.
+    private let stamped: UISemanticContentAttribute = .forceRightToLeft
 
-    /// A value neither switch position ever produces, so a view that still holds it was genuinely
-    /// left alone rather than coincidentally reset to the value "off" happens to use.
-    private let untouched: UISemanticContentAttribute = .forceLeftToRight
+    /// A value the walk must never produce or overwrite, so a view still holding it was genuinely
+    /// left alone rather than coincidentally reset to the value a clear happens to write.
+    private let foreignValue: UISemanticContentAttribute = .forceLeftToRight
 
     // MARK: - Helpers
 
-    /// A controller whose root view holds two nested subviews, all three stamped with `attribute`.
+    /// A controller whose root view holds two nested subviews, all three set to `attribute`.
+    @discardableResult
     private func hierarchy(
         _ controller: UIViewController,
-        stampedWith attribute: UISemanticContentAttribute
+        setTo attribute: UISemanticContentAttribute
     ) -> (root: UIView, child: UIView, grandchild: UIView) {
         let child = UIView()
         let grandchild = UIView()
@@ -51,132 +60,152 @@ final class PseudoLocalizationLayoutTests: XCTestCase {
         return (controller.view, child, grandchild)
     }
 
-    // MARK: - Ownership
+    // MARK: - Roles
 
-    func testAViewOwnedByAScytherControllerIsScythers() {
-        let controller = OwnedController()
-        let views = hierarchy(controller, stampedWith: .unspecified)
-        XCTAssertTrue(PseudoLocalizationLayout.isScytherOwned(views.root))
-        XCTAssertTrue(PseudoLocalizationLayout.isScytherOwned(views.grandchild))
+    func testAViewSwiftUIHostsForScytherIsRecognisedAsSuch() {
+        let controller = HostingController()
+        let views = hierarchy(controller, setTo: .unspecified)
+        XCTAssertEqual(PseudoLocalizationLayout.role(of: views.root), .swiftUIHosted)
+        XCTAssertEqual(PseudoLocalizationLayout.role(of: views.grandchild), .swiftUIHosted)
     }
 
-    func testAViewOwnedByTheAppIsNotScythers() {
-        let controller = UIViewController()
-        let views = hierarchy(controller, stampedWith: .unspecified)
-        XCTAssertFalse(PseudoLocalizationLayout.isScytherOwned(views.root))
-        XCTAssertFalse(PseudoLocalizationLayout.isScytherOwned(views.grandchild))
-    }
-
-    func testAContainerHostingAScytherControllerIsScythers() {
+    func testTheChromeAroundAPresentedScytherScreenIsRecognisedAsScythers() {
         let container = UIViewController()
-        let scyther = OwnedController()
-        container.addChild(scyther)
-        container.view.addSubview(scyther.view)
-        XCTAssertTrue(PseudoLocalizationLayout.isScytherOwned(container.view))
+        let bar = UIView()
+        container.view.addSubview(bar)
+        let hosting = HostingController()
+        container.addChild(hosting)
+        container.view.addSubview(hosting.view)
+        XCTAssertEqual(PseudoLocalizationLayout.role(of: container.view), .scytherChrome)
+        XCTAssertEqual(PseudoLocalizationLayout.role(of: bar), .scytherChrome)
     }
 
-    func testScythersOwnOverlayViewsAreScythers() {
-        XCTAssertTrue(PseudoLocalizationLayout.isScytherOwned(TopLevelViewsWrapper()))
-        XCTAssertTrue(PseudoLocalizationLayout.isScytherOwned(TopLevelView()))
+    func testScythersOwnOverlayViewsAreRecognisedAsScythers() {
+        XCTAssertEqual(PseudoLocalizationLayout.role(of: TopLevelViewsWrapper()), .scytherChrome)
+        XCTAssertEqual(PseudoLocalizationLayout.role(of: TopLevelView()), .scytherChrome)
     }
 
-    // MARK: - Switching on
-
-    func testSwitchingOnForcesRightToLeftOnEveryViewScytherOwns() {
-        let controller = OwnedController()
-        let views = hierarchy(controller, stampedWith: .unspecified)
-        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: true, in: [views.root])
-        XCTAssertEqual(views.root.semanticContentAttribute, .forceRightToLeft)
-        XCTAssertEqual(views.child.semanticContentAttribute, .forceRightToLeft)
-        XCTAssertEqual(views.grandchild.semanticContentAttribute, .forceRightToLeft)
+    func testAViewOwnedByTheAppIsForeign() {
+        let controller = UIViewController()
+        let views = hierarchy(controller, setTo: .unspecified)
+        XCTAssertEqual(PseudoLocalizationLayout.role(of: views.root), .foreign)
+        XCTAssertEqual(PseudoLocalizationLayout.role(of: views.grandchild), .foreign)
     }
 
-    // MARK: - Switching off
+    // MARK: - Clearing
 
-    func testSwitchingOffClearsEveryViewScytherOwns() {
-        let controller = OwnedController()
-        let views = hierarchy(controller, stampedWith: stale)
-        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: false, in: [views.root])
+    func testClearingTakesTheStampOffScythersChrome() {
+        let container = UIViewController()
+        let views = hierarchy(container, setTo: stamped)
+        let hosting = HostingController()
+        container.addChild(hosting)
+        PseudoLocalizationLayout.clearForcedDirection(in: [views.root])
         XCTAssertEqual(views.root.semanticContentAttribute, .unspecified)
         XCTAssertEqual(views.child.semanticContentAttribute, .unspecified)
         XCTAssertEqual(views.grandchild.semanticContentAttribute, .unspecified)
     }
 
-    /// The defect as reported: on, then off, and the menu is still mirrored.
-    func testSwitchingOnThenOffLeavesNothingOfScythersMirrored() {
-        let controller = OwnedController()
-        let views = hierarchy(controller, stampedWith: .unspecified)
-        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: true, in: [views.root])
-        for view in [views.root, views.child, views.grandchild] {
-            XCTAssertEqual(view.semanticContentAttribute, .forceRightToLeft)
-            XCTAssertEqual(view.effectiveUserInterfaceLayoutDirection, .rightToLeft)
+    /// `.unspecified` rather than `.forceLeftToRight`, so a genuinely Arabic device is handed back
+    /// to its own language rather than pinned the other way.
+    func testClearingWritesUnspecifiedRatherThanForcingTheOtherDirection() {
+        let container = UIViewController()
+        let views = hierarchy(container, setTo: stamped)
+        let hosting = HostingController()
+        container.addChild(hosting)
+        PseudoLocalizationLayout.clearForcedDirection(in: [views.root])
+        XCTAssertNotEqual(views.root.semanticContentAttribute, .forceLeftToRight)
+        XCTAssertEqual(views.root.effectiveUserInterfaceLayoutDirection, .leftToRight)
+    }
+
+    /// The walk exists to undo one specific stamp, so a view holding anything else was never this
+    /// feature's to touch.
+    func testClearingLeavesAViewHoldingAnyOtherValueAlone() {
+        let container = UIViewController()
+        let views = hierarchy(container, setTo: foreignValue)
+        let hosting = HostingController()
+        container.addChild(hosting)
+        PseudoLocalizationLayout.clearForcedDirection(in: [views.root])
+        XCTAssertEqual(views.root.semanticContentAttribute, foreignValue)
+        XCTAssertEqual(views.child.semanticContentAttribute, foreignValue)
+        XCTAssertEqual(views.grandchild.semanticContentAttribute, foreignValue)
+    }
+
+    /// The assertion the earlier fix would have failed: the walk must not write to a view SwiftUI
+    /// hosts, even one the appearance proxy stamped, because forcing a direction on a hosting view
+    /// mirrors the text it renders.
+    func testNothingSwiftUIHostsIsEverWrittenTo() {
+        let hosting = HostingController()
+        let views = hierarchy(hosting, setTo: stamped)
+        PseudoLocalizationLayout.clearForcedDirection(in: [views.root])
+        XCTAssertEqual(views.root.semanticContentAttribute, stamped)
+        XCTAssertEqual(views.child.semanticContentAttribute, stamped)
+        XCTAssertEqual(views.grandchild.semanticContentAttribute, stamped)
+    }
+
+    func testTheWalkStopsAtAHostingViewWhileClearingTheChromeAroundIt() {
+        let container = UIViewController()
+        let bar = UIView()
+        container.view.addSubview(bar)
+        let hosting = HostingController()
+        container.addChild(hosting)
+        container.view.addSubview(hosting.view)
+        let hosted = UIView()
+        hosting.view.addSubview(hosted)
+        for view in [container.view!, bar, hosting.view!, hosted] {
+            view.semanticContentAttribute = stamped
         }
-        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: false, in: [views.root])
-        for view in [views.root, views.child, views.grandchild] {
-            XCTAssertEqual(view.semanticContentAttribute, .unspecified)
-            XCTAssertEqual(view.effectiveUserInterfaceLayoutDirection, .leftToRight)
-        }
+
+        PseudoLocalizationLayout.clearForcedDirection(in: [container.view])
+
+        XCTAssertEqual(container.view.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(bar.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(hosting.view.semanticContentAttribute, stamped)
+        XCTAssertEqual(hosted.semanticContentAttribute, stamped)
     }
 
     // MARK: - Descending from a window
 
-    func testTheWalkFindsScythersViewsBelowViewsThatAreNot() {
+    func testTheWalkFindsScythersChromeBelowViewsThatAreNot() {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
         let app = UIViewController()
-        let appViews = hierarchy(app, stampedWith: untouched)
+        let appViews = hierarchy(app, setTo: stamped)
         window.rootViewController = app
-        let scyther = OwnedController()
-        let scytherViews = hierarchy(scyther, stampedWith: stale)
-        window.addSubview(scyther.view)
 
-        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: false, in: [window])
+        let container = UIViewController()
+        let scytherViews = hierarchy(container, setTo: stamped)
+        let hosting = HostingController()
+        container.addChild(hosting)
+        window.addSubview(container.view)
+
+        PseudoLocalizationLayout.clearForcedDirection(in: [window])
 
         XCTAssertEqual(scytherViews.root.semanticContentAttribute, .unspecified)
         XCTAssertEqual(scytherViews.child.semanticContentAttribute, .unspecified)
         XCTAssertEqual(scytherViews.grandchild.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(appViews.root.semanticContentAttribute, untouched)
-        XCTAssertEqual(appViews.child.semanticContentAttribute, untouched)
-        XCTAssertEqual(appViews.grandchild.semanticContentAttribute, untouched)
+        XCTAssertEqual(appViews.root.semanticContentAttribute, stamped)
+        XCTAssertEqual(appViews.child.semanticContentAttribute, stamped)
+        XCTAssertEqual(appViews.grandchild.semanticContentAttribute, stamped)
     }
 
-    func testTheWalkReachesAContainersOwnViewsAndNotTheAppsAroundIt() {
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
-        let app = UIViewController()
-        let appViews = hierarchy(app, stampedWith: untouched)
-        window.rootViewController = app
-
-        let container = UIViewController()
-        let bar = UIView()
-        container.view.addSubview(bar)
-        let scyther = OwnedController()
-        container.addChild(scyther)
-        container.view.addSubview(scyther.view)
-        for view in [container.view!, bar, scyther.view!] {
-            view.semanticContentAttribute = stale
-        }
-        window.addSubview(container.view)
-
-        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: false, in: [window])
-
-        XCTAssertEqual(bar.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(container.view.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(scyther.view.semanticContentAttribute, .unspecified)
-        XCTAssertEqual(appViews.root.semanticContentAttribute, untouched)
-    }
-
-    // MARK: - The host app
-
-    func testTheWalkLeavesTheHostAppsViewsAloneInBothDirections() {
+    /// The host app's UIKit views un-mirror on their next launch through the appearance proxy, the
+    /// same way they mirror on one. Nothing here may bring that forward.
+    func testTheWalkNeverWritesToTheHostAppsViews() {
         let controller = UIViewController()
-        let views = hierarchy(controller, stampedWith: untouched)
-        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: true, in: [views.root])
-        XCTAssertEqual(views.root.semanticContentAttribute, untouched)
-        XCTAssertEqual(views.child.semanticContentAttribute, untouched)
-        XCTAssertEqual(views.grandchild.semanticContentAttribute, untouched)
-        PseudoLocalizationLayout.applyToOwnedViews(rightToLeft: false, in: [views.root])
-        XCTAssertEqual(views.root.semanticContentAttribute, untouched)
-        XCTAssertEqual(views.child.semanticContentAttribute, untouched)
-        XCTAssertEqual(views.grandchild.semanticContentAttribute, untouched)
+        let views = hierarchy(controller, setTo: stamped)
+        PseudoLocalizationLayout.clearForcedDirection(in: [views.root])
+        XCTAssertEqual(views.root.semanticContentAttribute, stamped)
+        XCTAssertEqual(views.child.semanticContentAttribute, stamped)
+        XCTAssertEqual(views.grandchild.semanticContentAttribute, stamped)
+    }
+
+    func testClearingAnAlreadyClearHierarchyChangesNothing() {
+        let container = UIViewController()
+        let views = hierarchy(container, setTo: .unspecified)
+        let hosting = HostingController()
+        container.addChild(hosting)
+        PseudoLocalizationLayout.clearForcedDirection(in: [views.root])
+        XCTAssertEqual(views.root.semanticContentAttribute, .unspecified)
+        XCTAssertEqual(views.grandchild.semanticContentAttribute, .unspecified)
     }
 }
 #endif

--- a/Tests/ScytherTests/Features/PseudoLocalizationTests.swift
+++ b/Tests/ScytherTests/Features/PseudoLocalizationTests.swift
@@ -210,13 +210,5 @@ final class PseudoLocalizationTests: XCTestCase {
 
         wait(for: [announced], timeout: 1)
     }
-
-    func testForcingRightToLeftAsksForTheForcedAttribute() {
-        XCTAssertEqual(PseudoLocalizationLayout.attribute(rightToLeft: true), .forceRightToLeft)
-    }
-
-    func testNotForcingRightToLeftLeavesTheDirectionUnspecifiedRatherThanPinnedLeftToRight() {
-        XCTAssertEqual(PseudoLocalizationLayout.attribute(rightToLeft: false), .unspecified)
-    }
 }
 #endif

--- a/Tests/ScytherTests/Features/PseudoLocalizationTests.swift
+++ b/Tests/ScytherTests/Features/PseudoLocalizationTests.swift
@@ -42,8 +42,23 @@ final class PseudoLocalizationTests: XCTestCase {
         XCTAssertFalse(settings.showsKeys)
     }
 
-    func testNoModesAreStoredByDefault() {
-        XCTAssertTrue(settings.storedModes.isEmpty)
+    func testNoTextModeIsStoredByDefault() {
+        XCTAssertTrue(settings.storedModes.intersection(.textAffecting).isEmpty)
+        XCTAssertFalse(settings.storedModes.contains(.rightToLeft))
+    }
+
+    /// The one switch that is on with nothing stored, so an install that predates it keeps the
+    /// brackets it has always had.
+    func testShowingBoundariesIsOnByDefault() {
+        XCTAssertTrue(settings.showsBoundaries)
+        XCTAssertNil(defaults.object(forKey: "Scyther_pseudo_localization_show_boundaries"))
+        XCTAssertEqual(settings.storedModes, .showsBoundaries)
+    }
+
+    func testShowingBoundariesCanBeSwitchedOff() {
+        settings.showsBoundaries = false
+        XCTAssertFalse(settings.showsBoundaries)
+        XCTAssertFalse(settings.storedModes.contains(.showsBoundaries))
     }
 
     // MARK: - Persistence
@@ -72,6 +87,15 @@ final class PseudoLocalizationTests: XCTestCase {
         XCTAssertTrue(settings.showsKeys)
     }
 
+    func testShowsBoundariesPersistsUnderItsNamespacedKey() {
+        settings.showsBoundaries = false
+        XCTAssertEqual(defaults.object(forKey: "Scyther_pseudo_localization_show_boundaries") as? Bool, false)
+        XCTAssertFalse(settings.showsBoundaries)
+        settings.showsBoundaries = true
+        XCTAssertEqual(defaults.object(forKey: "Scyther_pseudo_localization_show_boundaries") as? Bool, true)
+        XCTAssertTrue(settings.showsBoundaries)
+    }
+
     func testASecondInstanceReadsWhatTheFirstWrote() {
         settings.accented = true
         XCTAssertTrue(PseudoLocalization(defaults: defaults).accented)
@@ -80,6 +104,7 @@ final class PseudoLocalizationTests: XCTestCase {
     // MARK: - Stored modes
 
     func testStoredModesReflectsEachSwitchIndependently() {
+        settings.showsBoundaries = false
         settings.accented = true
         XCTAssertEqual(settings.storedModes, .accented)
         settings.showsKeys = true
@@ -87,6 +112,11 @@ final class PseudoLocalizationTests: XCTestCase {
         settings.lengthened = true
         settings.rightToLeft = true
         XCTAssertEqual(settings.storedModes, [.accented, .showsKeys, .lengthened, .rightToLeft])
+        settings.showsBoundaries = true
+        XCTAssertEqual(
+            settings.storedModes,
+            [.accented, .showsKeys, .lengthened, .rightToLeft, .showsBoundaries]
+        )
     }
 
     // MARK: - Reset
@@ -99,11 +129,19 @@ final class PseudoLocalizationTests: XCTestCase {
 
         settings.reset()
 
-        XCTAssertTrue(settings.storedModes.isEmpty)
+        XCTAssertEqual(settings.storedModes, .showsBoundaries)
         XCTAssertFalse(defaults.bool(forKey: "Scyther_pseudo_localization_accented"))
         XCTAssertFalse(defaults.bool(forKey: "Scyther_pseudo_localization_lengthened"))
         XCTAssertFalse(defaults.bool(forKey: "Scyther_pseudo_localization_right_to_left"))
         XCTAssertFalse(defaults.bool(forKey: "Scyther_pseudo_localization_show_keys"))
+    }
+
+    /// Reset restores the shipped state rather than clearing every switch, and for the brackets
+    /// the shipped state is on.
+    func testResetPutsTheBoundariesBackOn() {
+        settings.showsBoundaries = false
+        settings.reset()
+        XCTAssertTrue(settings.showsBoundaries)
     }
 
     // MARK: - Production guard

--- a/Tests/ScytherTests/Features/PseudoLocalizationTests.swift
+++ b/Tests/ScytherTests/Features/PseudoLocalizationTests.swift
@@ -168,47 +168,5 @@ final class PseudoLocalizationTests: XCTestCase {
         XCTAssertFalse(PseudoLocalization.canAffectHostApp(isTestCase: false, isAppStore: true))
         XCTAssertFalse(PseudoLocalization.canAffectHostApp(isTestCase: true, isAppStore: true))
     }
-
-    // MARK: - Layout
-
-    func testForcingRightToLeftMirrorsAnEnglishInterface() {
-        XCTAssertEqual(
-            PseudoLocalizationLayout.layoutDirection(forcingRightToLeft: true, languageIdentifier: "en"),
-            .rightToLeft
-        )
-    }
-
-    func testAnEnglishInterfaceStaysLeftToRightWithTheModeOff() {
-        XCTAssertEqual(
-            PseudoLocalizationLayout.layoutDirection(forcingRightToLeft: false, languageIdentifier: "en"),
-            .leftToRight
-        )
-    }
-
-    func testAnArabicInterfaceIsStillRightToLeftWithTheModeOff() {
-        XCTAssertEqual(
-            PseudoLocalizationLayout.layoutDirection(forcingRightToLeft: false, languageIdentifier: "ar"),
-            .rightToLeft
-        )
-    }
-
-    func testForcingRightToLeftDoesNotFightAnArabicInterface() {
-        XCTAssertEqual(
-            PseudoLocalizationLayout.layoutDirection(forcingRightToLeft: true, languageIdentifier: "ar"),
-            .rightToLeft
-        )
-    }
-
-    func testApplyingEffectsAnnouncesTheChangeSoViewsAlreadyOnScreenCanReRender() {
-        let announced = expectation(
-            forNotification: PseudoLocalization.ModesChangedNotification,
-            object: nil,
-            handler: nil
-        )
-        settings.rightToLeft = true
-        settings.applyEffects(isTestCase: true, isAppStore: true)
-
-        wait(for: [announced], timeout: 1)
-    }
 }
 #endif

--- a/Tests/ScytherTests/Features/PseudoLocalizationTransformTests.swift
+++ b/Tests/ScytherTests/Features/PseudoLocalizationTransformTests.swift
@@ -211,7 +211,11 @@ final class PseudoLocalizationTransformTests: XCTestCase {
     }
 
     func testAccentingRunsBeforeLengtheningSoDelimitersStayPlain() {
-        let result = PseudoLocalizationTransform.apply(to: "Hello", key: "Hello", modes: [.accented, .lengthened])
+        let result = PseudoLocalizationTransform.apply(
+            to: "Hello",
+            key: "Hello",
+            modes: [.accented, .lengthened, .showsBoundaries]
+        )
         XCTAssertTrue(result.hasPrefix("["), "\(result) does not start with a plain bracket")
         XCTAssertTrue(result.hasSuffix("]"), "\(result) does not end with a plain bracket")
         XCTAssertTrue(result.contains("Ĥéļļö"), "\(result) does not contain the accented original")
@@ -221,7 +225,98 @@ final class PseudoLocalizationTransformTests: XCTestCase {
         XCTAssertFalse(PseudoLocalizationTransform.apply(to: "Hello", key: "Hello", modes: .accented).contains("["))
     }
 
+    // MARK: - Boundaries
+
+    func testLengtheningWithoutBoundariesDropsTheBrackets() {
+        let result = PseudoLocalizationTransform.apply(to: "Save changes", key: "Save changes", modes: .lengthened)
+        XCTAssertFalse(result.contains("["))
+        XCTAssertFalse(result.contains("]"))
+        XCTAssertTrue(result.contains("Save changes"))
+        XCTAssertTrue(result.contains(String(PseudoLocalizationTransform.paddingCharacter)))
+    }
+
+    func testLengtheningWithBoundariesKeepsTheBrackets() {
+        let result = PseudoLocalizationTransform.apply(
+            to: "Save changes",
+            key: "Save changes",
+            modes: [.lengthened, .showsBoundaries]
+        )
+        XCTAssertTrue(result.hasPrefix("["))
+        XCTAssertTrue(result.hasSuffix("]"))
+    }
+
+    /// The brackets are counted towards the target either way, so switching them off gives their
+    /// two characters back to the padding rather than shortening the result.
+    func testBothFormsExpandByTheSameAmount() {
+        for source in ["Save changes to your profile", "Network logs are empty"] {
+            XCTAssertEqual(
+                PseudoLocalizationTransform.lengthen(source, showingBoundaries: true).count,
+                PseudoLocalizationTransform.lengthen(source, showingBoundaries: false).count,
+                "\(source) expanded differently with and without its boundaries"
+            )
+        }
+    }
+
+    func testAccentingWithoutBoundariesIsUnchanged() {
+        let withBoundaries = PseudoLocalizationTransform.apply(
+            to: "Hello",
+            key: "Hello",
+            modes: [.accented, .showsBoundaries]
+        )
+        let without = PseudoLocalizationTransform.apply(to: "Hello", key: "Hello", modes: .accented)
+        XCTAssertEqual(withBoundaries, "Ĥéļļö")
+        XCTAssertEqual(without, "Ĥéļļö")
+    }
+
+    func testShowingKeysIsUnaffectedByBoundaries() {
+        for modes: PseudoLocalizationMode in [.showsKeys, [.showsKeys, .showsBoundaries]] {
+            XCTAssertEqual(
+                PseudoLocalizationTransform.apply(to: "Selected 5 items", key: "Selected %lld items", modes: modes),
+                "Selected %lld items"
+            )
+        }
+    }
+
+    func testAccentingAndLengtheningWithoutBoundariesKeepsTheAccentedOriginal() {
+        let result = PseudoLocalizationTransform.apply(to: "Hello", key: "Hello", modes: [.accented, .lengthened])
+        XCTAssertTrue(result.hasPrefix("Ĥéļļö"), "\(result) does not start with the accented original")
+        XCTAssertFalse(result.contains("["))
+    }
+
+    /// The mode modifies the others rather than transforming anything itself, so on its own — and
+    /// alongside a mode that changes no text — it must do nothing at all.
+    func testBoundariesAloneChangeNothing() {
+        let combinations: [PseudoLocalizationMode] = [
+            .showsBoundaries,
+            [],
+            [.showsBoundaries, .rightToLeft],
+            .rightToLeft,
+        ]
+        for modes in combinations {
+            XCTAssertEqual(
+                PseudoLocalizationTransform.apply(to: "Save changes", key: "Save changes", modes: modes),
+                "Save changes",
+                "modes \(modes.rawValue) transformed a string with no text mode on"
+            )
+        }
+    }
+
+    func testSwitchingBoundariesOffChangesNothingWhenNoTextModeIsOn() {
+        XCTAssertEqual(
+            PseudoLocalizationTransform.apply(to: "Save changes", key: "Save changes", modes: .showsBoundaries),
+            PseudoLocalizationTransform.apply(to: "Save changes", key: "Save changes", modes: [])
+        )
+    }
+
+    func testLengtheningWithoutBoundariesLeavesAnEmptyStringAlone() {
+        XCTAssertEqual(PseudoLocalizationTransform.lengthen("", showingBoundaries: false), "")
+    }
+
     // MARK: - Modes
+
+    func testShowingBoundariesIsNotATextMode() {
+        XCTAssertFalse(PseudoLocalizationMode.textAffecting.contains(.showsBoundaries))
+    }
 
     func testTextAffectingExcludesRightToLeft() {
         XCTAssertFalse(PseudoLocalizationMode.textAffecting.contains(.rightToLeft))

--- a/Tests/ScytherTests/Features/PseudoLocalizationViewModelTests.swift
+++ b/Tests/ScytherTests/Features/PseudoLocalizationViewModelTests.swift
@@ -1,0 +1,79 @@
+//
+//  PseudoLocalizationViewModelTests.swift
+//  ScytherTests
+//
+//  Created by Brandon Stillitano on 7/9/2026.
+//
+
+#if !os(macOS)
+@testable import Scyther
+import XCTest
+
+/// Covers the relaunch alert the Right to Left switch raises.
+///
+/// Right to Left takes effect only when the process next starts, so a developer who flicks it and
+/// sees nothing move has been told nothing at all. The alert is the whole of that explanation, and
+/// these tests pin the one thing about it that can be got wrong quietly: *when* it is raised.
+@MainActor
+final class PseudoLocalizationViewModelTests: XCTestCase {
+
+    /// The view model writes through to the shared singleton, which is backed by the developer's
+    /// own settings suite. Restored afterwards so running the suite does not switch a mode on or
+    /// off behind their back.
+    private var restore: Bool = false
+
+    override func setUp() {
+        super.setUp()
+        restore = PseudoLocalization.instance.rightToLeft
+    }
+
+    override func tearDown() {
+        PseudoLocalization.instance.rightToLeft = restore
+        super.tearDown()
+    }
+
+    func testSwitchingRightToLeftOnRaisesTheRelaunchAlert() {
+        let viewModel = PseudoLocalizationViewModel()
+        viewModel.rightToLeft = true
+        XCTAssertTrue(viewModel.showingRelaunchAlert)
+    }
+
+    /// Both directions, unlike the language page's alert. Switching off is just as invisible as
+    /// switching on: the keys go immediately and the running process keeps the direction it
+    /// launched with.
+    func testSwitchingRightToLeftOffRaisesTheRelaunchAlertToo() {
+        let viewModel = PseudoLocalizationViewModel()
+        viewModel.rightToLeft = true
+        viewModel.showingRelaunchAlert = false
+        viewModel.rightToLeft = false
+        XCTAssertTrue(viewModel.showingRelaunchAlert)
+    }
+
+    func testATextModeDoesNotRaiseTheRelaunchAlert() {
+        let viewModel = PseudoLocalizationViewModel()
+        viewModel.accented = true
+        viewModel.lengthened = true
+        viewModel.showsKeys = true
+        viewModel.showsBoundaries = false
+        XCTAssertFalse(viewModel.showingRelaunchAlert)
+    }
+
+    /// Turning everything off is the other way to switch right-to-left off, and the one most
+    /// likely to be reached by someone trying to put things back.
+    func testTurningEverythingOffRaisesTheAlertWhenRightToLeftWasOn() {
+        let viewModel = PseudoLocalizationViewModel()
+        viewModel.rightToLeft = true
+        viewModel.showingRelaunchAlert = false
+        viewModel.turnEverythingOff()
+        XCTAssertTrue(viewModel.showingRelaunchAlert)
+    }
+
+    func testTurningEverythingOffIsSilentWhenRightToLeftWasAlreadyOff() {
+        let viewModel = PseudoLocalizationViewModel()
+        viewModel.rightToLeft = false
+        viewModel.showingRelaunchAlert = false
+        viewModel.turnEverythingOff()
+        XCTAssertFalse(viewModel.showingRelaunchAlert)
+    }
+}
+#endif


### PR DESCRIPTION
Two things, both found by running the app on the simulator.

## Right to Left never turned off

Reported as: *"Turn on RTL, go back, view is RTL, turn off RTL, go back, view is RTL."*

The mode wrote `AppleTextDirection` and `NSForceRightToLeftWritingDirection` into the host app's defaults — the keys Xcode's own **Right to Left Pseudolanguage** scheme option sets, which is what makes the mode reach UIKit as well as SwiftUI. Those keys apply to UIKit live but only *un*-apply at relaunch, while the SwiftUI `\.layoutDirection` environment the mode also installed flipped immediately. The two halves disagreed, and the disagreement rendered as reversed glyphs: `Fonts` came out `stnoF`.

The fix is to stop having two halves. Right to Left is now a next-launch setting on every surface:

- The keys are still written on, and removed on off.
- The SwiftUI environment half is gone. Nothing mirrors mid-session, so nothing can disagree. `layoutDirection` lost its forcing parameter and is now `LanguageOverride.layoutDirection(forLanguage:)`; `ModesChangedNotification` went with it.
- Both directions raise the same **Relaunch required** alert the language override already uses — *Later* / *Quit App* — so a switch that visibly does nothing is never a surprise. `quitApp()` moved up to the base `ViewModel` so both features share one implementation. Turn Everything Off raises it too.

A second defect turned up while verifying that: `MenuView` pinned `\.layoutDirection` unconditionally to the language override's direction — `.leftToRight` whenever no override was set, which is the usual case — and that beat the launch keys. Relaunched with the mode on, the host app mirrored and Scyther's menu, alone on screen, did not. `menuLayoutDirection` now returns nil with no override, installed through `transformEnvironment`, so nil means "inherit the process" rather than "left to right".

## Show Boundaries

The lengthening mode wrapped every string in brackets with no way to turn that off. It is now its own switch, default on, with its own section: it marks where a string starts and ends so a truncated one is visible, and only appears alongside another text mode.

## Verification

Both directions, on the simulator, after a relaunch:

- **On:** the host app and Scyther's menu are both mirrored, and every string reads forwards.
- **Off:** both are left to right and readable — `Fonts`, `Interface Components`, close button on the left, chevrons on the right.
- Flicking the switch mid-session changes nothing on screen except the alert.

1,786 tests passing.