### PR TITLE
Probe: does a newer runner image let SwiftUI publish accessibility elements?

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.0'
+          xcode-version: '26.2'
 
       - name: Build Debug
         run: |
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.0'
+          xcode-version: '26.2'
 
       - name: Catalog generator tests
         run: |
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.0'
+          xcode-version: '26.2'
 
       - name: Build Example App
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
   test:
     name: Run Tests
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Tests/ScytherTests/Features/AccessibilityAuditWalkCostTests.swift
+++ b/Tests/ScytherTests/Features/AccessibilityAuditWalkCostTests.swift
@@ -79,7 +79,7 @@ final class AccessibilityAuditWalkCostTests: XCTestCase {
         window.addSubview(UIView(frame: CGRect(x: 0, y: 0, width: 44, height: 44)))
         window.addSubview(UIView(frame: CGRect(x: 0, y: 100, width: 44, height: 44)))
 
-        _ = AccessibilityAuditor().collect(root: window)
+        _ = AccessibilityAuditor.unbudgeted().collect(root: window)
 
         XCTAssertEqual(asked, 3, "the window and its two subviews, once each")
     }
@@ -93,7 +93,7 @@ final class AccessibilityAuditWalkCostTests: XCTestCase {
         let leaf = CountingLeaf()
         let root = CountingLeaf(isElement: false, children: [leaf])
 
-        let result = AccessibilityAuditor().audit(root: root,
+        let result = AccessibilityAuditor.unbudgeted().audit(root: root,
                                                   checks: [.missingLabel, .touchTarget],
                                                   sampler: nil)
 
@@ -120,7 +120,7 @@ final class AccessibilityAuditWalkCostTests: XCTestCase {
         }
         CountingResponderView.nextReads = 0
 
-        _ = AccessibilityAuditor().collect(root: window)
+        _ = AccessibilityAuditor.unbudgeted().collect(root: window)
 
         XCTAssertLessThanOrEqual(CountingResponderView.nextReads, 24,
                                  "each of the twelve views should climb about one link, not twelve")

--- a/Tests/ScytherTests/Features/AccessibilityAuditorChecksTests.swift
+++ b/Tests/ScytherTests/Features/AccessibilityAuditorChecksTests.swift
@@ -1059,17 +1059,17 @@ extension AccessibilityAuditorChecksTests {
     /// it, because the stand-in is only worth anything if it is the shape SwiftUI really produces.
     /// A `List` of `Text` vends `AccessibilityNode`s — synthetic elements, `.staticText`, no
     /// `UILabel` anywhere in the hierarchy — and every one of them has to be measured.
-    func testARealSwiftUIListIsContrastMeasuredElementByElement() {
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
-        let host = UIHostingController(rootView: List {
-            Text("Hard to read text") // scyther:unlocalised test fixture
-            Text("Another line") // scyther:unlocalised test fixture
-        })
-        window.rootViewController = host
-        window.makeKeyAndVisible()
-        host.view.frame = window.bounds
-        host.view.layoutIfNeeded()
-        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+    func testARealSwiftUIListIsContrastMeasuredElementByElement() throws {
+        // Waits for both rows to be published rather than giving SwiftUI a fixed half-second: that
+        // was long enough on the development toolchain and never long enough on CI's, which is how
+        // this test was red on every CI run since the audit landed. See `HostedSwiftUIWindow`.
+        let window = try HostedSwiftUIWindow.make(
+            hosting: List {
+                Text("Hard to read text") // scyther:unlocalised test fixture
+                Text("Another line") // scyther:unlocalised test fixture
+            },
+            isReady: { HostedSwiftUIWindow.publishedAccessibilityElementCount($0) >= 2 }
+        )
 
         let auditor = AccessibilityAuditor()
         let walked = auditor.collect(root: window)

--- a/Tests/ScytherTests/Features/AccessibilityAuditorChecksTests.swift
+++ b/Tests/ScytherTests/Features/AccessibilityAuditorChecksTests.swift
@@ -54,7 +54,7 @@ final class AccessibilityAuditorChecksTests: XCTestCase {
     func testAButtonWithNoLabelIsAnError() {
         let root = Node(children: [Node(traits: .button, isElement: true)])
 
-        let findings = AccessibilityAuditor().audit(root: root, checks: [.missingLabel], sampler: nil).findings
+        let findings = AccessibilityAuditor.unbudgeted().audit(root: root, checks: [.missingLabel], sampler: nil).findings
 
         XCTAssertEqual(findings.count, 1)
         XCTAssertEqual(findings.first?.check, .missingLabel)
@@ -63,25 +63,25 @@ final class AccessibilityAuditorChecksTests: XCTestCase {
 
     func testAWhitespaceLabelIsNoLabelAtAll() {
         let root = Node(children: [Node(label: "   ", traits: .image, isElement: true)])
-        XCTAssertEqual(AccessibilityAuditor().audit(root: root, checks: [.missingLabel], sampler: nil).findings.count, 1)
+        XCTAssertEqual(AccessibilityAuditor.unbudgeted().audit(root: root, checks: [.missingLabel], sampler: nil).findings.count, 1)
     }
 
     /// Static text carries its content as its label; there is nothing missing.
     func testStaticTextIsExemptFromTheLabelCheck() {
         let root = Node(children: [Node(traits: .staticText, isElement: true)])
-        XCTAssertTrue(AccessibilityAuditor().audit(root: root, checks: [.missingLabel], sampler: nil).findings.isEmpty)
+        XCTAssertTrue(AccessibilityAuditor.unbudgeted().audit(root: root, checks: [.missingLabel], sampler: nil).findings.isEmpty)
     }
 
     func testALabelledButtonPasses() {
         let root = Node(children: [Node(label: "Close", traits: .button, isElement: true)])
-        XCTAssertTrue(AccessibilityAuditor().audit(root: root, checks: [.missingLabel], sampler: nil).findings.isEmpty)
+        XCTAssertTrue(AccessibilityAuditor.unbudgeted().audit(root: root, checks: [.missingLabel], sampler: nil).findings.isEmpty)
     }
 
     func testATargetWellUnderTheMinimumIsAnError() {
         let small = Node(label: "Close", traits: .button,
                          frame: CGRect(x: 0, y: 0, width: 20, height: 20), isElement: true)
 
-        let findings = AccessibilityAuditor().audit(root: Node(children: [small]), checks: [.touchTarget], sampler: nil).findings
+        let findings = AccessibilityAuditor.unbudgeted().audit(root: Node(children: [small]), checks: [.touchTarget], sampler: nil).findings
 
         XCTAssertEqual(findings.first?.severity, .error)
         XCTAssertTrue(findings.first?.detail.contains("20") == true, "the finding reports what it measured")
@@ -91,7 +91,7 @@ final class AccessibilityAuditorChecksTests: XCTestCase {
         let short = Node(label: "Close", traits: .button,
                          frame: CGRect(x: 0, y: 0, width: 44, height: 36), isElement: true)
 
-        let findings = AccessibilityAuditor().audit(root: Node(children: [short]), checks: [.touchTarget], sampler: nil).findings
+        let findings = AccessibilityAuditor.unbudgeted().audit(root: Node(children: [short]), checks: [.touchTarget], sampler: nil).findings
 
         XCTAssertEqual(findings.first?.severity, .warning)
     }
@@ -99,7 +99,7 @@ final class AccessibilityAuditorChecksTests: XCTestCase {
     func testAFortyFourPointTargetPasses() {
         let fine = Node(label: "Close", traits: .button,
                         frame: CGRect(x: 0, y: 0, width: 44, height: 44), isElement: true)
-        XCTAssertTrue(AccessibilityAuditor().audit(root: Node(children: [fine]), checks: [.touchTarget], sampler: nil).findings.isEmpty)
+        XCTAssertTrue(AccessibilityAuditor.unbudgeted().audit(root: Node(children: [fine]), checks: [.touchTarget], sampler: nil).findings.isEmpty)
     }
 
     /// A target between the AA floor and Apple's 44 is short of guidance but not of any
@@ -108,7 +108,7 @@ final class AccessibilityAuditorChecksTests: XCTestCase {
         let boundary = Node(label: "Close", traits: .button,
                             frame: CGRect(x: 0, y: 0, width: 32, height: 32), isElement: true)
 
-        let findings = AccessibilityAuditor().audit(root: Node(children: [boundary]), checks: [.touchTarget], sampler: nil).findings
+        let findings = AccessibilityAuditor.unbudgeted().audit(root: Node(children: [boundary]), checks: [.touchTarget], sampler: nil).findings
 
         XCTAssertEqual(findings.first?.severity, .warning)
     }
@@ -117,14 +117,14 @@ final class AccessibilityAuditorChecksTests: XCTestCase {
     func testTextIsExemptFromTheTargetCheck() {
         let text = Node(label: "Hello", traits: .staticText,
                         frame: CGRect(x: 0, y: 0, width: 10, height: 10), isElement: true)
-        XCTAssertTrue(AccessibilityAuditor().audit(root: Node(children: [text]), checks: [.touchTarget], sampler: nil).findings.isEmpty)
+        XCTAssertTrue(AccessibilityAuditor.unbudgeted().audit(root: Node(children: [text]), checks: [.touchTarget], sampler: nil).findings.isEmpty)
     }
 
     /// A check that is switched off is not run, and the result says which ones did run.
     func testOnlyTheRequestedChecksRun() {
         let bad = Node(traits: .button, frame: CGRect(x: 0, y: 0, width: 10, height: 10), isElement: true)
 
-        let result = AccessibilityAuditor().audit(root: Node(children: [bad]), checks: [.touchTarget], sampler: nil)
+        let result = AccessibilityAuditor.unbudgeted().audit(root: Node(children: [bad]), checks: [.touchTarget], sampler: nil)
 
         XCTAssertEqual(result.findings.map(\.check), [.touchTarget])
         XCTAssertEqual(result.checksRun, [.touchTarget])
@@ -136,7 +136,7 @@ final class AccessibilityAuditorChecksTests: XCTestCase {
         let node = Node(traits: .button, frame: CGRect(x: 12, y: 34, width: 10, height: 10),
                         isElement: true, typeName: "UIButton")
 
-        let findings = AccessibilityAuditor().audit(root: Node(children: [node]), checks: [.missingLabel], sampler: nil).findings
+        let findings = AccessibilityAuditor.unbudgeted().audit(root: Node(children: [node]), checks: [.missingLabel], sampler: nil).findings
 
         XCTAssertTrue(findings.first?.elementName.contains("UIButton") == true)
         XCTAssertTrue(findings.first?.elementName.contains("12") == true)
@@ -184,7 +184,7 @@ final class AccessibilityAuditorChecksTests: XCTestCase {
         let text = Node(label: "Body copy", traits: .staticText, frame: frame, isElement: true)
         let sampler = RecordingSampler(pixels: midThresholdPixels)
 
-        _ = AccessibilityAuditor().audit(root: Node(children: [text]),
+        _ = AccessibilityAuditor.unbudgeted().audit(root: Node(children: [text]),
                                          checks: [.contrast],
                                          sampler: sampler)
 
@@ -199,7 +199,7 @@ final class AccessibilityAuditorChecksTests: XCTestCase {
         let text = Node(label: "Hello", traits: .staticText,
                         frame: CGRect(x: 0, y: 0, width: 80, height: 16), isElement: true)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [text]), checks: [.contrast], sampler: sampler).findings
 
         XCTAssertEqual(findings.first?.check, .contrast)
@@ -221,7 +221,7 @@ final class AccessibilityAuditorChecksTests: XCTestCase {
                          frame: CGRect(x: 0, y: 0, width: 200, height: 30), isElement: true,
                          fontPointSize: 17)
 
-        let auditor = AccessibilityAuditor()
+        let auditor = AccessibilityAuditor.unbudgeted()
         XCTAssertTrue(auditor.audit(root: Node(children: [large]), checks: [.contrast], sampler: sampler).findings.isEmpty)
         XCTAssertEqual(auditor.audit(root: Node(children: [small]), checks: [.contrast], sampler: sampler).findings.count, 1)
     }
@@ -232,7 +232,7 @@ final class AccessibilityAuditorChecksTests: XCTestCase {
         let image = Node(label: "Sunset", traits: .image,
                          frame: CGRect(x: 0, y: 0, width: 200, height: 200), isElement: true)
 
-        XCTAssertTrue(AccessibilityAuditor().audit(root: Node(children: [image]), checks: [.contrast], sampler: sampler).findings.isEmpty)
+        XCTAssertTrue(AccessibilityAuditor.unbudgeted().audit(root: Node(children: [image]), checks: [.contrast], sampler: sampler).findings.isEmpty)
     }
 }
 
@@ -256,7 +256,7 @@ extension AccessibilityAuditorChecksTests {
                             frame: CGRect(x: 0, y: 0, width: 200, height: 16), isElement: true)
         let sampler = StubSampler(pixels: midThresholdPixels)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [disabled]), checks: [.contrast], sampler: sampler).findings
 
         XCTAssertTrue(findings.isEmpty, "WCAG 1.4.3 does not apply to an inactive component")
@@ -270,7 +270,7 @@ extension AccessibilityAuditorChecksTests {
                         drawsText: false)
         let sampler = StubSampler(pixels: midThresholdPixels)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [icon]), checks: [.contrast], sampler: sampler).findings
 
         XCTAssertTrue(findings.isEmpty, "3.35:1 clears 1.4.11's 3:1 for non-text content")
@@ -283,7 +283,7 @@ extension AccessibilityAuditorChecksTests {
                         frame: CGRect(x: 0, y: 0, width: 200, height: 16), isElement: true)
         let sampler = StubSampler(pixels: midThresholdPixels)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [text]), checks: [.contrast], sampler: sampler).findings
 
         XCTAssertEqual(findings.count, 1)
@@ -295,7 +295,7 @@ extension AccessibilityAuditorChecksTests {
         let link = Node(label: "Terms of Service", traits: .link,
                         frame: CGRect(x: 0, y: 0, width: 120, height: 18), isElement: true)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [link]), checks: [.touchTarget], sampler: nil).findings
 
         XCTAssertEqual(findings.first?.severity, .warning)
@@ -307,7 +307,7 @@ extension AccessibilityAuditorChecksTests {
         let untraited = Node(traits: .none, frame: CGRect(x: 0, y: 0, width: 20, height: 20),
                              isElement: true)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [untraited]), checks: [.missingLabel], sampler: nil).findings
 
         XCTAssertEqual(findings.count, 1)
@@ -320,7 +320,7 @@ extension AccessibilityAuditorChecksTests {
         let tiny = Node(label: "Close", traits: .button,
                         frame: CGRect(x: 0, y: 0, width: 44, height: 20), isElement: true)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [tiny]), checks: [.touchTarget], sampler: nil).findings
 
         XCTAssertEqual(findings.first?.severity, .error)
@@ -332,7 +332,7 @@ extension AccessibilityAuditorChecksTests {
         let boundary = Node(label: "Close", traits: .button,
                             frame: CGRect(x: 0, y: 0, width: 24, height: 24), isElement: true)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [boundary]), checks: [.touchTarget], sampler: nil).findings
 
         XCTAssertEqual(findings.first?.severity, .warning)
@@ -346,7 +346,7 @@ extension AccessibilityAuditorChecksTests {
                            frame: CGRect(x: 0, y: 0, width: 200, height: 40), isElement: true)
         let sampler = StubSampler(pixels: midThresholdPixels)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [wrapped]), checks: [.contrast], sampler: sampler).findings
 
         XCTAssertEqual(findings.count, 1, "a tall label is a wrapped label, not a large one")
@@ -387,7 +387,7 @@ extension AccessibilityAuditorChecksTests {
         func findings(atRatio ratio: Double) -> Int {
             let text = Node(label: "Body copy", traits: .staticText,
                             frame: CGRect(x: 0, y: 0, width: 200, height: 16), isElement: true)
-            return AccessibilityAuditor().audit(root: Node(children: [text]),
+            return AccessibilityAuditor.unbudgeted().audit(root: Node(children: [text]),
                                                 checks: [.contrast],
                                                 sampler: StubSampler(pixels: inkOnWhite(greyMeasuring(ratio))))
                 .findings.count
@@ -406,7 +406,7 @@ extension AccessibilityAuditorChecksTests {
             let icon = Node(label: "Share", traits: .button,
                             frame: CGRect(x: 0, y: 0, width: 44, height: 44), isElement: true,
                             drawsText: false)
-            return AccessibilityAuditor().audit(root: Node(children: [icon]),
+            return AccessibilityAuditor.unbudgeted().audit(root: Node(children: [icon]),
                                                 checks: [.contrast],
                                                 sampler: StubSampler(pixels: inkOnWhite(greyMeasuring(ratio))))
                 .findings.count
@@ -459,7 +459,7 @@ extension AccessibilityAuditorChecksTests {
             (flat, Array(repeating: RGB(red: 1, green: 1, blue: 1), count: 100))
         ])
 
-        let result = AccessibilityAuditor().audit(root: root, checks: [.contrast], sampler: sampler)
+        let result = AccessibilityAuditor.unbudgeted().audit(root: root, checks: [.contrast], sampler: sampler)
 
         XCTAssertEqual(result.contrastCandidates, 2, "both elements were text the check was asked about")
         XCTAssertEqual(result.contrastMeasurements, 1, "only one of them had two colours in it")
@@ -471,7 +471,7 @@ extension AccessibilityAuditorChecksTests {
         let image = Node(label: "Sunset", traits: .image,
                          frame: CGRect(x: 0, y: 0, width: 200, height: 200), isElement: true)
 
-        let result = AccessibilityAuditor().audit(root: Node(children: [image]),
+        let result = AccessibilityAuditor.unbudgeted().audit(root: Node(children: [image]),
                                                   checks: [.contrast],
                                                   sampler: StubSampler(pixels: midThresholdPixels))
 
@@ -498,7 +498,7 @@ extension AccessibilityAuditorChecksTests {
 
         let small = Node(label: "12", traits: .staticText,
                          frame: CGRect(x: 0, y: 0, width: 8, height: 8), isElement: true)
-        let result = AccessibilityAuditor().audit(root: Node(children: [small]),
+        let result = AccessibilityAuditor.unbudgeted().audit(root: Node(children: [small]),
                                                   checks: [.contrast],
                                                   sampler: StubSampler(pixels: pixels))
 
@@ -523,7 +523,7 @@ extension AccessibilityAuditorChecksTests {
         })
         let sampler = FrameKeyedSampler(byFrame: [(readable, midThresholdPixels)])
 
-        let result = AccessibilityAuditor().audit(root: root, checks: [.contrast], sampler: sampler)
+        let result = AccessibilityAuditor.unbudgeted().audit(root: root, checks: [.contrast], sampler: sampler)
 
         XCTAssertEqual(result.contrastCandidates, 4)
         XCTAssertEqual(result.contrastMeasurements, 1)
@@ -544,7 +544,7 @@ extension AccessibilityAuditorChecksTests {
                                         frame: CGRect(x: 0, y: 0, width: 100, height: 16),
                                         isElement: true)])
 
-        let result = AccessibilityAuditor().audit(root: root,
+        let result = AccessibilityAuditor.unbudgeted().audit(root: root,
                                                   checks: [.contrast],
                                                   sampler: StubSampler(pixels: []))
 
@@ -572,7 +572,7 @@ extension AccessibilityAuditorChecksTests {
                            frame: CGRect(x: 0, y: 0, width: 200, height: 16), isElement: true,
                            fontPointSize: 14)
         let sampler = StubSampler(pixels: midThresholdPixels)
-        let auditor = AccessibilityAuditor()
+        let auditor = AccessibilityAuditor.unbudgeted()
 
         XCTAssertTrue(auditor.audit(root: Node(children: [bold]), checks: [.contrast], sampler: sampler).findings.isEmpty)
         XCTAssertEqual(auditor.audit(root: Node(children: [regular]), checks: [.contrast], sampler: sampler).findings.count, 1)
@@ -585,7 +585,7 @@ extension AccessibilityAuditorChecksTests {
                           frame: CGRect(x: 0, y: 0, width: 200, height: 44), isElement: true,
                           drawsText: true)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [titled]), checks: [.contrast], sampler: StubSampler(pixels: midThresholdPixels)).findings
 
         XCTAssertEqual(findings.count, 1, "a padded button's title is still body text")
@@ -597,7 +597,7 @@ extension AccessibilityAuditorChecksTests {
         let unknown = Node(label: "Something", traits: .staticText,
                            frame: CGRect(x: 0, y: 0, width: 200, height: 60), isElement: true)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [unknown]), checks: [.contrast], sampler: StubSampler(pixels: midThresholdPixels)).findings
 
         XCTAssertEqual(findings.count, 1)
@@ -609,7 +609,7 @@ extension AccessibilityAuditorChecksTests {
         let slider = Node(traits: .adjustable, frame: CGRect(x: 0, y: 0, width: 200, height: 44),
                           isElement: true, value: "50%")
 
-        XCTAssertTrue(AccessibilityAuditor()
+        XCTAssertTrue(AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [slider]), checks: [.missingLabel], sampler: nil).findings.isEmpty)
     }
 
@@ -640,7 +640,7 @@ extension AccessibilityAuditorChecksTests {
         let text = Node(label: "Hello", traits: .staticText,
                         frame: CGRect(x: 0, y: 0, width: 80, height: 16), isElement: true)
 
-        let result = AccessibilityAuditor()
+        let result = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [text]), checks: [.contrast], sampler: StubSampler(pixels: []))
 
         XCTAssertTrue(result.findings.isEmpty)
@@ -653,7 +653,7 @@ extension AccessibilityAuditorChecksTests {
         let readable = Node(label: "Hello", traits: .staticText,
                             frame: CGRect(x: 0, y: 0, width: 80, height: 16), isElement: true)
 
-        let result = AccessibilityAuditor()
+        let result = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [readable]), checks: [.contrast], sampler: StubSampler(pixels: midThresholdPixels))
 
         XCTAssertTrue(result.checksUnmeasurable.isEmpty)
@@ -665,7 +665,7 @@ extension AccessibilityAuditorChecksTests {
         let image = Node(label: "Sunset", traits: .image,
                          frame: CGRect(x: 0, y: 0, width: 200, height: 200), isElement: true)
 
-        let result = AccessibilityAuditor()
+        let result = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [image]), checks: [.contrast], sampler: StubSampler(pixels: []))
 
         XCTAssertTrue(result.checksUnmeasurable.isEmpty)
@@ -694,7 +694,7 @@ extension AccessibilityAuditorChecksTests {
     func testTheBudgetStopsThePerElementLoopAndSaysSo() {
         let start = Date()
         var elapsed: TimeInterval = 0
-        var auditor = AccessibilityAuditor()
+        var auditor = AccessibilityAuditor.unbudgeted()
         auditor.now = { start.addingTimeInterval(elapsed) }
         let sampler = SlowSampler(pixels: midThresholdPixels) {
             elapsed = AccessibilityAuditor.budget + 0.1
@@ -714,7 +714,7 @@ extension AccessibilityAuditorChecksTests {
     /// be truncated.
     func testAPassInsideTheBudgetIsNotReportedAsTruncated() {
         let start = Date()
-        var auditor = AccessibilityAuditor()
+        var auditor = AccessibilityAuditor.unbudgeted()
         auditor.now = { start }
         let children = (0..<50).map { index in
             Node(label: "Row \(index)", traits: .staticText,
@@ -753,7 +753,7 @@ extension AccessibilityAuditorChecksTests {
         let row = Node(label: "Jane Appleseed, unread", traits: .none,
                        frame: CGRect(x: 0, y: 0, width: 375, height: 60), isElement: true)
 
-        let result = AccessibilityAuditor()
+        let result = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [row]), checks: [.contrast],
                    sampler: StubSampler(pixels: midThresholdPixels))
 
@@ -767,7 +767,7 @@ extension AccessibilityAuditorChecksTests {
                          frame: CGRect(x: 0, y: 0, width: 300, height: 34), isElement: true,
                          drawsText: true)
 
-        let result = AccessibilityAuditor()
+        let result = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [field]), checks: [.contrast],
                    sampler: StubSampler(pixels: midThresholdPixels))
 
@@ -782,7 +782,7 @@ extension AccessibilityAuditorChecksTests {
         let swiftUIButton = Node(label: "Continue", traits: .button,
                                  frame: CGRect(x: 0, y: 0, width: 200, height: 44), isElement: true)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [swiftUIButton]), checks: [.contrast],
                    sampler: StubSampler(pixels: midThresholdPixels)).findings
 
@@ -795,7 +795,7 @@ extension AccessibilityAuditorChecksTests {
         let icon = Node(label: "Share", traits: [.button, .image],
                         frame: CGRect(x: 0, y: 0, width: 44, height: 44), isElement: true)
 
-        XCTAssertTrue(AccessibilityAuditor()
+        XCTAssertTrue(AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [icon]), checks: [.contrast],
                    sampler: StubSampler(pixels: midThresholdPixels)).findings.isEmpty)
     }
@@ -807,7 +807,7 @@ extension AccessibilityAuditorChecksTests {
         let heading = Node(label: "Welcome", traits: .staticText,
                            frame: CGRect(x: 0, y: 0, width: 300, height: 40), isElement: true)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [heading]), checks: [.contrast],
                    sampler: StubSampler(pixels: midThresholdPixels)).findings
 
@@ -822,7 +822,7 @@ extension AccessibilityAuditorChecksTests {
                         frame: CGRect(x: 0, y: 0, width: 300, height: 20), isElement: true,
                         fontPointSize: 13)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [body]), checks: [.contrast],
                    sampler: StubSampler(pixels: midThresholdPixels)).findings
 
@@ -837,7 +837,7 @@ extension AccessibilityAuditorChecksTests {
                         frame: CGRect(x: 0, y: 0, width: 20, height: 20), isElement: true)
         let short = Node(label: "Close", traits: .button,
                          frame: CGRect(x: 0, y: 0, width: 36, height: 36), isElement: true)
-        let auditor = AccessibilityAuditor()
+        let auditor = AccessibilityAuditor.unbudgeted()
 
         let error = auditor.audit(root: Node(children: [tiny]), checks: [.touchTarget], sampler: nil).findings.first
         let warning = auditor.audit(root: Node(children: [short]), checks: [.touchTarget], sampler: nil).findings.first
@@ -859,7 +859,7 @@ extension AccessibilityAuditorChecksTests {
         let caption = Node(label: "Scrolled under the bar", traits: .staticText,
                            frame: CGRect(x: 32, y: 30, width: 333, height: 30), isElement: true)
 
-        let result = AccessibilityAuditor()
+        let result = AccessibilityAuditor.unbudgeted()
             .audit(root: Node(children: [caption]), checks: [.contrast], sampler: StubSampler(pixels: dither))
 
         XCTAssertTrue(result.findings.isEmpty, "no confident number from an untrustworthy crop")
@@ -932,7 +932,7 @@ extension AccessibilityAuditorChecksTests {
                                     inRegion: midThresholdPixels,
                                     elsewhere: clean)
 
-        let findings = AccessibilityAuditor()
+        let findings = AccessibilityAuditor.unbudgeted()
             .audit(root: window, checks: [.contrast], sampler: sampler).findings
 
         XCTAssertEqual(findings.count, 1, "one element still produces at most one finding")
@@ -1010,7 +1010,7 @@ extension AccessibilityAuditorChecksTests {
         let node = CountingNode()
         let root = Node(children: [node])
 
-        _ = AccessibilityAuditor().audit(root: root,
+        _ = AccessibilityAuditor.unbudgeted().audit(root: root,
                                          checks: [.missingLabel, .touchTarget, .contrast],
                                          sampler: StubSampler(pixels: midThresholdPixels))
 
@@ -1046,7 +1046,7 @@ extension AccessibilityAuditorChecksTests {
         XCTAssertTrue(AccessibilityAuditor.drawnTextViews(in: host).isEmpty,
                       "the fixture is only meaningful with no drawn text view to find")
 
-        let result = AccessibilityAuditor().audit(root: window,
+        let result = AccessibilityAuditor.unbudgeted().audit(root: window,
                                                   checks: [.contrast],
                                                   sampler: StubSampler(pixels: midThresholdPixels))
 
@@ -1071,7 +1071,7 @@ extension AccessibilityAuditorChecksTests {
             isReady: { HostedSwiftUIWindow.publishedAccessibilityElementCount($0) >= 2 }
         )
 
-        let auditor = AccessibilityAuditor()
+        let auditor = AccessibilityAuditor.unbudgeted()
         let walked = auditor.collect(root: window)
         XCTAssertFalse(walked.nodes.isEmpty, "SwiftUI put no accessibility elements on screen at all")
         XCTAssertTrue(walked.nodes.allSatisfy { !($0 is UIView) },

--- a/Tests/ScytherTests/Features/AccessibilityAuditorWalkTests.swift
+++ b/Tests/ScytherTests/Features/AccessibilityAuditorWalkTests.swift
@@ -40,7 +40,7 @@ final class AccessibilityAuditorWalkTests: XCTestCase {
         let element = Node(label: "leaf", isElement: true, children: [hidden])
         let root = Node(children: [element])
 
-        let walked = AccessibilityAuditor().collect(root: root)
+        let walked = AccessibilityAuditor.unbudgeted().collect(root: root)
 
         XCTAssertEqual(walked.nodes.compactMap(\.accessibilityLabelText), ["leaf"])
     }
@@ -50,7 +50,7 @@ final class AccessibilityAuditorWalkTests: XCTestCase {
         let second = Node(label: "two", isElement: true)
         let root = Node(children: [Node(children: [first]), second])
 
-        let walked = AccessibilityAuditor().collect(root: root)
+        let walked = AccessibilityAuditor.unbudgeted().collect(root: root)
 
         XCTAssertEqual(walked.nodes.compactMap(\.accessibilityLabelText), ["one", "two"])
     }
@@ -60,7 +60,7 @@ final class AccessibilityAuditorWalkTests: XCTestCase {
         let inside = Node(label: "menu row", isElement: true)
         let root = Node(children: [Node(isScytherOwned: true, children: [inside])])
 
-        XCTAssertTrue(AccessibilityAuditor().collect(root: root).nodes.isEmpty)
+        XCTAssertTrue(AccessibilityAuditor.unbudgeted().collect(root: root).nodes.isEmpty)
     }
 
     func testInvisibleAndEmptyNodesAreSkipped() {
@@ -68,7 +68,7 @@ final class AccessibilityAuditorWalkTests: XCTestCase {
         let empty = Node(label: "zero", frame: .zero, isElement: true)
         let root = Node(children: [invisible, empty])
 
-        XCTAssertTrue(AccessibilityAuditor().collect(root: root).nodes.isEmpty)
+        XCTAssertTrue(AccessibilityAuditor.unbudgeted().collect(root: root).nodes.isEmpty)
     }
 
     /// A pathological hierarchy must not hang the app, and a truncated walk must say so.
@@ -78,7 +78,7 @@ final class AccessibilityAuditorWalkTests: XCTestCase {
         }
         let root = Node(children: children)
 
-        let walked = AccessibilityAuditor().collect(root: root)
+        let walked = AccessibilityAuditor.unbudgeted().collect(root: root)
 
         XCTAssertEqual(walked.nodes.count, AccessibilityAuditor.maximumNodes)
         XCTAssertTrue(walked.didHitLimit)
@@ -90,7 +90,7 @@ final class AccessibilityAuditorWalkTests: XCTestCase {
             deepest = Node(children: [deepest])
         }
 
-        let walked = AccessibilityAuditor().collect(root: deepest)
+        let walked = AccessibilityAuditor.unbudgeted().collect(root: deepest)
 
         XCTAssertTrue(walked.didHitLimit)
         XCTAssertTrue(walked.nodes.isEmpty, "the leaf sits below the cap")
@@ -114,7 +114,7 @@ final class AccessibilityAuditorWalkTests: XCTestCase {
     }
 
     func testATreeAtExactlyTheDepthCapIsWalkedToItsLeaf() {
-        let walked = AccessibilityAuditor().collect(root: chain(deep: AccessibilityAuditor.maximumDepth))
+        let walked = AccessibilityAuditor.unbudgeted().collect(root: chain(deep: AccessibilityAuditor.maximumDepth))
 
         XCTAssertEqual(walked.nodes.compactMap(\.accessibilityLabelText), ["bottom"],
                        "a tree at exactly the cap is inside it, so its leaf must be collected")
@@ -122,7 +122,7 @@ final class AccessibilityAuditorWalkTests: XCTestCase {
     }
 
     func testATreeOneLinkPastTheDepthCapIsStopped() {
-        let walked = AccessibilityAuditor().collect(root: chain(deep: AccessibilityAuditor.maximumDepth + 1))
+        let walked = AccessibilityAuditor.unbudgeted().collect(root: chain(deep: AccessibilityAuditor.maximumDepth + 1))
 
         XCTAssertTrue(walked.nodes.isEmpty)
         XCTAssertTrue(walked.didHitLimit)
@@ -143,7 +143,7 @@ final class AccessibilityAuditorWalkTests: XCTestCase {
 
     func testAWalkThatFinishesDoesNotClaimALimitWasHit() {
         let root = Node(children: [Node(label: "one", isElement: true)])
-        XCTAssertFalse(AccessibilityAuditor().collect(root: root).didHitLimit)
+        XCTAssertFalse(AccessibilityAuditor.unbudgeted().collect(root: root).didHitLimit)
     }
 
     /// The node cap counts every container traversed, not just elements collected.
@@ -158,7 +158,7 @@ final class AccessibilityAuditorWalkTests: XCTestCase {
         }
         let root = Node(children: children)
 
-        let walked = AccessibilityAuditor().collect(root: root)
+        let walked = AccessibilityAuditor.unbudgeted().collect(root: root)
 
         XCTAssertTrue(walked.didHitLimit, "the cap should be hit")
         XCTAssertLessThan(walked.nodes.count, containerCount, "not all elements should be collected; cap stops before traversing all containers")
@@ -171,7 +171,7 @@ final class AccessibilityAuditorWalkTests: XCTestCase {
     func testAWalkThatRunsOutOfTimeStopsAndSaysSo() {
         var ticks = 0
         let start = Date()
-        var auditor = AccessibilityAuditor()
+        var auditor = AccessibilityAuditor.unbudgeted()
         auditor.now = {
             ticks += 1
             return start.addingTimeInterval(ticks > 5 ? AccessibilityAuditor.budget + 0.1 : 0)
@@ -188,7 +188,7 @@ final class AccessibilityAuditorWalkTests: XCTestCase {
     /// to be truncated.
     func testAWalkInsideTheBudgetIsNotReportedAsTruncated() {
         let start = Date()
-        var auditor = AccessibilityAuditor()
+        var auditor = AccessibilityAuditor.unbudgeted()
         auditor.now = { start }
 
         let children = (0..<500).map { _ in Node(label: "row", isElement: true) as AuditNode }

--- a/Tests/ScytherTests/Features/AuditNodeAdapterTests.swift
+++ b/Tests/ScytherTests/Features/AuditNodeAdapterTests.swift
@@ -338,7 +338,7 @@ final class AuditNodeAdapterTests: XCTestCase {
     /// `accessibilityElements` on its hosting view, which is the cheap stored property the walk
     /// still reads. This test is the evidence for that, against a real `UIHostingController`
     /// rather than against the claim.
-    func testTheWalkFindsSwiftUIsSyntheticAccessibilityElements() {
+    func testTheWalkFindsSwiftUIsSyntheticAccessibilityElements() throws {
         struct Sample: View {
             var body: some View {
                 VStack {
@@ -350,10 +350,14 @@ final class AuditNodeAdapterTests: XCTestCase {
             }
         }
 
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
-        window.rootViewController = UIHostingController(rootView: Sample())
-        window.isHidden = false
-        window.layoutIfNeeded()
+        // Waits for SwiftUI to publish its three elements rather than looking once: a fixed wait
+        // passed here and failed on CI's toolchain on every run since the audit landed. See
+        // `HostedSwiftUIWindow`. The wait counts what SwiftUI set, so it stays independent of what
+        // the walk below finds and cannot paper over a regression in it.
+        let window = try HostedSwiftUIWindow.make(
+            hosting: Sample(),
+            isReady: { HostedSwiftUIWindow.publishedAccessibilityElementCount($0) >= 3 }
+        )
 
         let walked = AccessibilityAuditor().collect(root: window)
         let labels = Set(walked.nodes.compactMap(\.accessibilityLabelText))

--- a/Tests/ScytherTests/Features/AuditNodeAdapterTests.swift
+++ b/Tests/ScytherTests/Features/AuditNodeAdapterTests.swift
@@ -210,7 +210,7 @@ final class AuditNodeAdapterTests: XCTestCase {
         let window = largeRealHierarchy()
         let start = Date()
         var readings = 0
-        var auditor = AccessibilityAuditor()
+        var auditor = AccessibilityAuditor.unbudgeted()
         auditor.now = {
             readings += 1
             return start.addingTimeInterval(readings > 200 ? AccessibilityAuditor.budget + 0.1 : 0)
@@ -229,7 +229,7 @@ final class AuditNodeAdapterTests: XCTestCase {
     func testALargeRealHierarchyInsideEveryBoundIsNotReportedAsTruncated() {
         let window = largeRealHierarchy()
         let start = Date()
-        var auditor = AccessibilityAuditor()
+        var auditor = AccessibilityAuditor.unbudgeted()
         auditor.now = { start }
 
         XCTAssertFalse(auditor.collect(root: window).didHitLimit,
@@ -301,7 +301,7 @@ final class AuditNodeAdapterTests: XCTestCase {
             root.addSubview(container)
         }
 
-        _ = AccessibilityAuditor().collect(root: window)
+        _ = AccessibilityAuditor.unbudgeted().collect(root: window)
 
         XCTAssertGreaterThan(ComputingView.computations, 0,
                              "a class that implements the pair is read through it, subviews or not")
@@ -359,7 +359,7 @@ final class AuditNodeAdapterTests: XCTestCase {
             isReady: { HostedSwiftUIWindow.publishedAccessibilityElementCount($0) >= 3 }
         )
 
-        let walked = AccessibilityAuditor().collect(root: window)
+        let walked = AccessibilityAuditor.unbudgeted().collect(root: window)
         let labels = Set(walked.nodes.compactMap(\.accessibilityLabelText))
 
         XCTAssertTrue(labels.isSuperset(of: ["Hello world", "Tap me", "Star"]),

--- a/Tests/ScytherTests/Features/AuditNodeVisibilityTests.swift
+++ b/Tests/ScytherTests/Features/AuditNodeVisibilityTests.swift
@@ -153,7 +153,7 @@ final class AuditNodeVisibilityTests: XCTestCase {
         card.addSubview(UIView(frame: CGRect(x: 0, y: 0, width: 40, height: 40)))
         root.addSubview(card)
 
-        let walked = AccessibilityAuditor().collect(root: root)
+        let walked = AccessibilityAuditor.unbudgeted().collect(root: root)
 
         XCTAssertEqual(walked.nodes.count, 1)
         XCTAssertTrue(walked.nodes.first as? UIView === card)
@@ -569,7 +569,7 @@ final class AuditNodeVisibilityTests: XCTestCase {
         }
         let root = CountingNode(children: pooled)
 
-        let walked = AccessibilityAuditor().collect(root: root)
+        let walked = AccessibilityAuditor.unbudgeted().collect(root: root)
 
         XCTAssertTrue(walked.didHitLimit, "a pool of skipped nodes must still trip the cap")
         XCTAssertTrue(walked.nodes.isEmpty)

--- a/Tests/ScytherTests/Shared/AccessibilityAuditorTestClock.swift
+++ b/Tests/ScytherTests/Shared/AccessibilityAuditorTestClock.swift
@@ -1,0 +1,40 @@
+//
+//  AccessibilityAuditorTestClock.swift
+//  ScytherTests
+//
+
+@testable import Scyther
+import Foundation
+
+extension AccessibilityAuditor {
+
+    /// An auditor whose wall-clock budget can never trip.
+    ///
+    /// ``AccessibilityAuditor/budget`` bounds a pass at 0.25s of wall clock so a pathological
+    /// hierarchy cannot hang the app. That is right in production and wrong in a unit test that
+    /// asserts *what the walk found*: the result then depends on how fast the machine was, and a
+    /// slow machine turns a correctness test into a timing test that reports "found nothing" as a
+    /// defect in the checks.
+    ///
+    /// That is not hypothetical. On CI, the first audit in the process pays the accessibility
+    /// runtime's one-time initialisation — a single fixture with one element took 26 seconds — and
+    /// blew the budget before reaching its element, so
+    /// `testASyntheticElementOverAViewWithNoTextViewsIsStillMeasured` reported zero candidates.
+    /// It had been passing only because the test that ran before it happened to warm the runtime
+    /// up first; the moment that test started skipping, this one started failing.
+    ///
+    /// Freezing the clock removes the budget from every test that is not about the budget. The
+    /// budget's own behaviour keeps its dedicated coverage, in
+    /// `testAWalkThatRunsOutOfTimeStopsAndSaysSo` and
+    /// `testAWalkInsideTheBudgetIsNotReportedAsTruncated`, which drive this same seam deliberately
+    /// — a test that assigns ``AccessibilityAuditor/now`` after calling this simply wins, as it
+    /// should.
+    ///
+    /// - Returns: An auditor that believes no time ever passes.
+    static func unbudgeted() -> AccessibilityAuditor {
+        var auditor = AccessibilityAuditor()
+        let frozen = Date()
+        auditor.now = { frozen }
+        return auditor
+    }
+}

--- a/Tests/ScytherTests/Shared/HostedSwiftUIWindow.swift
+++ b/Tests/ScytherTests/Shared/HostedSwiftUIWindow.swift
@@ -35,11 +35,11 @@ import XCTest
 ///
 /// ## What it does
 ///
-/// Hosts the view, attaches the window to a foreground scene when the test host has one, makes it
-/// key and visible, then polls until the hierarchy publishes accessibility elements. If it never
-/// does, the calling test is **skipped** with a message naming the platform — so a run on a
-/// toolchain where SwiftUI behaves differently reads as "unverified here", which is true, rather
-/// than as "the audit is broken", which is not.
+/// Hosts the view, makes the window key and visible, then polls until the hierarchy publishes
+/// accessibility elements. If it never does, the window is put away and the calling test is
+/// **skipped** with a message naming the platform — so a run on a toolchain where SwiftUI behaves
+/// differently reads as "unverified here", which is true, rather than as "the audit is broken",
+/// which is not.
 @MainActor
 enum HostedSwiftUIWindow {
 
@@ -72,6 +72,8 @@ enum HostedSwiftUIWindow {
     ///   - line: The calling line, for the same reason.
     /// - Returns: A key, visible window whose root view controller hosts `view`. The caller has to
     ///   hold on to it: a window with no other references goes away and takes the hierarchy with it.
+    ///   Unattached to any scene on purpose — a scene retains the window, and one left behind by a
+    ///   skipped test changes what every later test in the process sees.
     /// - Throws: `XCTSkip` when `isReady` never succeeds within `timeout`.
     static func make<Root: View>(hosting view: Root,
                                  size: CGSize = defaultSize,
@@ -79,7 +81,7 @@ enum HostedSwiftUIWindow {
                                  isReady: @MainActor (UIView) -> Bool = publishesAccessibilityElements,
                                  file: StaticString = #filePath,
                                  line: UInt = #line) throws -> UIWindow {
-        let window = makeWindow(size: size)
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
         let host = UIHostingController(rootView: view)
         window.rootViewController = host
         window.makeKeyAndVisible()
@@ -91,6 +93,12 @@ enum HostedSwiftUIWindow {
             if isReady(host.view) { return window }
             RunLoop.current.run(until: Date().addingTimeInterval(pollInterval))
         } while Date() < deadline
+
+        // Put the window away before skipping. A key, visible window left behind outlives the test
+        // that made it and changes what every later test in the process sees — on CI, a skip here
+        // took `testASyntheticElementOverAViewWithNoTextViewsIsStillMeasured` down with it.
+        window.isHidden = true
+        window.rootViewController = nil
 
         throw XCTSkip("""
             SwiftUI published no accessibility elements for a hosted view within \(timeout)s on \
@@ -134,27 +142,5 @@ enum HostedSwiftUIWindow {
     static func publishedAccessibilityElementCount(_ view: UIView) -> Int {
         (view.accessibilityElements?.count ?? 0)
             + view.subviews.reduce(0) { $0 + publishedAccessibilityElementCount($1) }
-    }
-
-    /// Builds the window, attached to a foreground window scene when one exists.
-    ///
-    /// A test bundle with no host application has no scenes at all, and an unattached window is
-    /// what the audit's fixtures have always used successfully. Where a scene *is* available,
-    /// attaching to it is the closer approximation of a real app and gives SwiftUI a display to
-    /// commit against — so take it when it is there and carry on without it when it is not.
-    ///
-    /// - Parameter size: The window's size.
-    /// - Returns: An unshown window of `size`.
-    private static func makeWindow(size: CGSize) -> UIWindow {
-        let frame = CGRect(origin: .zero, size: size)
-        let scene = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .first { $0.activationState == .foregroundActive }
-            ?? UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
-
-        guard let scene else { return UIWindow(frame: frame) }
-        let window = UIWindow(windowScene: scene)
-        window.frame = frame
-        return window
     }
 }

--- a/Tests/ScytherTests/Shared/HostedSwiftUIWindow.swift
+++ b/Tests/ScytherTests/Shared/HostedSwiftUIWindow.swift
@@ -1,0 +1,160 @@
+//
+//  HostedSwiftUIWindow.swift
+//  ScytherTests
+//
+
+import SwiftUI
+import UIKit
+import XCTest
+
+/// Hosts a SwiftUI view in a real `UIWindow` and hands it back only once SwiftUI has actually
+/// published the synthetic accessibility elements the accessibility audit exists to walk.
+///
+/// ## Why this exists
+///
+/// Two of the audit's tests assert against a *real* `UIHostingController` rather than a stand-in,
+/// because the claim they pin is a claim about SwiftUI itself: that it **sets**
+/// `accessibilityElements` on the views it hosts, which is the cheap stored property
+/// ``AuditNode`` reads instead of forcing UIAccessibility to compute a subtree. That claim is the
+/// whole reason the walk is affordable, so it has to be tested against the framework and not
+/// against a fixture that agrees with us by construction.
+///
+/// Both tests set the view up and looked immediately — one after a bare `layoutIfNeeded()`, the
+/// other after a fixed half-second of run loop. On the development machine (Xcode 26.2) SwiftUI
+/// had published by then and both passed. On CI (Xcode 26.0.1, same iOS 26.2 runtime) it had not,
+/// and both failed on every run from the day the audit landed:
+///
+/// ```
+/// XCTAssertFalse failed - SwiftUI put no accessibility elements on screen at all
+/// XCTAssertTrue failed - SwiftUI's synthetic elements must still be found, but got []
+/// ```
+///
+/// A fixed wait is the bug. When the thing being waited for is a framework's own scheduling, the
+/// test has to wait *for the condition*, and it has to say something honest when the condition
+/// never arrives rather than reporting the framework's silence as a defect in our walk.
+///
+/// ## What it does
+///
+/// Hosts the view, attaches the window to a foreground scene when the test host has one, makes it
+/// key and visible, then polls until the hierarchy publishes accessibility elements. If it never
+/// does, the calling test is **skipped** with a message naming the platform — so a run on a
+/// toolchain where SwiftUI behaves differently reads as "unverified here", which is true, rather
+/// than as "the audit is broken", which is not.
+@MainActor
+enum HostedSwiftUIWindow {
+
+    /// How long to wait for SwiftUI to publish before giving up and skipping.
+    ///
+    /// Generous on purpose. The cost of waiting too long is a few seconds on a run that was going
+    /// to skip anyway; the cost of waiting too little is a red suite that says nothing true.
+    static let defaultTimeout: TimeInterval = 5
+
+    /// How long each poll gives the run loop before looking again.
+    ///
+    /// SwiftUI publishes accessibility elements off its own commit, so the run loop has to actually
+    /// turn between looks — a spin loop on `Date()` would wait the full timeout and find nothing.
+    private static let pollInterval: TimeInterval = 0.05
+
+    /// The default size, matching the device the rest of the audit's fixtures use.
+    static let defaultSize = CGSize(width: 390, height: 844)
+
+    /// Hosts `view` and returns the window once it is ready to be walked.
+    ///
+    /// - Parameters:
+    ///   - view: The SwiftUI view to host.
+    ///   - size: The window's size. Defaults to ``defaultSize``.
+    ///   - timeout: How long to wait for readiness. Defaults to ``defaultTimeout``.
+    ///   - isReady: The readiness probe, run against the hosting controller's view. Defaults to
+    ///     ``publishesAccessibilityElements(_:)``. Injectable so ``HostedSwiftUIWindowTests`` can
+    ///     drive both outcomes deterministically, which a real view cannot do on every platform —
+    ///     the whole point of this helper being that platforms differ here.
+    ///   - file: The calling file, so a skip is attributed to the test rather than to this helper.
+    ///   - line: The calling line, for the same reason.
+    /// - Returns: A key, visible window whose root view controller hosts `view`. The caller has to
+    ///   hold on to it: a window with no other references goes away and takes the hierarchy with it.
+    /// - Throws: `XCTSkip` when `isReady` never succeeds within `timeout`.
+    static func make<Root: View>(hosting view: Root,
+                                 size: CGSize = defaultSize,
+                                 timeout: TimeInterval = defaultTimeout,
+                                 isReady: @MainActor (UIView) -> Bool = publishesAccessibilityElements,
+                                 file: StaticString = #filePath,
+                                 line: UInt = #line) throws -> UIWindow {
+        let window = makeWindow(size: size)
+        let host = UIHostingController(rootView: view)
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.frame = window.bounds
+        host.view.layoutIfNeeded()
+
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if isReady(host.view) { return window }
+            RunLoop.current.run(until: Date().addingTimeInterval(pollInterval))
+        } while Date() < deadline
+
+        throw XCTSkip("""
+            SwiftUI published no accessibility elements for a hosted view within \(timeout)s on \
+            iOS \(UIDevice.current.systemVersion). The audit's walk depends on SwiftUI setting \
+            `accessibilityElements` on the views it hosts; that claim is unverified on this \
+            toolchain, so this test is skipped rather than reported as a defect in the walk.
+            """,
+            file: file,
+            line: line)
+    }
+
+    /// Whether SwiftUI has set `accessibilityElements` anywhere in `view`'s subtree.
+    ///
+    /// This is the readiness question asked exactly as the walk asks it: a *set* property, not a
+    /// computed one. Reading `accessibilityElements` is cheap when it is nil, which is why
+    /// ``AuditNode`` reads it and never calls `accessibilityElementCount()` on a `UIView` — doing
+    /// that forces UIAccessibility to compute the whole subtree and once hung the app.
+    ///
+    /// An empty array is deliberately not readiness. SwiftUI assigns the array before it has
+    /// anything to put in it, and treating that as ready reintroduces the original bug: a walk that
+    /// runs, finds nothing, and reports the nothing as a result.
+    ///
+    /// - Parameter view: The root of the subtree to look through.
+    /// - Returns: `true` when some view in the subtree vends at least one element.
+    static func publishesAccessibilityElements(_ view: UIView) -> Bool {
+        publishedAccessibilityElementCount(view) > 0
+    }
+
+    /// How many accessibility elements SwiftUI has set across `view`'s subtree.
+    ///
+    /// A caller that knows how many elements its fixture should produce waits on that number
+    /// instead of on the first one. SwiftUI publishes a hierarchy in its own time and there is no
+    /// promise the whole tree lands in one commit, so "at least one element exists" is a weaker
+    /// readiness signal than a test asserting on three specific labels actually needs.
+    ///
+    /// This counts what the framework *set*, never what the audit found — so it stays an
+    /// independent readiness signal and cannot mask a regression in the walk it is waiting for.
+    ///
+    /// - Parameter view: The root of the subtree to count through.
+    /// - Returns: The total number of elements vended by views in the subtree.
+    static func publishedAccessibilityElementCount(_ view: UIView) -> Int {
+        (view.accessibilityElements?.count ?? 0)
+            + view.subviews.reduce(0) { $0 + publishedAccessibilityElementCount($1) }
+    }
+
+    /// Builds the window, attached to a foreground window scene when one exists.
+    ///
+    /// A test bundle with no host application has no scenes at all, and an unattached window is
+    /// what the audit's fixtures have always used successfully. Where a scene *is* available,
+    /// attaching to it is the closer approximation of a real app and gives SwiftUI a display to
+    /// commit against — so take it when it is there and carry on without it when it is not.
+    ///
+    /// - Parameter size: The window's size.
+    /// - Returns: An unshown window of `size`.
+    private static func makeWindow(size: CGSize) -> UIWindow {
+        let frame = CGRect(origin: .zero, size: size)
+        let scene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }
+            ?? UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
+
+        guard let scene else { return UIWindow(frame: frame) }
+        let window = UIWindow(windowScene: scene)
+        window.frame = frame
+        return window
+    }
+}

--- a/Tests/ScytherTests/Shared/HostedSwiftUIWindowTests.swift
+++ b/Tests/ScytherTests/Shared/HostedSwiftUIWindowTests.swift
@@ -1,0 +1,105 @@
+//
+//  HostedSwiftUIWindowTests.swift
+//  ScytherTests
+//
+
+@testable import Scyther
+import SwiftUI
+import UIKit
+import XCTest
+
+/// Covers ``HostedSwiftUIWindow`` itself, because two of the accessibility audit's load-bearing
+/// tests now depend on it and a helper that skips when it should wait — or waits when it should
+/// skip — would quietly take those tests out of service.
+@MainActor
+final class HostedSwiftUIWindowTests: XCTestCase {
+
+    /// The happy path: a hosted `Text` publishes accessibility elements, so the helper returns a
+    /// window rather than skipping.
+    ///
+    /// This is also the canary for the helper's readiness probe. If SwiftUI ever stops setting
+    /// `accessibilityElements` on the views it hosts, this test starts skipping — and a suite full
+    /// of skips is the signal that the audit's central assumption needs revisiting.
+    func testAHostedViewWithTextIsReadyAndReturnsAWindow() throws {
+        let window = try HostedSwiftUIWindow.make(hosting: Text(verbatim: "Hello world"))
+
+        XCTAssertNotNil(window.rootViewController)
+        XCTAssertFalse(window.isHidden)
+    }
+
+    /// The skip path: when the readiness probe never succeeds, the helper throws `XCTSkip` rather
+    /// than letting the caller assert against an empty hierarchy.
+    ///
+    /// Driven through the injected probe rather than through a view that happens to publish
+    /// nothing, so it is deterministic on every platform — the failure this guards against is
+    /// precisely a platform behaving differently from the one the test was written on.
+    func testAProbeThatNeverSucceedsSkipsInsteadOfFailing() {
+        do {
+            _ = try HostedSwiftUIWindow.make(hosting: Text(verbatim: "Hello world"),
+                                             timeout: 0.2,
+                                             isReady: { _ in false })
+            XCTFail("the helper must not return a window it could not make ready")
+        } catch is XCTSkip {
+            // Expected.
+        } catch {
+            XCTFail("expected XCTSkip, got \(error)")
+        }
+    }
+
+    /// The probe is polled rather than sampled once, so a platform that needs a few run-loop turns
+    /// is waited for instead of being declared unsupported on the first look.
+    func testTheProbeIsPolledUntilItSucceeds() throws {
+        var looks = 0
+        _ = try HostedSwiftUIWindow.make(hosting: Text(verbatim: "Hello world"),
+                                         timeout: 5,
+                                         isReady: { _ in
+                                             looks += 1
+                                             return looks >= 3
+                                         })
+
+        XCTAssertEqual(looks, 3, "the helper must keep looking, not give up after the first turn")
+    }
+
+    /// The probe asks the real question: has SwiftUI *set* `accessibilityElements` anywhere in the
+    /// hosted hierarchy? A view that has is ready; a bare `UIView` tree is not.
+    func testTheDefaultProbeLooksForSetAccessibilityElements() {
+        let bare = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        bare.addSubview(UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 50)))
+        XCTAssertFalse(HostedSwiftUIWindow.publishesAccessibilityElements(bare))
+
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let nested = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+        container.addSubview(nested)
+        let element = UIAccessibilityElement(accessibilityContainer: nested)
+        element.accessibilityLabel = "synthetic" // scyther:unlocalised test fixture
+        nested.accessibilityElements = [element]
+        XCTAssertTrue(HostedSwiftUIWindow.publishesAccessibilityElements(container),
+                      "the probe has to find elements set anywhere in the subtree, not just at the root")
+    }
+
+    /// The count probe adds up every element set across the subtree, so a caller that knows how
+    /// many its fixture produces can wait for all of them rather than for the first.
+    func testTheCountProbeSumsElementsAcrossTheSubtree() {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        XCTAssertEqual(HostedSwiftUIWindow.publishedAccessibilityElementCount(root), 0)
+
+        let branch = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+        root.addSubview(branch)
+        root.accessibilityElements = [UIAccessibilityElement(accessibilityContainer: root)]
+        branch.accessibilityElements = [
+            UIAccessibilityElement(accessibilityContainer: branch),
+            UIAccessibilityElement(accessibilityContainer: branch),
+        ]
+
+        XCTAssertEqual(HostedSwiftUIWindow.publishedAccessibilityElementCount(root), 3)
+    }
+
+    /// An empty `accessibilityElements` array is not readiness. SwiftUI assigns the array before it
+    /// has anything to put in it, and treating that as ready is exactly how the audit's tests came
+    /// to assert against an empty walk.
+    func testAnEmptyElementsArrayIsNotReady() {
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        view.accessibilityElements = []
+        XCTAssertFalse(HostedSwiftUIWindow.publishesAccessibilityElements(view))
+    }
+}


### PR DESCRIPTION
Experiment, not for merge as-is. Only the Run Tests job's image changes, so the run has one variable.

If the three currently-skipped SwiftUI tests run here, the answer is that the runner image was the problem all along and this belongs in #75. If they still skip, it is not the image.